### PR TITLE
Feature/bckhouse_caf_wgts

### DIFF
--- a/sbnana/CAFAna/Core/FileReducer.cxx
+++ b/sbnana/CAFAna/Core/FileReducer.cxx
@@ -219,10 +219,10 @@ namespace ana
           // Copy globalTree verbatim from input to output
           caf::SRGlobal global;
           caf::SRGlobal* pglobal = &global;
-          globalIn->SetBranchAddress("global", &global);
+          globalIn->SetBranchAddress("global", &pglobal);
           fout.cd();
           TTree globalOut("globalTree", "globalTree");
-          globalOut.Branch("global", "caf::SRGlobal", &pglobal);
+          globalOut.Branch("global", "caf::SRGlobal", &global);
           assert(globalIn->GetEntries() == 1);
           // TODO check that the globalTree is the same in every file
           globalIn->GetEntry(0);

--- a/sbnana/CAFAna/Core/FileReducer.cxx
+++ b/sbnana/CAFAna/Core/FileReducer.cxx
@@ -6,6 +6,7 @@
 #include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
 
 #include "sbnanaobj/StandardRecord/StandardRecord.h"
+#include "sbnanaobj/StandardRecord/SRGlobal.h"
 
 #include <cassert>
 #include <iostream>
@@ -211,6 +212,24 @@ namespace ana
         if(n%100 == 0 && Nfiles == 1 && prog)
           prog->SetProgress(double(n)/Nentries);
       } // end for n
+
+      if(fileIdx == 0){
+        TTree* globalIn = (TTree*)f->Get("globalTree");
+        if(globalIn){
+          // Copy globalTree verbatim from input to output
+          caf::SRGlobal global;
+          caf::SRGlobal* pglobal = &global;
+          globalIn->SetBranchAddress("global", &global);
+          fout.cd();
+          TTree globalOut("globalTree", "globalTree");
+          globalOut.Branch("global", "caf::SRGlobal", &pglobal);
+          assert(globalIn->GetEntries() == 1);
+          // TODO check that the globalTree is the same in every file
+          globalIn->GetEntry(0);
+          globalOut.Fill();
+          globalOut.Write();
+        }
+      }
 
       if(prog) prog->SetProgress((fileIdx+1.)/Nfiles);
     } // end while GetNextFile

--- a/sbnana/FlatMaker/flatten_caf.cc
+++ b/sbnana/FlatMaker/flatten_caf.cc
@@ -15,7 +15,7 @@
 int main(int argc, char** argv)
 {
   if(argc != 3){
-    std::cout << "Usage: convert_to_flat input.events.root output.flat.root"
+    std::cout << "Usage: flatten_caf input.events.root output.flat.root"
               << std::endl;
     return 1;
   }

--- a/sbnana/FlatMaker/flatten_caf.cc
+++ b/sbnana/FlatMaker/flatten_caf.cc
@@ -1,4 +1,5 @@
 #include "sbnanaobj/StandardRecord/StandardRecord.h"
+#include "sbnanaobj/StandardRecord/SRGlobal.h"
 
 #include "sbnana/FlatMaker/FlatRecord.h"
 
@@ -59,6 +60,23 @@ int main(int argc, char** argv)
   prog.Done();
 
   trout->Write();
+
+  // Don't bother with a flat version for now, this info is tiny and read once
+  TTree* globalIn = (TTree*)fin->Get("globalTree");
+  if(globalIn){
+    // Copy globalTree verbatim from input to output
+    caf::SRGlobal global;
+    caf::SRGlobal* pglobal = &global;
+    globalIn->SetBranchAddress("global", &pglobal);
+    fout.cd();
+    TTree globalOut("globalTree", "globalTree");
+    globalOut.Branch("global", "caf::SRGlobal", &global);
+    assert(globalIn->GetEntries() == 1);
+    // TODO check that the globalTree is the same in every file
+    globalIn->GetEntry(0);
+    globalOut.Fill();
+    globalOut.Write();
+  }
 
   TH1* hPOT = (TH1*)fin->Get("TotalPOT");
   TH1* hEvts = (TH1*)fin->Get("TotalEvents");


### PR DESCRIPTION
Copy the globalTree, which is important for syst weights, when flattening or skimming/concatting CAFs.