### PR TITLE
Update to srproxy v00.34

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -38,7 +38,7 @@ sbnanaobj        v09_17_06_04
 #SAM tools?
 ifdhc            v2_5_16
 # For CAFAna
-srproxy          v00.32
+srproxy          v00.34
 osclib           v00.17
 # flux syst histograms etc
 sbndata		 v01_03


### PR DESCRIPTION
This release fixes the miss-indexing issue that is the root cause of the pre-production proton PID problem

This is a partner to https://github.com/SBNSoftware/sbnanaobj/pull/57

No equivalent is needed on the develop branch, because develop sbnana gets its srproxy dependency via sbnanaobj