### PR TITLE
Feature/bckhouse_cafana_weight_systs

### DIFF
--- a/sbnana/CAFAna/Prediction/PredictionLinFit.cxx
+++ b/sbnana/CAFAna/Prediction/PredictionLinFit.cxx
@@ -1,7 +1,3 @@
-#pragma message "WARNING: PredictionLinFit temporarily disabled"
-
-#if 0
-
 #include "sbnana/CAFAna/Prediction/PredictionLinFit.h"
 
 #include "sbnana/CAFAna/Core/HistCache.h"
@@ -56,7 +52,7 @@ namespace ana
       {
       }
 
-      void Shift(double sigma, caf::SRProxy* sr, double& weight) const override
+      void Shift(double sigma, caf::SRSliceProxy* sr, double& weight) const override
       {
         weight *= fVar(sr);
       }
@@ -543,5 +539,3 @@ namespace ana
   }
 
 }
-
-#endif

--- a/sbnana/CAFAna/Prediction/PredictionLinFit.h
+++ b/sbnana/CAFAna/Prediction/PredictionLinFit.h
@@ -1,5 +1,3 @@
-#if 0 // temporarily disable
-
 #pragma once
 
 #include "sbnana/CAFAna/Prediction/IPrediction.h"
@@ -88,5 +86,3 @@ namespace ana
     mutable std::vector<std::vector<double>> fCoeffs;
   };
 }
-
-#endif

--- a/sbnana/CAFAna/Systs/SBNWeightSysts.h
+++ b/sbnana/CAFAna/Systs/SBNWeightSysts.h
@@ -1,18 +1,13 @@
 #pragma once
 
-#if 0 // temporarily disabled. None of this exists in the CAFs at present
-
 #include "sbnana/CAFAna/Core/ISyst.h"
+#include "sbnana/CAFAna/Core/Cut.h"
 #include "sbnana/CAFAna/Core/Var.h"
 
-#include <vector>
-#include <unordered_map>
+#include "sbnana/CAFAna/StandardRecord/Proxy/FwdDeclare.h"
 
-namespace caf
-{
-  class PairProxy;
-  template<class T> class VectorProxy;
-}
+#include <unordered_map>
+#include <vector>
 
 namespace ana
 {
@@ -22,13 +17,12 @@ namespace ana
     UniverseWeight(const std::vector<std::string>& systs, int univIdx);
     UniverseWeight(const std::vector<const ISyst*>& systs, int univIdx);
 
-    double operator()(const caf::SRProxy* sr) const;
-  protected:
-    int GetIdx(const caf::VectorProxy<caf::PairProxy>& ws, int isyst) const;
+    double operator()(const caf::SRSliceProxy* sr) const;
 
+  protected:
     std::vector<std::string> fNames;
     int fUnivIdx;
-    mutable std::vector<int> fSystIdxs;
+    mutable std::vector<unsigned int> fSystIdxs;
   };
 
   Var GetUniverseWeight(const std::string& syst, int univIdx)
@@ -50,17 +44,14 @@ namespace ana
   class SBNWeightSyst: public ISyst
   {
   public:
-    SBNWeightSyst(const std::string& name, const Cut& cut = kNoCut);
+    SBNWeightSyst(const std::string& name, const SliceCut& cut = kNoCut);
 
-    void Shift(double x, caf::SRProxy* sr, double& weight) const override;
+    void Shift(double x, caf::SRSliceProxy* sr, double& weight) const override;
 
   protected:
     mutable int fIdx;
 
-    Cut fCut;
-
-    int GetIdx(const caf::VectorProxy<caf::PairProxy>& ws) const;
-
+    SliceCut fCut;
 
     struct Univs
     {
@@ -73,9 +64,7 @@ namespace ana
     Univs GetUnivs(double x) const;
   };
 
-  const std::vector<const ISyst*>& GetSBNGenieWeightSysts();
-  const std::vector<const ISyst*>& GetSBNFluxWeightSysts();
-  const std::vector<const ISyst*>& GetSBNWeightSysts(); // genie+flux
+  //  const std::vector<const ISyst*>& GetSBNGenieWeightSysts();
+  //  const std::vector<const ISyst*>& GetSBNFluxWeightSysts();
+  //  const std::vector<const ISyst*>& GetSBNWeightSysts(); // genie+flux
 }
-
-#endif

--- a/sbnana/CAFAna/Systs/UniverseOracle.cxx
+++ b/sbnana/CAFAna/Systs/UniverseOracle.cxx
@@ -127,10 +127,13 @@ namespace ana
   }
 
   // --------------------------------------------------------------------------
-  unsigned int UniverseOracle::SystIndex(const std::string& name)
+  unsigned int UniverseOracle::SystIndex(const std::string& name) const
   {
     auto it = fSystIdxs.find(name);
-    assert(it != fSystIdxs.end());
+    if(it == fSystIdxs.end()){
+      std::cout << "UniverseOracle: syst '" << name << "' not known" << std::endl;
+      abort();
+    }
     return it->second;
   }
 

--- a/sbnana/CAFAna/Systs/UniverseOracle.h
+++ b/sbnana/CAFAna/Systs/UniverseOracle.h
@@ -8,6 +8,7 @@
 
 namespace ana
 {
+  /// Desired match type in UniverseOracle::ClosestShiftIndex
   enum class ESide{
     kAbove, kBelow, kEither
   };
@@ -18,19 +19,27 @@ namespace ana
     static UniverseOracle& Instance();
 
     bool SystExists(const std::string& name) const;
+    /// List of all known syst names
     std::vector<std::string> Systs() const;
 
-    const std::vector<double>& ShiftsForSyst(const std::string& name) const;
-
+    /// List of shifts for this syst in each universe
+    const std::vector<float>& ShiftsForSyst(const std::string& name) const;
+    /// Get SystShifts objects representing each universe in a multiverse
+    /// consisting of the specificed systs.
     std::vector<SystShifts> ShiftsForSysts(const std::vector<const ISyst*>& systs, int nUniv) const;
 
-    unsigned int ClosestIndex(const std::string& name,
-                              double shift,
-                              ESide side = ESide::kEither,
-                              double* trueShift = 0) const;
+    /// Which index in the weights array corresponds to this syst?
+    unsigned int SystIndex(const std::string& name);
+
+    /// Within that entry, which index corresponds most closely to 'shift'?
+    unsigned int ClosestShiftIndex(const std::string& name,
+                                   double shift,
+                                   ESide side = ESide::kEither,
+                                   double* trueShift = 0) const;
   protected:
     UniverseOracle();
 
-    std::map<std::string, std::vector<double>> fData;
+    std::map<std::string, unsigned int> fSystIdxs;
+    std::map<std::string, std::vector<float>> fShiftVals;
   };
 }

--- a/sbnana/CAFAna/Systs/UniverseOracle.h
+++ b/sbnana/CAFAna/Systs/UniverseOracle.h
@@ -29,7 +29,7 @@ namespace ana
     std::vector<SystShifts> ShiftsForSysts(const std::vector<const ISyst*>& systs, int nUniv) const;
 
     /// Which index in the weights array corresponds to this syst?
-    unsigned int SystIndex(const std::string& name);
+    unsigned int SystIndex(const std::string& name) const;
 
     /// Within that entry, which index corresponds most closely to 'shift'?
     unsigned int ClosestShiftIndex(const std::string& name,

--- a/sbnana/CAFAna/test/test_evtwgt.C
+++ b/sbnana/CAFAna/test/test_evtwgt.C
@@ -1,0 +1,103 @@
+#include "sbnana/CAFAna/Core/Ratio.h"
+#include "sbnana/CAFAna/Core/SpectrumLoader.h"
+#include "sbnana/CAFAna/Core/Spectrum.h"
+#include "sbnana/CAFAna/Core/SystShifts.h"
+#include "sbnana/CAFAna/Systs/SBNWeightSysts.h"
+using namespace ana;
+
+#include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
+
+#include "sbnana/SBNAna/Cuts/TruthCuts.h"
+
+#include "TH1.h"
+#include "TPad.h"
+
+const double pot = 6e20;
+
+const std::vector<std::string> systs = {
+  "DISAth",
+  "DISBth",
+  "DISCv1u",
+  "DISCv2u",
+  "IntraNukeNabs",
+  "IntraNukeNcex",
+  "IntraNukeNinel",
+  "IntraNukeNmfp",
+  "IntraNukeNpi",
+  "IntraNukePIabs",
+  "IntraNukePIcex",
+  "IntraNukePIinel",
+  "IntraNukePImfp",
+  "IntraNukePIpi",
+  "NC",
+  "NonResRvbarp1pi",
+  //  "NonResRvbarp1pi", // need to do something with the Alt variants...
+  "NonResRvbarp2pi",
+  //  "NonResRvbarp2pi",
+  "NonResRvp1pi",
+  //  "NonResRvp1pi",
+  "NonResRvp2pi",
+  //  "NonResRvp2pi",
+  "ResDecayGamma",
+  "CCResAxial",
+  "CCResVector",
+  //  "CohMA", // return lots of NaNs...
+  //  "CohR0",
+  "NCELaxial",
+  "NCELeta",
+  "NCResAxial",
+  "NCResVector",
+  "QEMA",
+};
+
+void test_evtwgt()
+{
+  SpectrumLoader loader("workshop_SBNWorkshop0421_prodoverlay_corsika_cosmics_proton_genie_intrnue_spill_gsimple-configf-v1_tpc_flat_caf_sbnd");
+
+  HistAxis axis("True Energy (GeV)", Binning::Simple(20, 0, 5), SIMPLEVAR(truth.E));
+
+  std::map<std::string, Spectrum*> sPP, sP, sN, sNN;
+  for(const std::string& syst: systs){
+    ISyst* s = new SBNWeightSyst(syst);
+    sPP[syst] = new Spectrum(loader, axis, kIsCC, SystShifts(s, +2));
+    sP [syst] = new Spectrum(loader, axis, kIsCC, SystShifts(s, +1));
+    sN [syst] = new Spectrum(loader, axis, kIsCC, SystShifts(s, -1));
+    sNN[syst] = new Spectrum(loader, axis, kIsCC, SystShifts(s, -2));
+  }
+
+  Spectrum snom(loader, axis, kIsCC);
+
+  // This is very slow (to be investigated), so commented out for now
+  //  std::vector<Spectrum> multiverse;
+  //  multiverse.reserve(100);
+  //  for(int i = 0; i < 100; ++i) multiverse.emplace_back(loader, axis, kIsCC, kNoShift, GetUniverseWeight(systs, i));
+
+  loader.Go();
+
+  for(const std::string& syst: systs){
+    TH1* h = sPP[syst]->ToTH1(pot, kRed);
+    h->SetTitle(syst.c_str());
+    h->Draw("hist");
+    sP[syst]->ToTH1(pot, kRed-7)->Draw("hist same");
+    sN[syst]->ToTH1(pot, kBlue-7)->Draw("hist same");
+    sNN[syst]->ToTH1(pot, kBlue)->Draw("hist same");
+    snom.ToTH1(pot)->Draw("hist same");
+    gPad->Print(("spect_"+syst+".pdf").c_str());
+
+    h = (*sPP[syst] / snom).ToTH1(kRed);
+    h->SetTitle(syst.c_str());
+    h->GetYaxis()->SetRangeUser(.7, 1.3);
+    h->Draw("hist");
+    (*sP [syst] / snom).ToTH1(kRed-7)->Draw("hist same");
+    (*sN [syst] / snom).ToTH1(kBlue-7)->Draw("hist same");
+    (*sNN[syst] / snom).ToTH1(kBlue)->Draw("hist same");
+    gPad->Print(("ratio_"+syst+".pdf").c_str());
+  }
+
+  // TH1* h = snom.ToTH1(pot);
+  // h->Draw("hist");
+  // h->GetYaxis()->SetRangeUser(0, 1.3*h->GetMaximum());
+  // for(const Spectrum& s: multiverse) s.ToTH1(pot, kGray)->Draw("hist same");
+  // h->Draw("hist same");
+  // gPad->Print("multiverse.pdf");
+}


### PR DESCRIPTION
Enable use of weight systematics within CAFAna. Reactivates some code that was taken out of the build when this originally got broken in the transition to CAFs.