### PR TITLE
Upgrade to srproxy v00.20

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -38,7 +38,7 @@ sbnanaobj        v09_15_00
 #SAM tools?
 ifdhc            v2_5_7
 # For CAFAna
-srproxy          v00.17
+srproxy          v00.20
 osclib           v00.09
 
 # list products required ONLY for the build


### PR DESCRIPTION
Upgrade to srproxy v00.20. Fixes some problems with proxying arrays which we currently don't use but easily could hit in future.