### PR TITLE
Feature/mueller icarus numucc pac2021

### DIFF
--- a/sbnana/SBNAna/Analysis/202106PAC/contours_icarus.C
+++ b/sbnana/SBNAna/Analysis/202106PAC/contours_icarus.C
@@ -1,0 +1,78 @@
+#include "sbnana/CAFAna/Core/SpectrumLoader.h"
+#include "sbnana/CAFAna/Core/Spectrum.h"
+#include "sbnana/CAFAna/Core/Binning.h"
+#include "sbnana/CAFAna/Core/Var.h"
+#include "sbnana/CAFAna/Core/OscCalcSterileApprox.h"
+#include "sbnana/CAFAna/Prediction/PredictionNoExtrap.h"
+#include "sbnana/CAFAna/Core/Loaders.h"
+#include "sbnana/CAFAna/Analysis/ExpInfo.h"
+#include "sbnana/CAFAna/Analysis/FitAxis.h"
+
+#include "sbnana/CAFAna/Vars/FitVarsSterileApprox.h"
+
+#include "sbnana/CAFAna/Experiment/SingleSampleExperiment.h"
+
+#include "sbnana/CAFAna/Analysis/Surface.h"
+
+#include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
+
+#include "sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h"
+
+#include "TPad.h"
+
+using namespace ana;
+
+// This should be
+// workshop_SBNWorkshop0421_prodoverlay_corsika_cosmics_cosmics_proton_genie_nu_spill_gsimple-config_caf_icarus
+// but that is only available from SAM to icarus users, for now.
+//const std::string icarus_wildcard = "/pnfs/icarus/persistent/users/icaruspro/SBNworkshopApril2021/CAF/corsika_nue_BNB/*/*/*.root";
+
+// That dataset takes absolutely forever, because it isn't flattened. Use this
+// file for now.
+const std::string icarus_wildcard = "/icarus/data/users/mueller/NuMuSelection/v09_17_00/nucosmics/icarus_nucosmics.flat.root";
+
+void contours_icarus()
+{
+  Loaders loaders;
+  loaders.SetLoaderPath(icarus_wildcard, Loaders::kMC, ana::kBeam, Loaders::kNonSwap);
+
+  const Var kTrueE = SIMPLEVAR(truth.E);
+  const Var kRecoE = kTrueE; // TODO
+
+  const Var kCryostatWeight = Constant(2); // only using cryo0
+
+  const SpillCut kNumuSpillSel = kNoSpillCut; // TODO
+  const Cut kNumuSel = kNuMuCC_FullSelection;
+
+  // TODO should make this an official function somewhere
+  const vector<double> binEdges = {0.2, 0.3, 0.4, 0.45, 0.5,
+                                   0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0,
+                                   1.25, 1.5, 2.0, 2.5, 3.0};
+  const Binning binsEnergy = Binning::Custom(binEdges);
+
+
+  const HistAxis axEnergy("Reconstructed energy (GeV)", binsEnergy, kRecoE);
+
+  PredictionNoExtrap pred(loaders, axEnergy, kNumuSpillSel, kNumuSel, kNoShift, kCryostatWeight);
+
+  loaders.Go();
+
+
+  // Fake data spectrum
+  osc::NoOscillations noosc;
+  const Spectrum fake = pred.Predict(&noosc).FakeData(kPOTnominal);
+
+  OscCalcSterileApproxAdjustable* calc = DefaultSterileApproxCalc();
+
+  const FitAxis kAxTh(&kFitSinSq2ThetaMuMu, 30, 1e-3, 1, true);
+  const FitAxis kAxDmSq(&kFitDmSqSterile, 30, 1e-2, 1e2, true);
+  
+  SingleSampleExperiment expt(&pred, fake);
+
+  Surface surf(&expt, calc, kAxTh, kAxDmSq);
+
+  TH2* crit5sig = Gaussian5Sigma1D1Sided(surf);
+  surf.DrawContour(crit5sig, kSolid, kBlack);
+
+  gPad->Print("contour_icarus.pdf");
+}

--- a/sbnana/SBNAna/Analysis/202106PAC/reduce_icarus.C
+++ b/sbnana/SBNAna/Analysis/202106PAC/reduce_icarus.C
@@ -1,0 +1,22 @@
+#include "sbnana/CAFAna/Core/FileReducer.h"
+
+#include "sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h"
+
+using namespace ana;
+
+// This should be
+// workshop_SBNWorkshop0421_prodoverlay_corsika_cosmics_cosmics_proton_genie_nu_spill_gsimple-config_caf_icarus
+// but that is only available from SAM to icarus users, for now.
+const std::string icarus_wildcard = "/pnfs/icarus/persistent/users/icaruspro/SBNworkshopApril2021/CAF/corsika_nue_BNB/*/*/*.root";
+
+void reduce_icarus()
+{
+  const SpillCut kNumuSpillSel = kNoSpillCut; // TODO
+  const Cut kNumuSel = kNuMuCC_FullSelection;
+
+  FileReducer reducer(icarus_wildcard, "reduced_icarus.root");
+  reducer.AddSpillCut(kNumuSpillSel);
+  reducer.AddSliceCut(kNumuSel);
+
+  reducer.Go();
+}

--- a/sbnana/SBNAna/Analysis/202106PAC/spectra_icarus.C
+++ b/sbnana/SBNAna/Analysis/202106PAC/spectra_icarus.C
@@ -1,0 +1,73 @@
+#include "sbnana/CAFAna/Core/SpectrumLoader.h"
+#include "sbnana/CAFAna/Core/Spectrum.h"
+#include "sbnana/CAFAna/Core/Binning.h"
+#include "sbnana/CAFAna/Core/Var.h"
+
+#include "sbnana/CAFAna/Cuts/TruthCuts.h"
+
+#include "sbnana/CAFAna/Analysis/ExpInfo.h"
+
+#include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
+
+#include "sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h"
+
+#include "TH1.h"
+#include "TPad.h"
+
+using namespace ana;
+
+// This should be
+// workshop_SBNWorkshop0421_prodoverlay_corsika_cosmics_cosmics_proton_genie_nu_spill_gsimple-config_caf_icarus
+// but that is only available from SAM to icarus users, for now.
+//const std::string icarus_wildcard = "/pnfs/icarus/persistent/users/icaruspro/SBNworkshopApril2021/CAF/corsika_nue_BNB/*/*/*.root";
+
+// That dataset takes absolutely forever, because it isn't flattened. Use this
+// file for now.
+const std::string icarus_wildcard = "/icarus/data/users/mueller/NuMuSelection/v09_17_00/nucosmics/icarus_nucosmics.flat.root";
+
+void spectra_icarus()
+{
+  SpectrumLoader loader(icarus_wildcard);
+
+  const Var kTrueE = SIMPLEVAR(truth.E);
+  const Var kRecoE = kTrueE; // TODO
+
+  const Var kCryostatWeight = Constant(2); // only using cryo0
+
+  const SpillCut kNumuSpillSel = kNoSpillCut; // TODO
+  const Cut kNumuSel = kNuMuCC_FullSelection;
+
+  const Cut kIsCosmic = SIMPLEVAR(truth.index) < 0;
+
+  // This looks much better than the official fit binning 
+  const Binning binsEnergy = Binning::Simple(30, 0, 3);
+
+  // TODO should make this an official function somewhere
+  /*
+  const vector<double> binEdges = {0.2, 0.3, 0.4, 0.45, 0.5,
+                                   0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0,
+                                   1.25, 1.5, 2.0, 2.5, 3.0};
+  const Binning binsEnergy = Binning::Custom(binEdges);
+  */
+
+  const HistAxis axEnergy(/*Reconstructed*/"True energy (GeV)", binsEnergy, kRecoE);
+
+  Spectrum sTot(loader, axEnergy, kNumuSpillSel, kNumuSel, kNoShift, kCryostatWeight);
+  Spectrum sNC(loader, axEnergy, kNumuSpillSel, kNumuSel && kIsNC, kNoShift, kCryostatWeight);
+  //  Spectrum sCosmic(loader, axEnergy, kNumuSpillSel, kNumuSel && kIsCosmic, kNoShift, kCryostatWeight);
+
+  loader.Go();
+
+  sTot.ToTH1(kPOTnominal)->Draw("hist");
+  TH1* hNC = sNC.ToTH1(kPOTnominal, kBlue);
+  hNC->SetFillColor(kBlue-10);
+  hNC->Draw("histf same");
+  //  TH1* hCosmic = sCosmic.ToTH1(kPOTnominal, kMagenta);
+  //  hCosmic->Draw("hist same");
+
+  std::cout << sTot.Integral(kPOTnominal) << " events total" << std::endl;
+  std::cout << "  of which " << sNC.Integral(kPOTnominal) << " NC" << std::endl;
+  //  std::cout << "  and " << sCosmic.Integral(kPOTnominal) << " cosmics" << std::endl;
+
+  gPad->Print("spectrum_icarus.pdf");
+}

--- a/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.cxx
+++ b/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.cxx
@@ -1,7 +1,7 @@
+#include <cmath>
 #include "sbnana/SBNAna/Vars/NumuVarsIcarus202106.h"
 #include "sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h"
 #include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
-#include <cmath>
 
 namespace ana
 {

--- a/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.cxx
+++ b/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.cxx
@@ -1,0 +1,146 @@
+#include "sbnana/SBNAna/Vars/NumuVarsIcarus202106.h"
+#include "sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h"
+#include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
+#include <cmath>
+
+namespace ana
+{
+  const Cut kIsNuSlice = ( kTruthIndex >= 0.f );
+  
+  const Cut kIsCosmic = ( !kIsNuSlice );
+  
+  const Cut kIsNuMuCC([](const caf::SRSliceProxy* slc) {
+      return ( kIsNuSlice(slc) && slc->truth.iscc && ( slc->truth.pdg == 14 || slc->truth.pdg == -14 ) );
+    });
+  
+  const Cut kIsNuOther = ( kIsNuSlice && !kIsNuMuCC );
+
+  const Cut kCryo0([](const caf::SRSliceProxy* slc) {
+      return ( !isnan(slc->vertex.x) && slc->vertex.x < 0 );
+    });
+
+  const Cut kTFiducial([](const caf::SRSliceProxy* slc) {
+      return ( !isnan(slc->truth.position.x) &&
+	       ( ( slc->truth.position.x < -71.1 - 25 && slc->truth.position.x > -369.33 + 25 ) ||
+		 ( slc->truth.position.x > 71.1 + 25 && slc->truth.position.x < 369.33 - 25 ) ) &&
+	       !isnan(slc->truth.position.y) &&
+	       ( slc->truth.position.y > -181.7 + 25 && slc->truth.position.y < 134.8 - 25 ) &&
+	       !isnan(slc->truth.position.z) &&
+	       ( slc->truth.position.z > -895.95 + 30 && slc->truth.position.z < 895.95 - 50 ) );
+    });
+
+  const Cut kRFiducial([](const caf::SRSliceProxy* slc) {
+      return ( !isnan(slc->vertex.x) &&
+	       ( ( slc->vertex.x < -71.1 - 25 && slc->vertex.x > -369.33 + 25 ) ||
+		 ( slc->vertex.x > 71.1 + 25 && slc->vertex.x < 369.33 - 25 ) ) &&
+	       !isnan(slc->vertex.y) &&
+	       ( slc->vertex.y > -181.7 + 25 && slc->vertex.y < 134.8 - 25 ) &&
+	       !isnan(slc->vertex.z) &&
+	       ( slc->vertex.z > -895.95 + 30 && slc->vertex.z < 895.95 - 50 ) );
+    });
+
+  const Cut kNotClearCosmic([](const caf::SRSliceProxy* slc) {
+      return !slc->is_clear_cosmic;
+    });
+
+  const Cut kNuScore([](const caf::SRSliceProxy* slc) {
+      return ( !isnan(slc->nu_score) && slc->nu_score > 0.4 );
+    });
+
+  const Cut kFMScore([](const caf::SRSliceProxy* slc) {
+      return ( !isnan(slc->fmatch.score) && slc->fmatch.score < 7.0 );
+    });
+
+  const Cut kPTrack([](const caf::SRSliceProxy* slc) {
+      // The (dis)qualification of a slice is based upon the track level information.
+      float Atslc, Chi2Proton, Chi2Muon;
+      std::vector<unsigned int> Candidates;
+      bool AtSlice, Contained, MaybeMuonExiting, MaybeMuonContained, ProgCut(false);
+      
+      for (auto const& trk : slc->reco.trk)
+      {
+	// First we calculate the distance of each track to the slice vertex.
+	Atslc = sqrt( pow( slc->vertex.x - trk.start.x, 2.0 ) +
+		      pow( slc->vertex.y - trk.start.y, 2.0 ) +
+		      pow( slc->vertex.z - trk.start.z, 2.0 ) );
+	// We require that the distance of the track from the slice is less than
+	// 10 cm and that the parent of the track has been marked as the primary.
+	AtSlice = ( Atslc < 10.0 && trk.parent_is_primary);
+	
+	if (trk.bestplane == 0)
+	{
+	  Chi2Proton = trk.chi2pid0.chi2_proton;
+	  Chi2Muon = trk.chi2pid0.chi2_muon;
+	}
+	else if (trk.bestplane == 1)
+	{
+	  Chi2Proton = trk.chi2pid1.chi2_proton;
+	  Chi2Muon = trk.chi2pid1.chi2_muon;
+	}
+	else
+	{
+	  Chi2Proton = trk.chi2pid2.chi2_proton;
+	  Chi2Muon = trk.chi2pid2.chi2_muon;
+	}
+
+	Contained = ( !isnan(trk.end.x) &&
+		      ( trk.end.x < -71.1 - 25 && trk.end.x > -369.33 + 25 ) &&//
+		      // || ( trk.end.x > 71.1 + 25 && trk.end.x < 369.33 - 25 ) ) &&
+		      !isnan(trk.end.y) &&
+		      ( trk.end.y > -181.7 + 25 && trk.end.y < 134.8 - 25 ) &&
+		      !isnan(trk.end.z) &&
+		      ( trk.end.z > -895.95 + 30 && trk.end.z < 895.95 - 50 ) );
+	MaybeMuonExiting = ( !Contained && trk.len > 100);
+	MaybeMuonContained = ( Contained && Chi2Proton > 60 && Chi2Muon < 30 && trk.len > 50 );
+	ProgCut = ProgCut || ( AtSlice && ( MaybeMuonExiting || MaybeMuonContained ) );
+      }
+      return ProgCut;
+    });
+
+  // "Successive" cuts for the selection. These are meant to successively build upon
+  // each other, which fits the flow of the selection.
+  const Cut kNuMuCC_Cryo0 = ( kIsNuMuCC && kCryo0 );
+
+  const Cut kCosmic_Cryo0 = ( kIsCosmic && kCryo0 );
+
+  const Cut kNuOther_Cryo0 = ( kIsNuOther && kCryo0 );
+  
+  const Cut kNuMuCC_TFiducial = ( kNuMuCC_Cryo0 && kTFiducial );
+
+  const Cut kNuMuCC_RFiducial = ( kNuMuCC_Cryo0 && kRFiducial );
+
+  const Cut kCosmic_TFiducial = ( kCosmic_Cryo0 && kTFiducial );
+
+  const Cut kCosmic_RFiducial = ( kCosmic_Cryo0 && kRFiducial );
+
+  const Cut kNuOther_TFiducial = ( kNuOther_Cryo0 && kTFiducial );
+
+  const Cut kNuOther_RFiducial = ( kNuOther_Cryo0 && kRFiducial );
+  
+  const Cut kNuMuCC_ClearCos = ( kNuMuCC_TFiducial && kNotClearCosmic );
+
+  const Cut kCosmic_ClearCos = ( kCosmic_RFiducial && kNotClearCosmic );
+ 
+  const Cut kNuOther_ClearCos = ( kNuOther_TFiducial && kNotClearCosmic );
+  
+  const Cut kNuMuCC_NuScore = ( kNuMuCC_ClearCos && kNuScore );
+ 
+  const Cut kCosmic_NuScore = ( kCosmic_ClearCos && kNuScore );
+
+  const Cut kNuOther_NuScore = ( kNuOther_ClearCos && kNuScore );
+  
+  const Cut kNuMuCC_FMScore = ( kNuMuCC_NuScore && kFMScore );
+
+  const Cut kCosmic_FMScore = ( kCosmic_NuScore && kFMScore );
+
+  const Cut kNuOther_FMScore = ( kNuOther_NuScore && kFMScore );
+  
+  const Cut kNuMuCC_PTrack = ( kNuMuCC_FMScore && kPTrack );
+
+  const Cut kCosmic_PTrack = ( kCosmic_FMScore && kPTrack );
+
+  const Cut kNuOther_PTrack = ( kNuOther_FMScore && kPTrack );
+  
+  // The full selection cut using only reco information.
+  const Cut kNuMuCC_FullSelection = ( kCryo0 && kRFiducial && kNotClearCosmic && kNuScore && kFMScore && kPTrack );
+}

--- a/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h
+++ b/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h
@@ -29,6 +29,10 @@ namespace ana
 
   extern const Cut kPTrack;
 
+  extern const Cut kPTrackContained;
+  
+  extern const Cut kPTrackExiting;
+
   // "Successive" cuts for the selection.
   extern const Cut kNuMuCC_Cryo0;
 
@@ -74,4 +78,7 @@ namespace ana
 
   // The full selection cut using only reco information.
   extern const Cut kNuMuCC_FullSelection;
+
+  // Spill level cuts.
+  extern const SpillCut kLongTrack;
 }

--- a/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h
+++ b/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h
@@ -1,130 +1,77 @@
-// SBNAna includes.
-#include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
+#pragma once
 
-// Custom includes.
-#include "TestVars.h"
+// Definition of the generic Cut object.
+#include "sbnana/CAFAna/Core/Cut.h"
 
-using namespace ana;
+namespace ana
+{
+  // Cuts for identifying slice category.
+  extern const Cut kIsNuSlice;
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Define the cuts for the selection.
-////////////////////////////////////////////////////////////////////////////////////////////////////
+  extern const Cut kIsCosmic;
 
-const Cut kIsNu = ( kTruthIndex >= 0.f );
+  extern const Cut kIsNuMuCC;
 
-const Cut kIsCosmic = ( !kIsNu );
+  extern const Cut kIsNuOther;
 
-const Cut kIsNuMuCC([](const caf::SRSliceProxy* slc) {
-    return ( kIsNu(slc) && slc->truth.iscc && ( slc->truth.pdg == 14 || slc->truth.pdg == -14 ) );
-  });
+  // "Raw" cuts for the selection.
+  extern const Cut kCryo0;
 
-const Cut kIsNuOther = ( kIsNu && !kIsNuMuCC );
+  extern const Cut kTFiducial;
 
-const Cut kCryo0([](const caf::SRSliceProxy* slc) {
-    return ( !std::isnan(slc->vertex.x) && slc->vertex.x < 0 );
-  });
+  extern const Cut kRFiducial;
 
-const Cut kTFiducial([](const caf::SRSliceProxy* slc) {
-    return ( !std::isnan(slc->truth.position.x) &&
-	     ( ( slc->truth.position.x < -71.1 - 25 && slc->truth.position.x > -369.33 + 25 ) ||
-	       ( slc->truth.position.x > 71.1 + 25 && slc->truth.position.x < 369.33 - 25 ) ) &&
-	     !std::isnan(slc->truth.position.y) &&
-	     ( slc->truth.position.y > -181.7 + 25 && slc->truth.position.y < 134.8 - 25 ) &&
-	     !std::isnan(slc->truth.position.z) &&
-	     ( slc->truth.position.z > -895.95 + 30 && slc->truth.position.z < 895.95 - 50 ) );
-  });
+  extern const Cut kNotClearCosmic;
 
-const Cut kRFiducial([](const caf::SRSliceProxy* slc) {
-    return ( !std::isnan(slc->vertex.x) &&
-	     ( ( slc->vertex.x < -71.1 - 25 && slc->vertex.x > -369.33 + 25 ) ||
-	       ( slc->vertex.x > 71.1 + 25 && slc->vertex.x < 369.33 - 25 ) ) &&
-	     !std::isnan(slc->vertex.y) &&
-	     ( slc->vertex.y > -181.7 + 25 && slc->vertex.y < 134.8 - 25 ) &&
-	     !std::isnan(slc->vertex.z) &&
-	     ( slc->vertex.z > -895.95 + 30 && slc->vertex.z < 895.95 - 50 ) );
-  });
+  extern const Cut kNuScore;
 
-const Cut kNotClearCosmic([](const caf::SRSliceProxy* slc) {
-    return !slc->is_clear_cosmic;
-  });
+  extern const Cut kFMScore;
 
-const Cut kNuScore([](const caf::SRSliceProxy* slc) {
-    return ( !std::isnan(slc->nu_score) && slc->nu_score > 0.4 );
-  });
+  extern const Cut kPTrack;
 
-const Cut kFMScore([](const caf::SRSliceProxy* slc) {
-    return ( !std::isnan(slc->fmatch.score) && slc->fmatch.score < 7.0 );
-  });
+  // "Successive" cuts for the selection.
+  extern const Cut kNuMuCC_Cryo0;
 
-const Cut kPTrack([](const caf::SRSliceProxy* slc) {
-    // The (dis)qualification of a slice is based upon the track level information.
-    float Atslc, Chi2Proton, Chi2Muon;
-    std::vector<unsigned int> Candidates;
-    bool AtSlice, Contained, MaybeMuonExiting, MaybeMuonContained, ProgCut(false);
+  extern const Cut kCosmic_Cryo0;
 
-    for (auto const& trk : slc->reco.trk)
-    {
-      // First we calculate the distance of each track to the slice vertex.
-      Atslc = sqrt( pow( slc->vertex.x - trk.start.x, 2.0 ) +
-		    pow( slc->vertex.y - trk.start.y, 2.0 ) +
-		    pow( slc->vertex.z - trk.start.z, 2.0 ) );
-      // We require that the distance of the track from the slice is less than
-      // 10 cm and that the parent of the track has been marked as the primary.
-      AtSlice = ( Atslc < 10.0 && trk.parent_is_primary);
-      
-      if (trk.bestplane == 0)
-      {
-	Chi2Proton = trk.chi2pid0.chi2_proton;
-	Chi2Muon = trk.chi2pid0.chi2_muon;
-      }
-      else if (trk.bestplane == 1)
-      {
-	Chi2Proton = trk.chi2pid1.chi2_proton;
-	Chi2Muon = trk.chi2pid1.chi2_muon;
-      }
-      else
-      {
-	Chi2Proton = trk.chi2pid2.chi2_proton;
-	Chi2Muon = trk.chi2pid2.chi2_muon;
-      }
+  extern const Cut kNuOther_Cryo0;
 
-      Contained = ( !std::isnan(trk.end.x) &&
-		    ( trk.end.x < -71.1 - 25 && trk.end.x > -369.33 + 25 ) &&//
-		      // || ( trk.end.x > 71.1 + 25 && trk.end.x < 369.33 - 25 ) ) &&
-		    !std::isnan(trk.end.y) &&
-		    ( trk.end.y > -181.7 + 25 && trk.end.y < 134.8 - 25 ) &&
-		    !std::isnan(trk.end.z) &&
-		    ( trk.end.z > -895.95 + 30 && trk.end.z < 895.95 - 50 ) );
-      MaybeMuonExiting = ( !Contained && trk.len > 100);
-      MaybeMuonContained = ( Contained && Chi2Proton > 60 && Chi2Muon < 30 && trk.len > 50 );
-      ProgCut = ProgCut || ( AtSlice && ( MaybeMuonExiting || MaybeMuonContained ) );
-    }
-    return ProgCut;
-  });
+  extern const Cut kNuMuCC_TFiducial;
 
-const Cut kNuMuCC_Cryo0 = ( kIsNuMuCC && kCryo0 );
-const Cut kCosmic_Cryo0 = ( kIsCosmic && kCryo0 );
-const Cut kNuOther_Cryo0 = ( kIsNuOther && kCryo0 );
+  extern const Cut kNuMuCC_RFiducial;
 
-const Cut kNuMuCC_TFiducial = ( kNuMuCC_Cryo0 && kTFiducial );
-const Cut kNuMuCC_RFiducial = ( kNuMuCC_Cryo0 && kRFiducial );
-const Cut kCosmic_TFiducial = ( kCosmic_Cryo0 && kTFiducial );
-const Cut kCosmic_RFiducial = ( kCosmic_Cryo0 && kRFiducial );
-const Cut kNuOther_TFiducial = ( kNuOther_Cryo0 && kTFiducial );
-const Cut kNuOther_RFiducial = ( kNuOther_Cryo0 && kRFiducial );
+  extern const Cut kCosmic_TFiducial;
 
-const Cut kNuMuCC_ClearCos = ( kNuMuCC_TFiducial && kNotClearCosmic );
-const Cut kCosmic_ClearCos = ( kCosmic_RFiducial && kNotClearCosmic );
-const Cut kNuOther_ClearCos = ( kNuOther_TFiducial && kNotClearCosmic );
+  extern const Cut kCosmic_RFiducial;
 
-const Cut kNuMuCC_NuScore = ( kNuMuCC_ClearCos && kNuScore );
-const Cut kCosmic_NuScore = ( kCosmic_ClearCos && kNuScore );
-const Cut kNuOther_NuScore = ( kNuOther_ClearCos && kNuScore );
+  extern const Cut kNuOther_TFiducial;
 
-const Cut kNuMuCC_FMScore = ( kNuMuCC_NuScore && kFMScore );
-const Cut kCosmic_FMScore = ( kCosmic_NuScore && kFMScore );
-const Cut kNuOther_FMScore = ( kNuOther_NuScore && kFMScore );
+  extern const Cut kNuOther_RFiducial;
 
-const Cut kNuMuCC_PTrack = ( kNuMuCC_FMScore && kPTrack );
-const Cut kCosmic_PTrack = ( kCosmic_FMScore && kPTrack );
-const Cut kNuOther_PTrack = ( kNuOther_FMScore && kPTrack );
+  extern const Cut kNuMuCC_ClearCos;
+
+  extern const Cut kCosmic_ClearCos;
+
+  extern const Cut kNuOther_ClearCos;
+
+  extern const Cut kNuMuCC_NuScore;
+
+  extern const Cut kCosmic_NuScore;
+
+  extern const Cut kNuOther_NuScore;
+
+  extern const Cut kNuMuCC_FMScore;
+
+  extern const Cut kCosmic_FMScore;
+
+  extern const Cut kNuOther_FMScore;
+
+  extern const Cut kNuMuCC_PTrack;
+
+  extern const Cut kCosmic_PTrack;
+
+  extern const Cut kNuOther_PTrack;
+
+  // The full selection cut using only reco information.
+  extern const Cut kNuMuCC_FullSelection;
+}

--- a/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h
+++ b/sbnana/SBNAna/Cuts/NumuCutsIcarus202106.h
@@ -1,0 +1,130 @@
+// SBNAna includes.
+#include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
+
+// Custom includes.
+#include "TestVars.h"
+
+using namespace ana;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Define the cuts for the selection.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const Cut kIsNu = ( kTruthIndex >= 0.f );
+
+const Cut kIsCosmic = ( !kIsNu );
+
+const Cut kIsNuMuCC([](const caf::SRSliceProxy* slc) {
+    return ( kIsNu(slc) && slc->truth.iscc && ( slc->truth.pdg == 14 || slc->truth.pdg == -14 ) );
+  });
+
+const Cut kIsNuOther = ( kIsNu && !kIsNuMuCC );
+
+const Cut kCryo0([](const caf::SRSliceProxy* slc) {
+    return ( !std::isnan(slc->vertex.x) && slc->vertex.x < 0 );
+  });
+
+const Cut kTFiducial([](const caf::SRSliceProxy* slc) {
+    return ( !std::isnan(slc->truth.position.x) &&
+	     ( ( slc->truth.position.x < -71.1 - 25 && slc->truth.position.x > -369.33 + 25 ) ||
+	       ( slc->truth.position.x > 71.1 + 25 && slc->truth.position.x < 369.33 - 25 ) ) &&
+	     !std::isnan(slc->truth.position.y) &&
+	     ( slc->truth.position.y > -181.7 + 25 && slc->truth.position.y < 134.8 - 25 ) &&
+	     !std::isnan(slc->truth.position.z) &&
+	     ( slc->truth.position.z > -895.95 + 30 && slc->truth.position.z < 895.95 - 50 ) );
+  });
+
+const Cut kRFiducial([](const caf::SRSliceProxy* slc) {
+    return ( !std::isnan(slc->vertex.x) &&
+	     ( ( slc->vertex.x < -71.1 - 25 && slc->vertex.x > -369.33 + 25 ) ||
+	       ( slc->vertex.x > 71.1 + 25 && slc->vertex.x < 369.33 - 25 ) ) &&
+	     !std::isnan(slc->vertex.y) &&
+	     ( slc->vertex.y > -181.7 + 25 && slc->vertex.y < 134.8 - 25 ) &&
+	     !std::isnan(slc->vertex.z) &&
+	     ( slc->vertex.z > -895.95 + 30 && slc->vertex.z < 895.95 - 50 ) );
+  });
+
+const Cut kNotClearCosmic([](const caf::SRSliceProxy* slc) {
+    return !slc->is_clear_cosmic;
+  });
+
+const Cut kNuScore([](const caf::SRSliceProxy* slc) {
+    return ( !std::isnan(slc->nu_score) && slc->nu_score > 0.4 );
+  });
+
+const Cut kFMScore([](const caf::SRSliceProxy* slc) {
+    return ( !std::isnan(slc->fmatch.score) && slc->fmatch.score < 7.0 );
+  });
+
+const Cut kPTrack([](const caf::SRSliceProxy* slc) {
+    // The (dis)qualification of a slice is based upon the track level information.
+    float Atslc, Chi2Proton, Chi2Muon;
+    std::vector<unsigned int> Candidates;
+    bool AtSlice, Contained, MaybeMuonExiting, MaybeMuonContained, ProgCut(false);
+
+    for (auto const& trk : slc->reco.trk)
+    {
+      // First we calculate the distance of each track to the slice vertex.
+      Atslc = sqrt( pow( slc->vertex.x - trk.start.x, 2.0 ) +
+		    pow( slc->vertex.y - trk.start.y, 2.0 ) +
+		    pow( slc->vertex.z - trk.start.z, 2.0 ) );
+      // We require that the distance of the track from the slice is less than
+      // 10 cm and that the parent of the track has been marked as the primary.
+      AtSlice = ( Atslc < 10.0 && trk.parent_is_primary);
+      
+      if (trk.bestplane == 0)
+      {
+	Chi2Proton = trk.chi2pid0.chi2_proton;
+	Chi2Muon = trk.chi2pid0.chi2_muon;
+      }
+      else if (trk.bestplane == 1)
+      {
+	Chi2Proton = trk.chi2pid1.chi2_proton;
+	Chi2Muon = trk.chi2pid1.chi2_muon;
+      }
+      else
+      {
+	Chi2Proton = trk.chi2pid2.chi2_proton;
+	Chi2Muon = trk.chi2pid2.chi2_muon;
+      }
+
+      Contained = ( !std::isnan(trk.end.x) &&
+		    ( trk.end.x < -71.1 - 25 && trk.end.x > -369.33 + 25 ) &&//
+		      // || ( trk.end.x > 71.1 + 25 && trk.end.x < 369.33 - 25 ) ) &&
+		    !std::isnan(trk.end.y) &&
+		    ( trk.end.y > -181.7 + 25 && trk.end.y < 134.8 - 25 ) &&
+		    !std::isnan(trk.end.z) &&
+		    ( trk.end.z > -895.95 + 30 && trk.end.z < 895.95 - 50 ) );
+      MaybeMuonExiting = ( !Contained && trk.len > 100);
+      MaybeMuonContained = ( Contained && Chi2Proton > 60 && Chi2Muon < 30 && trk.len > 50 );
+      ProgCut = ProgCut || ( AtSlice && ( MaybeMuonExiting || MaybeMuonContained ) );
+    }
+    return ProgCut;
+  });
+
+const Cut kNuMuCC_Cryo0 = ( kIsNuMuCC && kCryo0 );
+const Cut kCosmic_Cryo0 = ( kIsCosmic && kCryo0 );
+const Cut kNuOther_Cryo0 = ( kIsNuOther && kCryo0 );
+
+const Cut kNuMuCC_TFiducial = ( kNuMuCC_Cryo0 && kTFiducial );
+const Cut kNuMuCC_RFiducial = ( kNuMuCC_Cryo0 && kRFiducial );
+const Cut kCosmic_TFiducial = ( kCosmic_Cryo0 && kTFiducial );
+const Cut kCosmic_RFiducial = ( kCosmic_Cryo0 && kRFiducial );
+const Cut kNuOther_TFiducial = ( kNuOther_Cryo0 && kTFiducial );
+const Cut kNuOther_RFiducial = ( kNuOther_Cryo0 && kRFiducial );
+
+const Cut kNuMuCC_ClearCos = ( kNuMuCC_TFiducial && kNotClearCosmic );
+const Cut kCosmic_ClearCos = ( kCosmic_RFiducial && kNotClearCosmic );
+const Cut kNuOther_ClearCos = ( kNuOther_TFiducial && kNotClearCosmic );
+
+const Cut kNuMuCC_NuScore = ( kNuMuCC_ClearCos && kNuScore );
+const Cut kCosmic_NuScore = ( kCosmic_ClearCos && kNuScore );
+const Cut kNuOther_NuScore = ( kNuOther_ClearCos && kNuScore );
+
+const Cut kNuMuCC_FMScore = ( kNuMuCC_NuScore && kFMScore );
+const Cut kCosmic_FMScore = ( kCosmic_NuScore && kFMScore );
+const Cut kNuOther_FMScore = ( kNuOther_NuScore && kFMScore );
+
+const Cut kNuMuCC_PTrack = ( kNuMuCC_FMScore && kPTrack );
+const Cut kCosmic_PTrack = ( kCosmic_FMScore && kPTrack );
+const Cut kNuOther_PTrack = ( kNuOther_FMScore && kPTrack );

--- a/sbnana/SBNAna/Vars/NumuVarsIcarus202106.cxx
+++ b/sbnana/SBNAna/Vars/NumuVarsIcarus202106.cxx
@@ -1,3 +1,4 @@
+#include <cmath>
 #include "sbnana/SBNAna/Vars/NumuVarsIcarus202106.h"
 #include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
 
@@ -15,4 +16,87 @@ namespace ana
       }
       return len;
     });
+
+  const Var kPTrackInd([](const caf::SRSliceProxy* slc) -> int {
+      // The (dis)qualification of a slice is based upon the track level information.
+      float Atslc, Chi2Proton, Chi2Muon, Longest(0);
+      bool AtSlice, Contained, MaybeMuonExiting, MaybeMuonContained;
+      int PTrackInd(-1);
+      for (std::size_t i(0); i < slc->reco.trk.size(); ++i)
+      {
+	auto const& trk = slc->reco.trk.at(i);
+	// First we calculate the distance of each track to the slice vertex.
+	Atslc = sqrt( pow( slc->vertex.x - trk.start.x, 2.0 ) +
+		      pow( slc->vertex.y - trk.start.y, 2.0 ) +
+		      pow( slc->vertex.z - trk.start.z, 2.0 ) );
+	// We require that the distance of the track from the slice is less than
+	// 10 cm and that the parent of the track has been marked as the primary.
+	AtSlice = ( Atslc < 10.0 && trk.parent_is_primary);
+	
+	if (trk.bestplane == 0)
+	{
+	  Chi2Proton = trk.chi2pid0.chi2_proton;
+	  Chi2Muon = trk.chi2pid0.chi2_muon;
+	}
+	else if (trk.bestplane == 1)
+	{
+	  Chi2Proton = trk.chi2pid1.chi2_proton;
+	  Chi2Muon = trk.chi2pid1.chi2_muon;
+	}
+	else
+	{
+	  Chi2Proton = trk.chi2pid2.chi2_proton;
+	  Chi2Muon = trk.chi2pid2.chi2_muon;
+	}
+
+	Contained = ( !isnan(trk.end.x) &&
+		      ( trk.end.x < -71.1 - 25 && trk.end.x > -369.33 + 25 ) &&
+		      !isnan(trk.end.y) &&
+		      ( trk.end.y > -181.7 + 25 && trk.end.y < 134.8 - 25 ) &&
+		      !isnan(trk.end.z) &&
+		      ( trk.end.z > -895.95 + 30 && trk.end.z < 895.95 - 50 ) );
+	MaybeMuonExiting = ( !Contained && trk.len > 100);
+	MaybeMuonContained = ( Contained && Chi2Proton > 60 && Chi2Muon < 30 && trk.len > 50 );
+	if ( AtSlice && ( MaybeMuonExiting || MaybeMuonContained ) && trk.len > Longest )
+	{
+	  Longest = trk.len;
+	  PTrackInd = i;
+	}
+      }
+      return PTrackInd;
+    });
+
+  const Var kRecoMuonP([](const caf::SRSliceProxy* slc) -> float {
+      float p(-5.f);
+      bool Contained(false);
+      
+      if ( kPTrackInd(slc) >= 0 )
+      {
+	auto const& trk = slc->reco.trk.at(kPTrackInd(slc));
+	Contained = ( !isnan(trk.end.x) &&
+		      ( trk.end.x < -71.1 - 25 && trk.end.x > -369.33 + 25 ) &&
+		      !isnan(trk.end.y) &&
+		      ( trk.end.y > -181.7 + 25 && trk.end.y < 134.8 - 25 ) &&
+		      !isnan(trk.end.z) &&
+		      ( trk.end.z > -895.95 + 30 && trk.end.z < 895.95 - 50 ) );
+	if(Contained) p = trk.rangeP.p_muon;
+	else p = trk.mcsP.fwdP_muon;
+      }
+      return p;
+    });
+
+  const Var kTrueMuonP([](const caf::SRSliceProxy* slc) -> float {
+      float p(-5.f);
+      
+      if ( kPTrackInd(slc) >= 0 )
+      {
+	auto const& trk = slc->reco.trk.at(kPTrackInd(slc));
+	p = sqrt( pow(trk.truth.p.genp.x, 2) + 
+		  pow(trk.truth.p.genp.y, 2) + 
+		  pow(trk.truth.p.genp.z, 2) );
+      }
+      return p;
+    });
+
+
 }

--- a/sbnana/SBNAna/Vars/NumuVarsIcarus202106.cxx
+++ b/sbnana/SBNAna/Vars/NumuVarsIcarus202106.cxx
@@ -1,0 +1,18 @@
+#include "sbnana/SBNAna/Vars/NumuVarsIcarus202106.h"
+#include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
+
+namespace ana
+{
+  const Var kTruthIndex = SIMPLEVAR(truth.index);
+  
+  const Var kPrimaryEnergy = SIMPLEVAR(truth.E);
+  
+  const Var kMuMaxTrack([](const caf::SRSliceProxy* slc) -> float {
+      float len(-5.f);
+      for (auto const& trk : slc->reco.trk)
+      {
+	if ( (trk.truth.p.pdg == 13 || trk.truth.p.pdg == -13) && trk.truth.p.length > len ) len = trk.truth.p.length;
+      }
+      return len;
+    });
+}

--- a/sbnana/SBNAna/Vars/NumuVarsIcarus202106.h
+++ b/sbnana/SBNAna/Vars/NumuVarsIcarus202106.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// SBNAna includes.
+#include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
+
+using namespace ana;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Define the variables for the selection.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const Var kTruthIndex = SIMPLEVAR(truth.index);
+
+const Var kPrimaryEnergy = SIMPLEVAR(truth.E);
+
+const Var kMuMaxTrack([](const caf::SRSliceProxy* slc) -> float {
+    float len(-5.f);
+    for (auto const& trk : slc->reco.trk)
+    {
+      if ( (trk.truth.p.pdg == 13 || trk.truth.p.pdg == -13) && trk.truth.p.length > len ) len = trk.truth.p.length;
+    }
+    return len;
+  });

--- a/sbnana/SBNAna/Vars/NumuVarsIcarus202106.h
+++ b/sbnana/SBNAna/Vars/NumuVarsIcarus202106.h
@@ -9,4 +9,10 @@ namespace ana
   extern const Var kPrimaryEnergy;
 
   extern const Var kMuMaxTrack;
+
+  extern const Var kPTrackInd;
+  
+  extern const Var kRecoMuonP;
+
+  extern const Var kTrueMuonP;
 }

--- a/sbnana/SBNAna/Vars/NumuVarsIcarus202106.h
+++ b/sbnana/SBNAna/Vars/NumuVarsIcarus202106.h
@@ -1,23 +1,12 @@
 #pragma once
 
-// SBNAna includes.
-#include "sbnana/CAFAna/StandardRecord/Proxy/SRProxy.h"
+#include "sbnana/CAFAna/Core/Var.h"
 
-using namespace ana;
+namespace ana
+{
+  extern const Var kTruthIndex;
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Define the variables for the selection.
-////////////////////////////////////////////////////////////////////////////////////////////////////
+  extern const Var kPrimaryEnergy;
 
-const Var kTruthIndex = SIMPLEVAR(truth.index);
-
-const Var kPrimaryEnergy = SIMPLEVAR(truth.E);
-
-const Var kMuMaxTrack([](const caf::SRSliceProxy* slc) -> float {
-    float len(-5.f);
-    for (auto const& trk : slc->reco.trk)
-    {
-      if ( (trk.truth.p.pdg == 13 || trk.truth.p.pdg == -13) && trk.truth.p.length > len ) len = trk.truth.p.length;
-    }
-    return len;
-  });
+  extern const Var kMuMaxTrack;
+}


### PR DESCRIPTION
This feature branch contains the cuts and vars for the ICARUS nu mu CC selection for the 2021 PAC. The .h and .cxx files are named to be specific to ICARUS and to this PAC so that it is clear that they are the frozen cuts for the ICARUS nu mu CC selection for the 2021 PAC. These build successfully and are able to reproduce the selection previously done in Python.

Additionally, Chris Backhouse has committed to this branch some of the scripts that he used to generate the sensitivity plots.