### PR TITLE
Update shower energy units

### DIFF
--- a/sbnana/SBNAna/Cuts/NueCuts.cxx
+++ b/sbnana/SBNAna/Cuts/NueCuts.cxx
@@ -29,7 +29,7 @@ namespace ana{
       if ( largestShwIdx==-1 )
         return false;
 
-      return (slc->reco.shw[largestShwIdx].bestplane_energy > 200. &&
+      return (slc->reco.shw[largestShwIdx].bestplane_energy > 0.2f &&
           slc->reco.shw[largestShwIdx].bestplane_dEdx < 3 &&
           slc->reco.shw[largestShwIdx].conversion_gap < 3 );
   }
@@ -42,7 +42,7 @@ namespace ana{
       if ( largestShwIdx==-1 )
         return false;
 
-      return (slc->reco.shw[largestShwIdx].bestplane_energy > 200.f );
+      return (slc->reco.shw[largestShwIdx].bestplane_energy > 0.2f );
     }
     );
 

--- a/sbnana/SBNAna/Vars/NueVars.cxx
+++ b/sbnana/SBNAna/Vars/NueVars.cxx
@@ -217,10 +217,10 @@ const Var kRecoShower_trackWidth(
     });
 
 const Var kRecoShowers_EnergyCut(
-    [](const caf::SRSliceProxy* slc) -> double {
+    [](const caf::SRSliceProxy* slc) -> unsigned {
       unsigned int counter(0);
       for (auto const& shw : slc->reco.shw) {
-        if (shw.bestplane_energy > 200)
+        if (shw.bestplane_energy > 0.2f)
           ++counter;
       }
       return counter;

--- a/sbnana/SBNAna/ananue/PAC2020/SBND/helper_eff_spill.h
+++ b/sbnana/SBNAna/ananue/PAC2020/SBND/helper_eff_spill.h
@@ -77,7 +77,6 @@ struct PlotDef {
 };
 
 const Binning kBDTBinning = Binning::Simple(40, 0, 1.0);
-const Binning kEnergyBinning = Binning::Simple(40, 0, 3000);
 const Binning kEnergyBinningGeV = Binning::Simple(30, 0, 3);
 const Binning kdEdxBinning = Binning::Simple(40, 0, 10);
 const Binning kGapBinning = Binning::Simple(20, 0, 10);

--- a/sbnana/SBNAna/ananue/PAC2020/SBND/helper_pur_slc_cumulative.h
+++ b/sbnana/SBNAna/ananue/PAC2020/SBND/helper_pur_slc_cumulative.h
@@ -28,7 +28,7 @@ const Binning kPdgBinning = Binning::Simple(5000, -2500, 2500);
 // // In this example, we are making the following Spectra
 std::vector<PlotDef> plots = {
   { "count", "", Binning::Simple(3, 0, 3), kCounting },
-  { "bestenergy", "Best plane energy (MeV)", kEnergyBinningGeV, kRecoShower_BestEnergy },
+  { "bestenergy", "Best plane energy (GeV)", kEnergyBinningGeV, kRecoShower_BestEnergy },
   { "conversion", "Conversion gap (cm)", kGapBinning, kRecoShower_ConversionGap },
   { "dedx", "dEdx (MeV/cm)", kdEdxBinning, kRecoShower_BestdEdx },
   { "slength", "Shower Length (cm)", kLengthBinning, kRecoShower_Length },

--- a/sbnana/SBNAna/ananue/PAC2020/SBND/helper_pur_slc_cumulative.h
+++ b/sbnana/SBNAna/ananue/PAC2020/SBND/helper_pur_slc_cumulative.h
@@ -14,7 +14,6 @@ struct PlotDef {
 };
 
 const Binning kBDTBinning = Binning::Simple(40, 0, 1.0);
-const Binning kEnergyBinning = Binning::Simple(40, 0, 3000);
 const Binning kEnergyBinningGeV = Binning::Simple(40, 0, 3);
 const Binning kdEdxBinning = Binning::Simple(40, 0, 10);
 const Binning kGapBinning = Binning::Simple(20, 0, 20);
@@ -29,7 +28,7 @@ const Binning kPdgBinning = Binning::Simple(5000, -2500, 2500);
 // // In this example, we are making the following Spectra
 std::vector<PlotDef> plots = {
   { "count", "", Binning::Simple(3, 0, 3), kCounting },
-  { "bestenergy", "Best plane energy (MeV)", kEnergyBinning, kRecoShower_BestEnergy },
+  { "bestenergy", "Best plane energy (MeV)", kEnergyBinningGeV, kRecoShower_BestEnergy },
   { "conversion", "Conversion gap (cm)", kGapBinning, kRecoShower_ConversionGap },
   { "dedx", "dEdx (MeV/cm)", kdEdxBinning, kRecoShower_BestdEdx },
   { "slength", "Shower Length (cm)", kLengthBinning, kRecoShower_Length },

--- a/sbnana/SBNAna/ananue/eventselection/helper_nuesel_icarus.h
+++ b/sbnana/SBNAna/ananue/eventselection/helper_nuesel_icarus.h
@@ -75,7 +75,7 @@ struct SelDefSpill
 };
 
 // Define all the variables and cuts first, including binnings
-const Binning kEnergyBinning    = Binning::Simple(40,0.,3000.); // to define
+const Binning kEnergyBinning    = Binning::Simple(40,0.,3.); // to define
 const Binning kDedxBinning      = Binning::Simple(40,0.,10); // to define
 const Binning kGapBinning       = Binning::Simple(40,0.,10);
 const Binning kDensityBinning   = Binning::Simple(50,0.,10);

--- a/sbnana/SBNAna/ananue/helper.h
+++ b/sbnana/SBNAna/ananue/helper.h
@@ -42,7 +42,7 @@ const Binning kTimeBinning      = Binning::Simple(70,0.,3500);
 // // In this example, we are making the following Spectra
 std::vector<PlotDef> plots = 
   {{"count", "", Binning::Simple(3,0,3), kCounting},
-   {"bestenergy", "Best plane energy (MeV)", kLowEnergyBinningGeV,	kRecoShower_BestEnergy},  
+   {"bestenergy", "Best plane energy (GeV)", kLowEnergyBinningGeV,	kRecoShower_BestEnergy},  
    {"conversion", "Conversion gap (cm)",     kGapBinning,       kRecoShower_ConversionGap},  
    {"density",    "Shower density (MeV/cm)", kDensityBinning,   kRecoShower_Density},
    {"energy",     "Energy (MeV)",            kNueEnergyBinning, kRecoShower_Energy},

--- a/sbnana/SBNAna/ananue/helper.h
+++ b/sbnana/SBNAna/ananue/helper.h
@@ -42,7 +42,7 @@ const Binning kTimeBinning      = Binning::Simple(70,0.,3500);
 // // In this example, we are making the following Spectra
 std::vector<PlotDef> plots = 
   {{"count", "", Binning::Simple(3,0,3), kCounting},
-   {"bestenergy", "Best plane energy (MeV)", kLowEnergyBinning,	kRecoShower_BestEnergy},  
+   {"bestenergy", "Best plane energy (MeV)", kLowEnergyBinningGeV,	kRecoShower_BestEnergy},  
    {"conversion", "Conversion gap (cm)",     kGapBinning,       kRecoShower_ConversionGap},  
    {"density",    "Shower density (MeV/cm)", kDensityBinning,   kRecoShower_Density},
    {"energy",     "Energy (MeV)",            kNueEnergyBinning, kRecoShower_Energy},


### PR DESCRIPTION
This updates the CAF cut values to account for the change in units for shower energy. This is a breaking change for the current set of official CAFs however, so it is probably best to leave this un-merged until closer to a new production. 