### PR TITLE
Add logic for FileReducer to still make sure it writes out rejected records if they contain POT information

### DIFF
--- a/sbnana/CAFAna/Core/FileReducer.h
+++ b/sbnana/CAFAna/Core/FileReducer.h
@@ -53,6 +53,9 @@ namespace ana
                         const std::set<std::string>& mask,
                         const std::vector<std::string>& fnames) const;
 
+    /// Strip all information out of this record and tag it as a husk
+    void Huskify(caf::StandardRecord* sr) const;
+
     std::string fOutfile;
     SpillCut*   fSpillCut;
     SliceCut*   fSliceCut;

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -137,6 +137,12 @@ namespace ana
       assert(tr);
     }
 
+    // We try to access this field for every record. It was only added to the
+    // files in late 2021, and we don't want to render all earlier files
+    // unusable at a stroke. This logic can safely be removed once all extant
+    // files have such a field (estimate mid-2022?)
+    const bool has_husk = tr->GetLeaf("rec.hdr.husk");
+
     const caf::CAFType type = caf::GetCAFType(dir, tr);
 
     long n;
@@ -149,6 +155,9 @@ namespace ana
 
     for(n = 0; n < Nentries; ++n){
       if(type != caf::kFlatMultiTree) tr->LoadTree(n); // for all single-tree modes
+
+      // If there is no husk field there is no concept of husk events
+      if(!has_husk) sr.hdr.husk = false;
 
       HandleRecord(&sr);
 
@@ -194,6 +203,10 @@ namespace ana
       // hdr.pot, I think it may be file-based in practice too.
       fNGenEvt += sr->hdr.ngenevt;
     }
+
+    // This record was only kept as a receptacle for exposure information. It
+    // shouldn't be included in any selected spectra.
+    if(sr->hdr.husk) return;
 
     // Do the spill-level spectra first. Keep this very simple because we
     // intend to change it.

--- a/sbnana/CAFAna/test/test_reducer.C
+++ b/sbnana/CAFAna/test/test_reducer.C
@@ -1,6 +1,6 @@
 #include "sbnana/CAFAna/Core/FileReducer.h"
 
-#include "SBNAna/Cuts/Cuts.h"
+#include "sbnana/SBNAna/Cuts/Cuts.h"
 
 using namespace ana;
 


### PR DESCRIPTION
...tag them as "husks" and make CAFAna skip those records.

Depends on https://github.com/SBNSoftware/sbnanaobj/pull/40 which adds the flag in question

This still needs to be tested. I am struggling a little because of the tortured git history of the SRBNBInfo object. Easiest thing I think is to get that part merged back into main.

- does the `has_husk` check work properly? On regular and FlatCAFs?
- does this work properly on MC?

Observations
- Are we counting number of spills properly in data, analogous to MC's `nGenEvent`? I think the BNB accounting gives us the mechanism to do that, but I don't think we actually propagate the info all the way through
- We have `first_in_file` and `first_in_subrun` flags at the moment.  I think they only support this use-case. Should we scrap them and just make the test be "pot field is non-empty"?
- If you apply a slice cut in FileReducer that removes all slices, the containing spills will still be kept, with the slice list emptied out. The only way to remove spills and get this husk state is with a spill cut. Should we add some kind of "drop zero-slice spills" option to FileReducer?