### PR TITLE
Added check for duplicate run/subrun when combining CAF metadata

### DIFF
--- a/sbnana/CAFAna/Core/Utilities.cxx
+++ b/sbnana/CAFAna/Core/Utilities.cxx
@@ -620,7 +620,7 @@ namespace ana
         if (r1.find(r2tmp) != std::string::npos){
           std::cout << "Found files with duplicate run/subrun metadata: " << r2tmp << std::endl;
 
-          assert(false);
+          abort();
         } 
 
         if(r1.empty()){

--- a/sbnana/CAFAna/Core/Utilities.cxx
+++ b/sbnana/CAFAna/Core/Utilities.cxx
@@ -613,6 +613,16 @@ namespace ana
 
         assert(!r2.empty());
 
+        // Strip the outermost enclosing []
+        const std::string& r2tmp = r2.substr(1, r2.length()-2);
+
+        // Check that the run/subrun is not already present
+        if (r1.find(r2tmp) != std::string::npos){
+          std::cout << "Found files with duplicate run/subrun metadata: " << r2tmp << std::endl;
+
+          assert(false);
+        } 
+
         if(r1.empty()){
           base[key] = r2;
           continue;


### PR DESCRIPTION
I ran into an issue where you could concatenate 2 CAFs with the same run/subrun and the resulting CAF could not be declared to SAM due to repeated entries in the run/subrun metadata, this adds in a simple check to catch this case. 