### PR TITLE
Feature/bckhouse_caf_metadata

### DIFF
--- a/sbnana/CAFAna/Core/FileReducer.cxx
+++ b/sbnana/CAFAna/Core/FileReducer.cxx
@@ -238,6 +238,7 @@ namespace ana
       meta.erase(m);
     }
 
+    /*
     // change caf -> decaf in the metadata field, if parents have data_tier
     if(meta.find("data_tier") != meta.end()){
       std::string decaf_tier = meta["data_tier"];
@@ -249,6 +250,7 @@ namespace ana
         decaf_tier.replace(decaf_tier.size()-4,3,"decaf");
       meta["data_tier"] = decaf_tier;
     }
+    */
 
     std::string parents = "[";
     for(const std::string& f: fnames){

--- a/sbnana/CAFAna/Core/FileReducer.cxx
+++ b/sbnana/CAFAna/Core/FileReducer.cxx
@@ -254,9 +254,9 @@ namespace ana
 
     std::string parents = "[";
     for(const std::string& f: fnames){
-      parents += "{\"file_name\":\""+std::string(basename((char *)f.c_str()))+"\"},";
+      parents += "{\"file_name\": \""+std::string(basename((char *)f.c_str()))+"\"}, ";
     }
-    if(parents[parents.size()-1] == ',') parents.resize(parents.size()-1);
+    if(!fnames.empty()) parents.resize(parents.size()-2); // drop trailing ", "
     parents += "]";
 
     meta["parents"] = parents;

--- a/sbnana/CAFAna/Core/FileReducer.cxx
+++ b/sbnana/CAFAna/Core/FileReducer.cxx
@@ -261,14 +261,9 @@ namespace ana
 
     meta["parents"] = parents;
 
-    // if there's one more than one parent, this is a concat.
-    // then we need "sumcaf", "sumdecaf", etc. as appropriate
+    // if there's one more than one parent, this is a concat
     if(fnames.size() > 1 && meta.find("data_tier") != meta.end()){
-      auto & tier = meta["data_tier"];
-      // if it ends with 'caf' and doesn't start with 'sum',
-      // it should now start with 'sum'
-      if (tier.substr(tier.size()-4, 3) == "caf" && tier.substr(1, 3) != "sum")
-        tier = "\"sum" + tier.substr(1);
+      meta["data_tier"] = "\"concat_caf\"";
     }
 
     // Allow user to override any metadata

--- a/sbnana/CAFAna/Core/FileReducer.cxx
+++ b/sbnana/CAFAna/Core/FileReducer.cxx
@@ -32,8 +32,7 @@ namespace ana
                            const std::string& outfile)
     : SpectrumLoaderBase(wildcard),
       fOutfile(outfile),
-      fSpillCut(nullptr), fSliceCut(nullptr),
-      fCopyMetadata(false)
+      fSpillCut(nullptr), fSliceCut(nullptr)
   {
   }
 
@@ -43,8 +42,7 @@ namespace ana
     : SpectrumLoaderBase(fnames),
       fOutfile(outfile),
       fSpillCut(nullptr),
-      fSliceCut(nullptr),
-      fCopyMetadata(false)
+      fSliceCut(nullptr)
   {
   }
 
@@ -123,8 +121,8 @@ namespace ana
 
     std::vector<std::string> fnames;
 
-    //    std::map<std::string, std::string> meta;
-    //    std::set<std::string> meta_mask;
+    std::map<std::string, std::string> meta;
+    std::set<std::string> meta_mask;
 
     caf::StandardRecord* oldsr = 0;
 
@@ -144,13 +142,9 @@ namespace ana
 
       fnames.push_back(f->GetName());
 
-      /*
-      if(fCopyMetadata){
-        TDirectory* meta_dir = (TDirectory*)f->Get("metadata");
-        assert(meta_dir);
-        CombineMetadata(meta, GetCAFMetadata(meta_dir), meta_mask);
-      }
-      */
+      TDirectory* meta_dir = (TDirectory*)f->Get("metadata");
+      assert(meta_dir);
+      CombineMetadata(meta, GetCAFMetadata(meta_dir), meta_mask);
 
       TH1* hEvents = (TH1*)f->Get("TotalEvents");
       assert(hEvents);
@@ -220,8 +214,8 @@ namespace ana
     hPOTOut->Write();
     hEventsOut->Write();
 
-    //    UpdateMetadata(meta, meta_mask, fnames);
-    //    WriteCAFMetadata(fout.mkdir("metadata"), meta);
+    UpdateMetadata(meta, meta_mask, fnames);
+    WriteCAFMetadata(fout.mkdir("metadata"), meta);
 
     fout.Close();
 
@@ -235,7 +229,6 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
-  /*
   void FileReducer::UpdateMetadata(std::map<std::string, std::string>& meta,
                                    const std::set<std::string>& mask,
                                    const std::vector<std::string>& fnames) const
@@ -245,23 +238,17 @@ namespace ana
       meta.erase(m);
     }
 
-    // change caf -> decaf in the metadata field,
-    // if we actually reduced anything
-    // and if parents have data_tier
-    if ( (!fReductionFuncs.empty() || !fReductionFuncsWithProxy.empty())
-        && meta.find("data_tier") != meta.end())
-    {
+    // change caf -> decaf in the metadata field, if parents have data_tier
+    if(meta.find("data_tier") != meta.end()){
       std::string decaf_tier = meta["data_tier"];
       assert(decaf_tier.size() >= 3);
-      assert(decaf_tier.substr(decaf_tier.size()-3,3) == "caf");
+      // For indexing: note that all of this is surrounded by quotes
+      assert(decaf_tier.substr(decaf_tier.size()-4,3) == "caf");
       // don't make 'decaf' into 'dedecaf', however
-      if (decaf_tier.size() < 5 || decaf_tier.substr(decaf_tier.size()-5,5) != "decaf")
-        decaf_tier.replace(decaf_tier.size()-3,3,"decaf");
+      if (decaf_tier.size() < 6 || decaf_tier.substr(decaf_tier.size()-6,5) != "decaf")
+        decaf_tier.replace(decaf_tier.size()-4,3,"decaf");
       meta["data_tier"] = decaf_tier;
     }
-
-    const char* rel = getenv("SRT_BASE_RELEASE");
-    if(rel) meta["decaf.base_release"] = rel;
 
     std::string parents = "[";
     for(const std::string& f: fnames){
@@ -274,18 +261,16 @@ namespace ana
 
     // if there's one more than one parent, this is a concat.
     // then we need "sumcaf", "sumdecaf", etc. as appropriate
-    if (fnames.size() > 1 && meta.find("data_tier") != meta.end())
-    {
+    if(fnames.size() > 1 && meta.find("data_tier") != meta.end()){
       auto & tier = meta["data_tier"];
       // if it ends with 'caf' and doesn't start with 'sum',
       // it should now start with 'sum'
-      if (tier.substr(tier.size()-3, 3) == "caf" && tier.substr(0, 3) != "sum")
-        tier = "sum" + tier;
+      if (tier.substr(tier.size()-4, 3) == "caf" && tier.substr(1, 3) != "sum")
+        tier = "\"sum" + tier.substr(1);
     }
 
     // Allow user to override any metadata
     for(auto it: fMetaMap) meta[it.first] = it.second;
   }
-  */
 
 } // namespace

--- a/sbnana/CAFAna/Core/FileReducer.h
+++ b/sbnana/CAFAna/Core/FileReducer.h
@@ -42,7 +42,8 @@ namespace ana
     /// Override any metadata key in the output file
     void SetMetadata(const std::string& key, const std::string& val)
     {
-      fMetaMap[key] = val;
+      // Let's assume the user is just setting string keys
+      fMetaMap[key] = "\""+val+"\"";
     }
 
     virtual void Go() override;

--- a/sbnana/CAFAna/Core/FileReducer.h
+++ b/sbnana/CAFAna/Core/FileReducer.h
@@ -40,14 +40,10 @@ namespace ana
     //    void AddReductionStep(const std::function<ReductionFuncWithProxy> &f) {fReductionFuncsWithProxy.push_back(f);}
 
     /// Override any metadata key in the output file
-    /*
     void SetMetadata(const std::string& key, const std::string& val)
     {
       fMetaMap[key] = val;
     }
-    */
-
-    //    void CopyMetadata(bool copy=true){fCopyMetadata = copy;};
 
     virtual void Go() override;
 
@@ -55,9 +51,9 @@ namespace ana
     virtual void AccumulateExposures(const caf::SRSpill* spill) override {};
 
   protected:
-    //    void UpdateMetadata(std::map<std::string, std::string>& meta,
-    //                        const std::set<std::string>& mask,
-    //                        const std::vector<std::string>& fnames) const;
+    void UpdateMetadata(std::map<std::string, std::string>& meta,
+                        const std::set<std::string>& mask,
+                        const std::vector<std::string>& fnames) const;
 
     std::string fOutfile;
     SpillCut*   fSpillCut;
@@ -69,6 +65,5 @@ namespace ana
     //    std::vector<std::function<ReductionFuncWithProxy>> fReductionFuncsWithProxy;
 
     std::map<std::string, std::string> fMetaMap;
-    bool        fCopyMetadata;
   };
 }

--- a/sbnana/CAFAna/bin/CMakeLists.txt
+++ b/sbnana/CAFAna/bin/CMakeLists.txt
@@ -3,5 +3,10 @@ cet_make_exec( diff_spectra
                LIBRARIES ${ROOT_BASIC_LIB_LIST}
                )
 
+cet_make_exec( concat_cafs
+               SOURCE concat_cafs.cc
+               LIBRARIES ${ROOT_BASIC_LIB_LIST} CAFAnaCore
+               )
+
 install_headers()
 install_source()

--- a/sbnana/CAFAna/bin/concat_cafs.cc
+++ b/sbnana/CAFAna/bin/concat_cafs.cc
@@ -5,11 +5,9 @@ using namespace ana;
 #include <string>
 #include <vector>
 
-template<class... T> void concat_cafs(T... args)
+int main(int argc, char** argv)
 {
-  std::vector<std::string> infiles = {args...};
-
-  if(infiles.size() < 2){
+  if(argc < 3){
     std::cout << "usage: cafe -bq concat_cafs INFILES    OUTFILE\n"
               << "       cafe -bq concat_cafs INFILES... OUTFILE\n"
               << "       cafe -bq concat_cafs 'WILDCARD' OUTFILE\n"
@@ -19,8 +17,9 @@ template<class... T> void concat_cafs(T... args)
     exit(1);
   }
 
-  const std::string outfile = infiles.back();
-  infiles.pop_back();
+  std::vector<std::string> infiles;
+  for(int i = 1; i < argc-1; ++i) infiles.push_back(argv[i]);
+  const std::string outfile = argv[argc-1];
 
   FileReducer* reducer = 0;
   if(infiles.size() == 1){

--- a/sbnana/CAFAna/concat_cafs.C
+++ b/sbnana/CAFAna/concat_cafs.C
@@ -1,0 +1,42 @@
+#include "sbnana/CAFAna/Core/FileReducer.h"
+using namespace ana;
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+template<class... T> void concat_cafs(T... args)
+{
+  std::vector<std::string> infiles = {args...};
+
+  if(infiles.size() < 2){
+    std::cout << "usage: cafe -bq concat_cafs INFILES    OUTFILE\n"
+              << "       cafe -bq concat_cafs INFILES... OUTFILE\n"
+              << "       cafe -bq concat_cafs 'WILDCARD' OUTFILE\n"
+              << "       cafe -bq concat_cafs SAMDEF     OUTFILE\n"
+              << "Warning: this argument order is different to hadd"
+              << std::endl;
+    exit(1);
+  }
+
+  const std::string outfile = infiles.back();
+  infiles.pop_back();
+
+  FileReducer* reducer = 0;
+  if(infiles.size() == 1){
+    // Could be an (escaped) wildcard, or SAM definition
+    reducer = new FileReducer(infiles[0], outfile);
+  }
+  else{
+    reducer = new FileReducer(infiles, outfile);
+  }
+
+  reducer->SetMetadata("data_tier", "concat_caf");
+  reducer->SetMetadata("file_format", "concat_caf");
+
+  reducer->Go();
+
+  delete reducer;
+
+  std::cout << "Created " << outfile << std::endl;
+}

--- a/sbnana/FlatMaker/flatten_caf.cc
+++ b/sbnana/FlatMaker/flatten_caf.cc
@@ -80,7 +80,8 @@ int main(int argc, char** argv)
     for(int i = 0; i < metain->GetEntries(); ++i){
       metain->GetEntry(i);
 
-      if(key == "data_tier") value = "\"flat"+value.substr(1);
+      if(key == "data_tier") value = "\"flat_caf\"";
+      if(key == "file_format") value = "\"flat_caf\"";
 
       metaout->Fill();
     }

--- a/sbnana/FlatMaker/flatten_caf.cc
+++ b/sbnana/FlatMaker/flatten_caf.cc
@@ -66,5 +66,26 @@ int main(int argc, char** argv)
   hPOT->Write("TotalPOT");
   hEvts->Write("TotalEvents");
 
+  TTree* metain = (TTree*)fin->Get("metadata/metatree");
+  if(metain){
+    TDirectory* metadir = fout.mkdir("metadata");
+    metadir->cd();
+    std::string key, value;
+    std::string *pkey = &key, *pvalue = &value;
+    TTree* metaout = new TTree("metatree", "metatree");
+    metaout->Branch("key", &key);
+    metaout->Branch("value", &value);
+    metain->SetBranchAddress("key", &pkey);
+    metain->SetBranchAddress("value", &pvalue);
+    for(int i = 0; i < metain->GetEntries(); ++i){
+      metain->GetEntry(i);
+
+      if(key == "data_tier") value = "\"flat"+value.substr(1);
+
+      metaout->Fill();
+    }
+    metaout->Write();
+  }
+
   return 0;
 }


### PR DESCRIPTION
Propagate CAF metadata through file reduction and flattening steps.

This requires CAFs made using feature/bckhouse_caf_metadata from sbncode (https://github.com/SBNSoftware/sbncode/pull/95)