### PR TITLE
Uglify all the logic to look for cafana files in two places.

### DIFF
--- a/sbnana/CAFAna/cafana.py
+++ b/sbnana/CAFAna/cafana.py
@@ -5,8 +5,17 @@ if __name__ == '__main__':
     exit(1)
 
 import os
-inc = os.environ['MRB_INSTALL']+'/sbnana/'+os.environ['SBNANA_VERSION']+'/include/'
-sao_inc = os.environ['MRB_INSTALL']+'/sbnanaobj/'+os.environ['SBNANAOBJ_VERSION']+'/include/'
+
+if 'SBNANA_INC' in os.environ:
+    inc = os.environ['SBNANA_INC']
+else:
+    inc = os.environ['MRB_INSTALL']+'/sbnana/'+os.environ['SBNANA_VERSION']+'/include/'
+
+if 'SBNANAOBJ_INC' in os.environ:
+    sao_inc = os.environ['SBNANAOBJ_INC']
+else:
+    sao_inc = os.environ['MRB_INSTALL']+'/sbnanaobj/'+os.environ['SBNANAOBJ_VERSION']+'/include/'
+
 os.environ['ROOT_INCLUDE_PATH'] = \
   ':'.join([inc,
             inc+'sbnana',
@@ -18,7 +27,10 @@ os.environ['ROOT_INCLUDE_PATH'] = \
 
 import ROOT
 
-ROOT.gApplication.ExecuteFile('$MRB_BUILDDIR/sbnana/bin/rootlogon.C')
+if 'SBNANA_FQ_DIR' in os.environ:
+    ROOT.gApplication.ExecuteFile('${SBNANA_FQ_DIR}/bin/rootlogon.C')
+else:
+    ROOT.gApplication.ExecuteFile('$MRB_BUILDDIR/sbnana/bin/rootlogon.C')
 print('  in python')
 ROOT.gROOT.ForceStyle()
 

--- a/sbnana/SBNAna/cafe
+++ b/sbnana/SBNAna/cafe
@@ -54,7 +54,12 @@ def makeParser():
 
 
 def libsPath():
-    return os.environ['MRB_BUILDDIR']+'/sbnana/bin/load_cafana_libs.C'
+    if 'SBNANA_FQ_DIR' in os.environ:
+        # ups product
+        return os.environ['SBNANA_FQ_DIR']+'/bin/load_cafana_libs.C'
+    else:
+        # checked out under mrb
+        return os.environ['SBNANA_DIR']+'/sbnana/SBNAna/load_cafana_libs.C'
 
 
 def escapeArg(arg):
@@ -156,7 +161,12 @@ if __name__ == '__main__':
             ROOT.gROOT.SetBatch(True)
 
         # Add cafana.py to the path
-        sys.path.append(os.environ['MRB_BUILDDIR']+'/sbnana/bin/')
+        if 'SBNANA_FQ_DIR' in os.environ:
+            # ups product
+            sys.path.append(os.environ['SBNANA_FQ_DIR']+'/bin/')
+        else:
+            # checked out under mrb
+            sys.path.append(os.environ['SBNANA_DIR']+'/sbnana/CAFAna/')
 
         sys.argv = args
         exec(open(script).read())

--- a/sbnana/SBNAna/load_cafana_libs.C
+++ b/sbnana/SBNAna/load_cafana_libs.C
@@ -38,19 +38,26 @@ void load_cafana_libs()
   gSystem->SetFlagsDebug(TString(gSystem->GetFlagsDebug())+" -fdiagnostics-color=auto");
   gSystem->SetFlagsOpt(TString(gSystem->GetFlagsOpt())+" -fdiagnostics-color=auto -UNDEBUG"); // match gcc's maxopt behaviour of retaining assert()
 
-
-  char* mrbi = getenv("MRB_INSTALL");
-  if(!mrbi){
-    std::cout << "$MRB_INSTALL is not set" << std::endl;
-    exit(1);
+  std::string incdir;
+  if(getenv("SBNANA_INC")){
+    // ups product
+    incdir = std::string(getenv("SBNANA_INC"));
   }
-  char* sbnv = getenv("SBNANA_VERSION");
-  if(!sbnv){
-    std::cout << "$SBNANA_VERSION is not set" << std::endl;
-    exit(1);
-  }
+  else{
+    // local mrb checkout
+    char* mrbi = getenv("MRB_INSTALL");
+    if(!mrbi){
+      std::cout << "$MRB_INSTALL is not set" << std::endl;
+      exit(1);
+    }
+    char* sbnv = getenv("SBNANA_VERSION");
+    if(!sbnv){
+      std::cout << "$SBNANA_VERSION is not set" << std::endl;
+      exit(1);
+    }
 
-  const std::string incdir = std::string(mrbi)+"/sbnana/"+std::string(sbnv)+"/include/";
+    incdir = std::string(mrbi)+"/sbnana/"+std::string(sbnv)+"/include/";
+  }
 
   // Include path - have to include CAFAna/ to allow looking up StandardRecord directly
   TString includes = "-I"+incdir+" -I"+incdir+"/sbnana -I"+incdir+"sbnana/CAFAna/ -I$ROOTSYS/include -I$NUTOOLS_INC -I$GENIE_INC/GENIE/ -I$SRPROXY_INC -I$OSCLIB_INC";
@@ -87,7 +94,12 @@ void load_cafana_libs()
   //  gSystem->Setenv("IFDH_DEBUG", "0"); // shut ifdh up
 
   // Pick up standard style
-  gROOT->Macro("${MRB_BUILDDIR}/sbnana/bin/rootlogon.C");
+  if(getenv("SBNANA_FQ_DIR")){
+    gROOT->Macro("${SBNANA_FQ_DIR}/bin/rootlogon.C");
+  }
+  else{
+    gROOT->Macro("${MRB_BUILDDIR}/sbnana/bin/rootlogon.C");
+  }
   gROOT->ForceStyle();
 
   TRint* rint = dynamic_cast<TRint*>(gApplication);


### PR DESCRIPTION
I hate how clumsy this all is. I don't know if it's mrb's fault, or my fault for not understanding mrb.

I _think_ this should allow for running `cafe` without an sbnana checkout