### PR TITLE
Update SBNWeightSysts to handle BNB flux systs

### DIFF
--- a/sbnana/CAFAna/Systs/SBNWeightSysts.cxx
+++ b/sbnana/CAFAna/Systs/SBNWeightSysts.cxx
@@ -241,19 +241,32 @@ namespace ana
     return ret;
   }
 
+  // -------------------------------------------------------------------------
+
+  std::vector<std::string> GetSBNBoosterFluxWeightNames()
+  {
+    // We can't ask the UniverseOracle about this, because it doesn't get
+    // properly configured until it's seen its first CAF file.
+    return {"expskin",
+            "horncurrent",
+            "nucleoninexsec",
+            "nucleonqexsec",
+            "nucleontotxsec",
+            "pioninexsec",
+            "pionqexsec",
+            "piontotxsec"};
+  }
+
   // --------------------------------------------------------------------------
-  /*
-  const std::vector<const ISyst*>& GetBoosterFluxWeightSysts()
+  
+  const std::vector<const ISyst*>& GetSBNBoosterFluxWeightSysts()
   {
     static std::vector<const ISyst*> ret;
-    if(ret.empty()){
-      const UniverseOracle& uo = UniverseOracle::Instance();
-      ret.reserve(uo.Systs().size());
-      for(const std::string& name: uo.Systs()){
-        if(name.find("genie") != std::string::npos) continue;
-        ret.push_back(new SBNWeightSyst(name));
-      }
-    }
+    if(!ret.empty()) return ret;
+
+    for(const std::string& name: GetSBNBoosterFluxWeightNames())
+      ret.push_back(new SBNWeightSyst(name));
+
     return ret;
   }
 
@@ -263,12 +276,12 @@ namespace ana
     static std::vector<const ISyst*> ret;
     if(ret.empty()){
       const std::vector<const ISyst*>& g = GetSBNGenieWeightSysts();
-      const std::vector<const ISyst*>& f = GetBoosterFluxWeightSysts();
+      const std::vector<const ISyst*>& f = GetSBNBoosterFluxWeightSysts();
       ret.reserve(g.size()+f.size());
       ret.insert(ret.end(), g.begin(), g.end());
       ret.insert(ret.end(), f.begin(), f.end());
     }
     return ret;
   }
-  */
+  
 }

--- a/sbnana/CAFAna/Systs/SBNWeightSysts.h
+++ b/sbnana/CAFAna/Systs/SBNWeightSysts.h
@@ -72,6 +72,6 @@ namespace ana
 
   const std::vector<const ISyst*>& GetSBNGenieWeightSysts();
 
-  //  const std::vector<const ISyst*>& GetSBNBoosterWeightSysts();
-  //  const std::vector<const ISyst*>& GetSBNWeightSysts(); // genie+flux
+  const std::vector<const ISyst*>& GetSBNBoosterFluxWeightSysts();
+  const std::vector<const ISyst*>& GetSBNWeightSysts(); // genie+flux
 }


### PR DESCRIPTION
Update sbnana/CAFAna/Systs/SBNWeightSysts.h and sbnana/CAFAna/Systs/SBNWeightSysts.cxx to handle BNB flux systs.

Flux hadron systematics (piplus, piminus, kplus, kminus, kzero) are still handled by BoosterFluxSysts.
This PR should handle 
  1: expskin
  2: horncurrent
  3: nucleoninexsec
  4: nucleonqexsec
  5: nucleontotxsec
  6: pioninexsec
  7: pionqexsec
  8: piontotxsec
  
Tested on ICARUS BNB nu+cosmics 2021C CAFs.