### PR TITLE
Energy scale systematics

### DIFF
--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -1,18 +1,19 @@
 #include "sbnana/CAFAna/Systs/EnergySysts.h"
+#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
 
 namespace ana {
 
   void EnergyScaleSyst::Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const
   {
     double scale = uncertainty * sigma;
-    auto baseline_cut = [detector = detector](double baseline){
-      auto all = (detector == EnergyScaleSystDetector::kAll);
-      auto nd = (detector == EnergyScaleSystDetector::kSBND && baseline < 120);
-      auto ub = (detector == EnergyScaleSystDetector::kMicroBooNE && baseline > 120 && baseline < 500);
-      auto fd = (detector == EnergyScaleSystDetector::kICARUS && baseline > 500);
+    auto detector_cut = [detector = detector](auto det){
+      bool all = (detector == EnergyScaleSystDetector::kAll);
+      bool nd = (detector == EnergyScaleSystDetector::kSBND && det == caf::kSBND);
+      bool ub = (detector == EnergyScaleSystDetector::kMicroBooNE && det == caf::kUNKNOWN);
+      bool fd = (detector == EnergyScaleSystDetector::kICARUS && det == caf::kICARUS);
       return all || nd || ub || fd;
     };
-    if(sr->truth.iscc && abs(sr->truth.pdg) == 14 && !isnan(sr->fake_reco.nuE) && baseline_cut(sr->truth.baseline)) {
+    if(sr->truth.iscc && abs(sr->truth.pdg) == 14 && !isnan(sr->fake_reco.nuE) && detector_cut(sr->truth.det)) {
       double particle_energy = 0.0;
       switch(part) {
       case EnergyScaleSystParticle::kMuon:

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -9,7 +9,7 @@ namespace ana {
     auto& det = sr->truth.det;
     bool all = (detector == EnergyScaleSystDetector::kAll);
     bool nd = (detector == EnergyScaleSystDetector::kSBND && det == caf::kSBND);
-    bool ub = (detector == EnergyScaleSystDetector::kMicroBooNE && det == caf::kUNKNOWN);
+    bool ub = (detector == EnergyScaleSystDetector::kMicroBooNE && det != caf::kSBND && det != caf::kICARUS);
     bool fd = (detector == EnergyScaleSystDetector::kICARUS && det == caf::kICARUS);
     bool detector_cut = all || nd || ub || fd;
     if(!sr->truth.iscc || abs(sr->truth.pdg) != 14 || isnan(sr->fake_reco.nuE) || !detector_cut) 
@@ -61,71 +61,71 @@ namespace ana {
    
   }
 
-   const EnergyScaleSyst kEnergyScaleMuon(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuon", "Correlated 2% scale systematic on E_{#mu}");
-   const EnergyScaleSyst kEnergyScaleMuonSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonSqrt", "Correlated 2% scale systematic on E_{#mu} * #sqrt{E_{#mu}}");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonInvSqrt", "Correlated 2% scale systematic on E_{#mu} / #sqrt{E_{#mu}}");
+   const EnergyScaleSyst kEnergyScaleMuon(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuon", "Correlated linear E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonSqrt", "Correlated sqrt E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonInvSqrt", "Correlated inv sqrt E_{#mu} scale");
 
-   const EnergyScaleSyst kEnergyScaleMuonND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonND", "Uncorrelated 2% scale systematic on E_{#mu} in SBND");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonSqrtND", "Uncorrelated 2% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in SBND");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonInvSqrtND", "Uncorrelated 2% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in SBND");
+   const EnergyScaleSyst kEnergyScaleMuonND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonND", "Uncorrelated SBND linear E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonSqrtND", "Uncorrelated SBND sqrt E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonInvSqrtND", "Uncorrelated SBND inv sqrt E_{#mu} scale");
 
-   const EnergyScaleSyst kEnergyScaleMuonUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonUB", "Uncorrelated 2% scale systematic on E_{#mu} in MicroBooNE");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonSqrtUB", "Uncorrelated 2% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in MicroBooNE");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonInvSqrtUB", "Uncorrelated 2% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleMuonUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonUB", "Uncorrelated MicroBooNE linear E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonSqrtUB", "Uncorrelated MicroBooNE sqrt E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonInvSqrtUB", "Uncorrelated MicroBooNE inv sqrt E_{#mu} scale");
 
-   const EnergyScaleSyst kEnergyScaleMuonFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonFD", "Uncorrelated 2% scale systematic on E_{#mu} in ICARUS");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonSqrtFD", "Uncorrelated 2% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in ICARUS");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonInvSqrtFD", "Uncorrelated 2% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleMuonFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonFD", "Uncorrelated ICARUS linear E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonSqrtFD", "Uncorrelated ICARUS sqrt E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonInvSqrtFD", "Uncorrelated ICARUS inv sqrt E_{#mu} scale");
 
-   const EnergyScaleSyst kEnergyScaleHadron(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadron", "Correlated 5% scale systematic on E_{had}");
-   const EnergyScaleSyst kEnergyScaleHadronSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronSqrt", "Correlated 5% scale systematic on E_{had} * #sqrt{E_{had}}");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronInvSqrt", "Correlated 5% scale systematic on E_{had} / #sqrt{E_{had}}");
+   const EnergyScaleSyst kEnergyScaleHadron(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadron", "Correlated linear E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronSqrt", "Correlated sqrt E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronInvSqrt", "Correlated inv sqrt E_{had} scale");
 
-   const EnergyScaleSyst kEnergyScaleHadronND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronND", "Uncorrelated 5% scale systematic on E_{had} in SBND");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronSqrtND", "Uncorrelated 5% scale systematic on E_{had} * #sqrt{E_{had}} in SBND");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronInvSqrtND", "Uncorrelated 5% scale systematic on E_{had} / #sqrt{E_{had}} in SBND");
+   const EnergyScaleSyst kEnergyScaleHadronND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronND", "Uncorrelated SBND linear E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronSqrtND", "Uncorrelated SBND sqrt E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronInvSqrtND", "Uncorrelated SBND inv sqrt E_{had} scale");
 
-   const EnergyScaleSyst kEnergyScaleHadronUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronUB", "Uncorrelated 5% scale systematic on E_{had} in MicroBooNE");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronSqrtUB", "Uncorrelated 5% scale systematic on E_{had} * #sqrt{E_{had}} in MicroBooNE");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronInvSqrtUB", "Uncorrelated 5% scale systematic on E_{had} / #sqrt{E_{had}} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleHadronUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronUB", "Uncorrelated MicroBooNE linear E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronSqrtUB", "Uncorrelated MicroBooNE sqrt E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronInvSqrtUB", "Uncorrelated MicroBooNE inv sqrt E_{had} scale");
 
-   const EnergyScaleSyst kEnergyScaleHadronFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronFD", "Uncorrelated 5% scale systematic on E_{had} in ICARUS");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronSqrtFD", "Uncorrelated 5% scale systematic on E_{had} * #sqrt{E_{had}} in ICARUS");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronInvSqrtFD", "Uncorrelated 5% scale systematic on E_{had} / #sqrt{E_{had}} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleHadronFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronFD", "Uncorrelated ICARUS linear E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronSqrtFD", "Uncorrelated ICARUS sqrt E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronInvSqrtFD", "Uncorrelated ICARUS inv sqrt E_{had} scale");
 
-   const EnergyScaleSyst kEnergyScaleMuonBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonBig", "Correlated 5% scale systematic on E_{#mu}");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonSqrtBig", "Correlated 5% scale systematic on E_{#mu} * #sqrt{E_{#mu}}");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonInvSqrtBig", "Correlated 5% scale systematic on E_{#mu} / #sqrt{E_{#mu}}");
+   const EnergyScaleSyst kEnergyScaleMuonBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonBig", "Correlated linear E_{#mu} scale ");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonSqrtBig", "Correlated sqrt E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonInvSqrtBig", "Correlated inv sqrt E_{#mu} scale");
 
-   const EnergyScaleSyst kEnergyScaleMuonNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonNDBig", "Uncorrelated 5% scale systematic on E_{#mu} in SBND");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonSqrtNDBig", "Uncorrelated 5% scale systematic on E_{#mu} * #sqrt_{E_{#mu}} in SBND");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonInvSqrtNDBig", "Uncorrelated 5% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in SBND");
+   const EnergyScaleSyst kEnergyScaleMuonNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonNDBig", "Uncorrelated SBND linear E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonSqrtNDBig", "Uncorrelated SBND sqrt E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonInvSqrtNDBig", "Uncorrelated SBND inv sqrt E_{#mu} scale");
 
-   const EnergyScaleSyst kEnergyScaleMuonUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonUBBig", "Uncorrelated 5% scale systematic on E_{#mu} in MicroBooNE");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonSqrtUBBig", "Uncorrelated 5% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in MicroBooNE");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonInvSqrtUBBig", "Uncorrelated 5% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleMuonUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonUBBig", "Uncorrelated MicroBooNE linear E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonSqrtUBBig", "Uncorrelated MicroBooNE sqrt E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonInvSqrtUBBig", "Uncorrelated MicroBooNE inv sqrt E_{#mu} scale");
 
-   const EnergyScaleSyst kEnergyScaleMuonFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonFDBig", "Uncorrelated 5% scale systematic on E_{#mu} in ICARUS");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonSqrtFDBig", "Uncorrelated 5% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in ICARUS");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonInvSqrtFDBig", "Uncorrelated 5% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleMuonFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonFDBig", "Uncorrelated ICARUS linear E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonSqrtFDBig", "Uncorrelated ICARUS sqrt E_{#mu} scale");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonInvSqrtFDBig", "Uncorrelated ICARUS inv sqrt E_{#mu} scale");
 
-   const EnergyScaleSyst kEnergyScaleHadronBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronBig", "Correlated 10% scale systematic on E_{had}");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronSqrtBig", "Correlated 10% scale systematic on E_{had} * #sqrt{E_{had}}");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronInvSqrtBig", "Correlated 10% scale systematic on E_{had} / #sqrt{E_{had}}");
+   const EnergyScaleSyst kEnergyScaleHadronBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronBig", "Correlated linear E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronSqrtBig", "Correlated sqrt E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronInvSqrtBig", "Correlated inv sqrt E_{had} scale");
 
-   const EnergyScaleSyst kEnergyScaleHadronNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronNDBig", "Uncorrelated 10% scale systematic on E_{had} in SBND");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronSqrtNDBig", "Uncorrelated 10% scale systematic on E_{had} * #sqrt{E_{had}} in SBND");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronInvSqrtNDBig", "Uncorrelated 10% scale systematic on E_{had} / #sqrt{E_{had}} in SBND");
+   const EnergyScaleSyst kEnergyScaleHadronNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronNDBig", "Uncorrelated SBND linear E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronSqrtNDBig", "Uncorrelated SBND sqrt E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronInvSqrtNDBig", "Uncorrelated SBND inv sqrt E_{had} scale");
 
-   const EnergyScaleSyst kEnergyScaleHadronUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronUBBig", "Uncorrelated 10% scale systematic on E_{had} in MicroBooNE");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronSqrtUBBig", "Uncorrelated 10% scale systematic on E_{had} * #sqrt{E_had}} in MicroBooNE");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronInvSqrtUBBig", "Uncorrelated 10% scale systematic on E_{had} / #sqrt{E_{had}} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleHadronUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronUBBig", "Uncorrelated MicroBooNE linear E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronSqrtUBBig", "Uncorrelated MicroBooNE sqrt E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronInvSqrtUBBig", "Uncorrelated MicroBooNE inv sqrt E_{had} scale");
 
-   const EnergyScaleSyst kEnergyScaleHadronFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronFDBig", "Uncorrelated 10% scale systematic on E_{had} in ICARUS");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronSqrtFDBig", "Uncorrelated 10% scale systematic on E_{had} * #sqrt{E_{had}} in ICARUS");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronInvSqrtFDBig", "Uncorrelated 10% scale systematic on E_{had} / #sqrt{E_{had}} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleHadronFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronFDBig", "Uncorrelated ICARUS linear E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronSqrtFDBig", "Uncorrelated ICARUS sqrt E_{had} scale");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronInvSqrtFDBig", "Uncorrelated ICARUS inv sqrt E_{had} scale");
 
-  std::vector<const EnergyScaleSyst*> GetEnergySysts() {
+  std::vector<const ISyst*> GetEnergySysts() {
     // MicroBooNE, ChargedHadron, Neutron, and EM systs
     // not being used right now
     return {&kEnergyScaleMuon,
@@ -182,7 +182,7 @@ namespace ana {
             &kEnergyScaleHadronInvSqrtFD};
   }
 
-  std::vector<const EnergyScaleSyst*> GetBigEnergySysts() {
+  std::vector<const ISyst*> GetBigEnergySysts() {
     return {&kEnergyScaleMuonBig,
             &kEnergyScaleMuonSqrtBig,
             &kEnergyScaleMuonInvSqrtBig,

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -60,69 +60,69 @@ namespace ana {
     }
   }
 
-   const EnergyScaleSyst kEnergyScaleMuon(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuon");
-   const EnergyScaleSyst kEnergyScaleMuonSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonSqrt");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonInvSqrt");
+   const EnergyScaleSyst kEnergyScaleMuon(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuon", "Correlated 2% scale systematic on E_{#mu}");
+   const EnergyScaleSyst kEnergyScaleMuonSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonSqrt", "Correlated 2% scale systematic on E_{#mu} * #sqrt{E_{#mu}}");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonInvSqrt", "Correlated 2% scale systematic on E_{#mu} / #sqrt{E_{#mu}}");
 
-   const EnergyScaleSyst kEnergyScaleMuonND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonND");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonSqrtND");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonInvSqrtND");
+   const EnergyScaleSyst kEnergyScaleMuonND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonND", "Uncorrelated 2% scale systematic on E_{#mu} in SBND");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonSqrtND", "Uncorrelated 2% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in SBND");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonInvSqrtND", "Uncorrelated 2% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in SBND");
 
-   const EnergyScaleSyst kEnergyScaleMuonUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonUB");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonSqrtUB");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonInvSqrtUB");
+   const EnergyScaleSyst kEnergyScaleMuonUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonUB", "Uncorrelated 2% scale systematic on E_{#mu} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonSqrtUB", "Uncorrelated 2% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonInvSqrtUB", "Uncorrelated 2% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in MicroBooNE");
 
-   const EnergyScaleSyst kEnergyScaleMuonFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonFD");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonSqrtFD");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonInvSqrtFD");
+   const EnergyScaleSyst kEnergyScaleMuonFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonFD", "Uncorrelated 2% scale systematic on E_{#mu} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonSqrtFD", "Uncorrelated 2% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonInvSqrtFD", "Uncorrelated 2% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in ICARUS");
 
-   const EnergyScaleSyst kEnergyScaleHadron(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadron");
-   const EnergyScaleSyst kEnergyScaleHadronSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronSqrt");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronInvSqrt");
+   const EnergyScaleSyst kEnergyScaleHadron(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadron", "Correlated 5% scale systematic on E_{had}");
+   const EnergyScaleSyst kEnergyScaleHadronSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronSqrt", "Correlated 5% scale systematic on E_{had} * #sqrt{E_{had}}");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronInvSqrt", "Correlated 5% scale systematic on E_{had} / #sqrt{E_{had}}");
 
-   const EnergyScaleSyst kEnergyScaleHadronND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronND");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronSqrtND");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronInvSqrtND");
+   const EnergyScaleSyst kEnergyScaleHadronND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronND", "Uncorrelated 5% scale systematic on E_{had} in SBND");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronSqrtND", "Uncorrelated 5% scale systematic on E_{had} * #sqrt{E_{had}} in SBND");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronInvSqrtND", "Uncorrelated 5% scale systematic on E_{had} / #sqrt{E_{had}} in SBND");
 
-   const EnergyScaleSyst kEnergyScaleHadronUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronUB");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronSqrtUB");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronInvSqrtUB");
+   const EnergyScaleSyst kEnergyScaleHadronUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronUB", "Uncorrelated 5% scale systematic on E_{had} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronSqrtUB", "Uncorrelated 5% scale systematic on E_{had} * #sqrt{E_{had}} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronInvSqrtUB", "Uncorrelated 5% scale systematic on E_{had} / #sqrt{E_{had}} in MicroBooNE");
 
-   const EnergyScaleSyst kEnergyScaleHadronFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronFD");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronSqrtFD");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronInvSqrtFD");
+   const EnergyScaleSyst kEnergyScaleHadronFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronFD", "Uncorrelated 5% scale systematic on E_{had} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronSqrtFD", "Uncorrelated 5% scale systematic on E_{had} * #sqrt{E_{had}} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronInvSqrtFD", "Uncorrelated 5% scale systematic on E_{had} / #sqrt{E_{had}} in ICARUS");
 
-   const EnergyScaleSyst kEnergyScaleMuonBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonBig");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonSqrtBig");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonInvSqrtBig");
+   const EnergyScaleSyst kEnergyScaleMuonBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonBig", "Correlated 5% scale systematic on E_{#mu}");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonSqrtBig", "Correlated 5% scale systematic on E_{#mu} * #sqrt{E_{#mu}}");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonInvSqrtBig", "Correlated 5% scale systematic on E_{#mu} / #sqrt{E_{#mu}}");
 
-   const EnergyScaleSyst kEnergyScaleMuonNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonNDBig");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonSqrtNDBig");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonInvSqrtNDBig");
+   const EnergyScaleSyst kEnergyScaleMuonNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonNDBig", "Uncorrelated 5% scale systematic on E_{#mu} in SBND");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonSqrtNDBig", "Uncorrelated 5% scale systematic on E_{#mu} * #sqrt_{E_{#mu}} in SBND");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonInvSqrtNDBig", "Uncorrelated 5% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in SBND");
 
-   const EnergyScaleSyst kEnergyScaleMuonUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonUBBig");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonSqrtUBBig");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonInvSqrtUBBig");
+   const EnergyScaleSyst kEnergyScaleMuonUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonUBBig", "Uncorrelated 5% scale systematic on E_{#mu} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonSqrtUBBig", "Uncorrelated 5% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonInvSqrtUBBig", "Uncorrelated 5% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in MicroBooNE");
 
-   const EnergyScaleSyst kEnergyScaleMuonFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonFDBig");
-   const EnergyScaleSyst kEnergyScaleMuonSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonSqrtFDBig");
-   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonInvSqrtFDBig");
+   const EnergyScaleSyst kEnergyScaleMuonFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonFDBig", "Uncorrelated 5% scale systematic on E_{#mu} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonSqrtFDBig", "Uncorrelated 5% scale systematic on E_{#mu} * #sqrt{E_{#mu}} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonInvSqrtFDBig", "Uncorrelated 5% scale systematic on E_{#mu} / #sqrt{E_{#mu}} in ICARUS");
 
-   const EnergyScaleSyst kEnergyScaleHadronBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronBig");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronSqrtBig");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronInvSqrtBig");
+   const EnergyScaleSyst kEnergyScaleHadronBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronBig", "Correlated 10% scale systematic on E_{had}");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronSqrtBig", "Correlated 10% scale systematic on E_{had} * #sqrt{E_{had}}");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronInvSqrtBig", "Correlated 10% scale systematic on E_{had} / #sqrt{E_{had}}");
 
-   const EnergyScaleSyst kEnergyScaleHadronNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronNDBig");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronSqrtNDBig");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronInvSqrtNDBig");
+   const EnergyScaleSyst kEnergyScaleHadronNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronNDBig", "Uncorrelated 10% scale systematic on E_{had} in SBND");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronSqrtNDBig", "Uncorrelated 10% scale systematic on E_{had} * #sqrt{E_{had}} in SBND");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronInvSqrtNDBig", "Uncorrelated 10% scale systematic on E_{had} / #sqrt{E_{had}} in SBND");
 
-   const EnergyScaleSyst kEnergyScaleHadronUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronUBBig");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronSqrtUBBig");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronInvSqrtUBBig");
+   const EnergyScaleSyst kEnergyScaleHadronUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronUBBig", "Uncorrelated 10% scale systematic on E_{had} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronSqrtUBBig", "Uncorrelated 10% scale systematic on E_{had} * #sqrt{E_had}} in MicroBooNE");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronInvSqrtUBBig", "Uncorrelated 10% scale systematic on E_{had} / #sqrt{E_{had}} in MicroBooNE");
 
-   const EnergyScaleSyst kEnergyScaleHadronFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronFDBig");
-   const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronSqrtFDBig");
-   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronInvSqrtFDBig");
+   const EnergyScaleSyst kEnergyScaleHadronFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronFDBig", "Uncorrelated 10% scale systematic on E_{had} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronSqrtFDBig", "Uncorrelated 10% scale systematic on E_{had} * #sqrt{E_{had}} in ICARUS");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronInvSqrtFDBig", "Uncorrelated 10% scale systematic on E_{had} / #sqrt{E_{had}} in ICARUS");
 
   EnergySystVector GetEnergySysts() {
     // MicroBooNE, ChargedHadron, Neutron, and EM systs

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -20,29 +20,29 @@ namespace ana {
         particle_energy += sr->fake_reco.lepton.ke;
         break;
       case EnergyScaleSystParticle::kHadron:
-        for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
-          particle_energy += sr->fake_reco.hadrons[i].ke;
+        for(const auto& hadron: sr->fake_reco.hadrons) {
+          particle_energy += hadron.ke;
         }
         break;
       case EnergyScaleSystParticle::kNeutron:
-        for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
-          if(sr->fake_reco.hadrons[i].pid == 2112) {
-            particle_energy += sr->fake_reco.hadrons[i].ke;
+        for(const auto& hadron: sr->fake_reco.hadrons) {
+          if(hadron.pid == 2112) {
+            particle_energy += hadron.ke;
           }
         }
         break;
       case EnergyScaleSystParticle::kEM:
-        for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
-          if(sr->fake_reco.hadrons[i].pid == 111) {
-            particle_energy += sr->fake_reco.hadrons[i].ke;
+        for(const auto& hadron: sr->fake_reco.hadrons) {
+          if(hadron.pid == 111) {
+            particle_energy += hadron.ke;
           }
         }
         break;
      case EnergyScaleSystParticle::kChargedHadron:
-        for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
-          auto pid = sr->fake_reco.hadrons[i].pid;
+        for(const auto& hadron: sr->fake_reco.hadrons) {
+          auto pid = hadron.pid;
           if(pid == 2212 || abs(pid) == 211) {
-            particle_energy += sr->fake_reco.hadrons[i].ke;
+            particle_energy += hadron.ke;
           }
         }
         break;

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -125,94 +125,87 @@ namespace ana {
    const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronSqrtFDBig", "Uncorrelated 10% scale systematic on E_{had} * #sqrt{E_{had}} in ICARUS");
    const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronInvSqrtFDBig", "Uncorrelated 10% scale systematic on E_{had} / #sqrt{E_{had}} in ICARUS");
 
-  EnergySystVector GetEnergySysts() {
+  std::vector<const EnergyScaleSyst*> GetEnergySysts() {
     // MicroBooNE, ChargedHadron, Neutron, and EM systs
     // not being used right now
-    EnergySystVector vec;
-    vec.push_back(&kEnergyScaleMuon);
-    vec.push_back(&kEnergyScaleMuonSqrt);
-    vec.push_back(&kEnergyScaleMuonInvSqrt);
-    vec.push_back(&kEnergyScaleMuonND);
-    vec.push_back(&kEnergyScaleMuonSqrtND);
-    vec.push_back(&kEnergyScaleMuonInvSqrtND);
-    //vec.push_back(&kEnergyScaleMuonUB);
-    //vec.push_back(&kEnergyScaleMuonSqrtUB);
-    //vec.push_back(&kEnergyScaleMuonInvSqrtUB);
-    vec.push_back(&kEnergyScaleMuonFD);
-    vec.push_back(&kEnergyScaleMuonSqrtFD);
-    vec.push_back(&kEnergyScaleMuonInvSqrtFD);
-    vec.push_back(&kEnergyScaleHadron);
-    //vec.push_back(&kEnergyScaleChargedHadron);
-    //vec.push_back(&kEnergyScaleEM);
-    //vec.push_back(&kEnergyScaleNeutron);
-    vec.push_back(&kEnergyScaleHadronSqrt);
-    //vec.push_back(&kEnergyScaleEMSqrt);
-    //vec.push_back(&kEnergyScaleNeutronSqrt);
-    vec.push_back(&kEnergyScaleHadronInvSqrt);
-    //vec.push_back(&kEnergyScaleEMInvSqrt);
-    //vec.push_back(&kEnergyScaleNeutronInvSqrt);
-    vec.push_back(&kEnergyScaleHadronND);
-    //vec.push_back(&kEnergyScaleChargedHadronND);
-    //vec.push_back(&kEnergyScaleEMND);
-    //vec.push_back(&kEnergyScaleNeutronND);
-    vec.push_back(&kEnergyScaleHadronSqrtND);
-    //vec.push_back(&kEnergyScaleEMSqrtND);
-    //vec.push_back(&kEnergyScaleNeutronSqrtND);
-    vec.push_back(&kEnergyScaleHadronInvSqrtND);
-    //vec.push_back(&kEnergyScaleEMInvSqrtND);
-    //vec.push_back(&kEnergyScaleNeutronInvSqrtND);
-    //vec.push_back(&kEnergyScaleHadronUB);
-    //vec.push_back(&kEnergyScaleChargedHadronUB);
-    //vec.push_back(&kEnergyScaleEMUB);
-    //vec.push_back(&kEnergyScaleNeutronUB);
-    //vec.push_back(&kEnergyScaleHadronSqrtUB);
-    //vec.push_back(&kEnergyScaleEMSqrtUB);
-    //vec.push_back(&kEnergyScaleNeutronSqrtUB);
-    //vec.push_back(&kEnergyScaleHadronInvSqrtUB);
-    //vec.push_back(&kEnergyScaleEMInvSqrtUB);
-    //vec.push_back(&kEnergyScaleNeutronInvSqrtUB);
-    vec.push_back(&kEnergyScaleHadronFD);
-    //vec.push_back(&kEnergyScaleChargedHadronFD);
-    //vec.push_back(&kEnergyScaleEMFD);
-    //vec.push_back(&kEnergyScaleNeutronFD);
-    vec.push_back(&kEnergyScaleHadronSqrtFD);
-    //vec.push_back(&kEnergyScaleEMSqrtFD);
-    //vec.push_back(&kEnergyScaleNeutronSqrtFD);
-    vec.push_back(&kEnergyScaleHadronInvSqrtFD);
-    //vec.push_back(&kEnergyScaleEMInvSqrtFD);
-    //vec.push_back(&kEnergyScaleNeutronInvSqrtFD);
-
-    return vec;
+    return {&kEnergyScaleMuon,
+            &kEnergyScaleMuonSqrt,
+            &kEnergyScaleMuonInvSqrt,
+            &kEnergyScaleMuonND,
+            &kEnergyScaleMuonSqrtND,
+            &kEnergyScaleMuonInvSqrtND,
+            //&kEnergyScaleMuonUB,
+            //&kEnergyScaleMuonSqrtUB,
+            //&kEnergyScaleMuonInvSqrtUB,
+            &kEnergyScaleMuonFD,
+            &kEnergyScaleMuonSqrtFD,
+            &kEnergyScaleMuonInvSqrtFD,
+            &kEnergyScaleHadron,
+            //&kEnergyScaleChargedHadron,
+            //&kEnergyScaleEM,
+            //&kEnergyScaleNeutron,
+            &kEnergyScaleHadronSqrt,
+            //&kEnergyScaleEMSqrt,
+            //&kEnergyScaleNeutronSqrt,
+            &kEnergyScaleHadronInvSqrt,
+            //&kEnergyScaleEMInvSqrt,
+            //&kEnergyScaleNeutronInvSqrt,
+            &kEnergyScaleHadronND,
+            //&kEnergyScaleChargedHadronND,
+            //&kEnergyScaleEMND,
+            //&kEnergyScaleNeutronND,
+            &kEnergyScaleHadronSqrtND,
+            //&kEnergyScaleEMSqrtND,
+            //&kEnergyScaleNeutronSqrtND,
+            &kEnergyScaleHadronInvSqrtND,
+            //&kEnergyScaleEMInvSqrtND,
+            //&kEnergyScaleNeutronInvSqrtND,
+            //&kEnergyScaleHadronUB,
+            //&kEnergyScaleChargedHadronUB,
+            //&kEnergyScaleEMUB,
+            //&kEnergyScaleNeutronUB,
+            //&kEnergyScaleHadronSqrtUB,
+            //&kEnergyScaleEMSqrtUB,
+            //&kEnergyScaleNeutronSqrtUB,
+            //&kEnergyScaleHadronInvSqrtUB,
+            //&kEnergyScaleEMInvSqrtUB,
+            //&kEnergyScaleNeutronInvSqrtUB,
+            &kEnergyScaleHadronFD,
+            //&kEnergyScaleChargedHadronFD,
+            //&kEnergyScaleEMFD,
+            //&kEnergyScaleNeutronFD,
+            &kEnergyScaleHadronSqrtFD,
+            //&kEnergyScaleEMSqrtFD,
+            //&kEnergyScaleNeutronSqrtFD,
+            //&kEnergyScaleEMInvSqrtFD,
+            //&kEnergyScaleNeutronInvSqrtFD,
+            &kEnergyScaleHadronInvSqrtFD};
   }
 
-  EnergySystVector GetBigEnergySysts() {
-
-    EnergySystVector vec;
-    vec.push_back(&kEnergyScaleMuonBig);
-    vec.push_back(&kEnergyScaleMuonSqrtBig);
-    vec.push_back(&kEnergyScaleMuonInvSqrtBig);
-    vec.push_back(&kEnergyScaleMuonNDBig);
-    vec.push_back(&kEnergyScaleMuonSqrtNDBig);
-    vec.push_back(&kEnergyScaleMuonInvSqrtNDBig);
-    //vec.push_back(&kEnergyScaleMuonUBBig);
-    //vec.push_back(&kEnergyScaleMuonSqrtUBBig);
-    //vec.push_back(&kEnergyScaleMuonInvSqrtUBBig);
-    vec.push_back(&kEnergyScaleMuonFDBig);
-    vec.push_back(&kEnergyScaleMuonSqrtFDBig);
-    vec.push_back(&kEnergyScaleMuonInvSqrtFDBig);
-    vec.push_back(&kEnergyScaleHadronBig);
-    vec.push_back(&kEnergyScaleHadronSqrtBig);
-    vec.push_back(&kEnergyScaleHadronInvSqrtBig);
-    vec.push_back(&kEnergyScaleHadronNDBig);
-    vec.push_back(&kEnergyScaleHadronSqrtNDBig);
-    vec.push_back(&kEnergyScaleHadronInvSqrtNDBig);
-    //vec.push_back(&kEnergyScaleHadronUBBig);
-    //vec.push_back(&kEnergyScaleHadronSqrtUBBig);
-    //vec.push_back(&kEnergyScaleHadronInvSqrtUBBig);
-    vec.push_back(&kEnergyScaleHadronFDBig);
-    vec.push_back(&kEnergyScaleHadronSqrtFDBig);
-    vec.push_back(&kEnergyScaleHadronInvSqrtFDBig);
-
-    return vec;
+  std::vector<const EnergyScaleSyst*> GetBigEnergySysts() {
+    return {&kEnergyScaleMuonBig,
+            &kEnergyScaleMuonSqrtBig,
+            &kEnergyScaleMuonInvSqrtBig,
+            &kEnergyScaleMuonNDBig,
+            &kEnergyScaleMuonSqrtNDBig,
+            &kEnergyScaleMuonInvSqrtNDBig,
+            //&kEnergyScaleMuonUBBig,
+            //&kEnergyScaleMuonSqrtUBBig,
+            //&kEnergyScaleMuonInvSqrtUBBig,
+            &kEnergyScaleMuonFDBig,
+            &kEnergyScaleMuonSqrtFDBig,
+            &kEnergyScaleMuonInvSqrtFDBig,
+            &kEnergyScaleHadronBig,
+            &kEnergyScaleHadronSqrtBig,
+            &kEnergyScaleHadronInvSqrtBig,
+            &kEnergyScaleHadronNDBig,
+            &kEnergyScaleHadronSqrtNDBig,
+            &kEnergyScaleHadronInvSqrtNDBig,
+            //&kEnergyScaleHadronUBBig,
+            //&kEnergyScaleHadronSqrtUBBig,
+            //&kEnergyScaleHadronInvSqrtUBBig,
+            &kEnergyScaleHadronFDBig,
+            &kEnergyScaleHadronSqrtFDBig,
+            &kEnergyScaleHadronInvSqrtFDBig};
   }
 } // namespace ana

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -1,0 +1,206 @@
+#include "sbnana/CAFAna/Systs/EnergySysts.h"
+
+namespace ana {
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuon(0.02, "EnergyScaleMuon");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonSqrt(0.02, "EnergyScaleMuonSqrt");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonInvSqrt(0.02, "EnergyScaleMuonInvSqrt");
+
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonND(0.02, "EnergyScaleMuonND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtND(0.02, "EnergyScaleMuonSqrtND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtND(0.02, "EnergyScaleMuonInvSqrtND");
+
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonUB(0.02, "EnergyScaleMuonUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtUB(0.02, "EnergyScaleMuonSqrtUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtUB(0.02, "EnergyScaleMuonInvSqrtUB");
+
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonFD(0.02, "EnergyScaleMuonFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtFD(0.02, "EnergyScaleMuonSqrtFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtFD(0.02, "EnergyScaleMuonInvSqrtFD");
+
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadron(0.05, "EnergyScaleHadron");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronSqrt(0.05, "EnergyScaleHadronSqrt");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronInvSqrt(0.05, "EnergyScaleHadronInvSqrt");
+
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronND(0.05, "EnergyScaleHadronND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtND(0.05, "EnergyScaleHadronSqrtND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtND(0.05, "EnergyScaleHadronInvSqrtND");
+
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronUB(0.05, "EnergyScaleHadronUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtUB(0.05, "EnergyScaleHadronSqrtUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtUB(0.05, "EnergyScaleHadronInvSqrtUB");
+
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronFD(0.05, "EnergyScaleHadronFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtFD(0.05, "EnergyScaleHadronSqrtFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtFD(0.05, "EnergyScaleHadronInvSqrtFD");
+
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonBig(0.05, "EnergyScaleMuonBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonSqrtBig(0.05, "EnergyScaleMuonSqrtBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonInvSqrtBig(0.05, "EnergyScaleMuonInvSqrtBig");
+
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonNDBig(0.05, "EnergyScaleMuonNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtNDBig(0.05, "EnergyScaleMuonSqrtNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtNDBig(0.05, "EnergyScaleMuonInvSqrtNDBig");
+
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonUBBig(0.05, "EnergyScaleMuonUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtUBBig(0.05, "EnergyScaleMuonSqrtUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtUBBig(0.05, "EnergyScaleMuonInvSqrtUBBig");
+
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonFDBig(0.05, "EnergyScaleMuonFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtFDBig(0.05, "EnergyScaleMuonSqrtFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtFDBig(0.05, "EnergyScaleMuonInvSqrtFDBig");
+
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronBig(0.10, "EnergyScaleHadronBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronSqrtBig(0.10, "EnergyScaleHadronSqrtBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronInvSqrtBig(0.10, "EnergyScaleHadronInvSqrtBig");
+
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronNDBig(0.10, "EnergyScaleHadronNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtNDBig(0.10, "EnergyScaleHadronSqrtNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtNDBig(0.10, "EnergyScaleHadronInvSqrtNDBig");
+
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronUBBig(0.10, "EnergyScaleHadronUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtUBBig(0.10, "EnergyScaleHadronSqrtUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtUBBig(0.10, "EnergyScaleHadronInvSqrtUBBig");
+
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronFDBig(0.10, "EnergyScaleHadronFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtFDBig(0.10, "EnergyScaleHadronSqrtFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtFDBig(0.10, "EnergyScaleHadronInvSqrtFDBig");
+
+  EnergySystVector GetEnergySysts() {
+    // MicroBooNE, ChargedHadron, Neutron, and EM systs
+    // not being used right now
+    EnergySystVector vec;
+    vec.push_back(&kEnergyScaleMuon);
+    vec.push_back(&kEnergyScaleMuonSqrt);
+    vec.push_back(&kEnergyScaleMuonInvSqrt);
+    vec.push_back(&kEnergyScaleMuonND);
+    vec.push_back(&kEnergyScaleMuonSqrtND);
+    vec.push_back(&kEnergyScaleMuonInvSqrtND);
+    //vec.push_back(&kEnergyScaleMuonUB);
+    //vec.push_back(&kEnergyScaleMuonSqrtUB);
+    //vec.push_back(&kEnergyScaleMuonInvSqrtUB);
+    vec.push_back(&kEnergyScaleMuonFD);
+    vec.push_back(&kEnergyScaleMuonSqrtFD);
+    vec.push_back(&kEnergyScaleMuonInvSqrtFD);
+    vec.push_back(&kEnergyScaleHadron);
+    //vec.push_back(&kEnergyScaleChargedHadron);
+    //vec.push_back(&kEnergyScaleEM);
+    //vec.push_back(&kEnergyScaleNeutron);
+    vec.push_back(&kEnergyScaleHadronSqrt);
+    //vec.push_back(&kEnergyScaleEMSqrt);
+    //vec.push_back(&kEnergyScaleNeutronSqrt);
+    vec.push_back(&kEnergyScaleHadronInvSqrt);
+    //vec.push_back(&kEnergyScaleEMInvSqrt);
+    //vec.push_back(&kEnergyScaleNeutronInvSqrt);
+    vec.push_back(&kEnergyScaleHadronND);
+    //vec.push_back(&kEnergyScaleChargedHadronND);
+    //vec.push_back(&kEnergyScaleEMND);
+    //vec.push_back(&kEnergyScaleNeutronND);
+    vec.push_back(&kEnergyScaleHadronSqrtND);
+    //vec.push_back(&kEnergyScaleEMSqrtND);
+    //vec.push_back(&kEnergyScaleNeutronSqrtND);
+    vec.push_back(&kEnergyScaleHadronInvSqrtND);
+    //vec.push_back(&kEnergyScaleEMInvSqrtND);
+    //vec.push_back(&kEnergyScaleNeutronInvSqrtND);
+    //vec.push_back(&kEnergyScaleHadronUB);
+    //vec.push_back(&kEnergyScaleChargedHadronUB);
+    //vec.push_back(&kEnergyScaleEMUB);
+    //vec.push_back(&kEnergyScaleNeutronUB);
+    //vec.push_back(&kEnergyScaleHadronSqrtUB);
+    //vec.push_back(&kEnergyScaleEMSqrtUB);
+    //vec.push_back(&kEnergyScaleNeutronSqrtUB);
+    //vec.push_back(&kEnergyScaleHadronInvSqrtUB);
+    //vec.push_back(&kEnergyScaleEMInvSqrtUB);
+    //vec.push_back(&kEnergyScaleNeutronInvSqrtUB);
+    vec.push_back(&kEnergyScaleHadronFD);
+    //vec.push_back(&kEnergyScaleChargedHadronFD);
+    //vec.push_back(&kEnergyScaleEMFD);
+    //vec.push_back(&kEnergyScaleNeutronFD);
+    vec.push_back(&kEnergyScaleHadronSqrtFD);
+    //vec.push_back(&kEnergyScaleEMSqrtFD);
+    //vec.push_back(&kEnergyScaleNeutronSqrtFD);
+    vec.push_back(&kEnergyScaleHadronInvSqrtFD);
+    //vec.push_back(&kEnergyScaleEMInvSqrtFD);
+    //vec.push_back(&kEnergyScaleNeutronInvSqrtFD);
+
+    return vec;
+  }
+
+  EnergySystVector GetBigEnergySysts() {
+
+    EnergySystVector vec;
+    vec.push_back(&kEnergyScaleMuonBig);
+    vec.push_back(&kEnergyScaleMuonSqrtBig);
+    vec.push_back(&kEnergyScaleMuonInvSqrtBig);
+    vec.push_back(&kEnergyScaleMuonNDBig);
+    vec.push_back(&kEnergyScaleMuonSqrtNDBig);
+    vec.push_back(&kEnergyScaleMuonInvSqrtNDBig);
+    //vec.push_back(&kEnergyScaleMuonUBBig);
+    //vec.push_back(&kEnergyScaleMuonSqrtUBBig);
+    //vec.push_back(&kEnergyScaleMuonInvSqrtUBBig);
+    vec.push_back(&kEnergyScaleMuonFDBig);
+    vec.push_back(&kEnergyScaleMuonSqrtFDBig);
+    vec.push_back(&kEnergyScaleMuonInvSqrtFDBig);
+    vec.push_back(&kEnergyScaleHadronBig);
+    vec.push_back(&kEnergyScaleHadronSqrtBig);
+    vec.push_back(&kEnergyScaleHadronInvSqrtBig);
+    vec.push_back(&kEnergyScaleHadronNDBig);
+    vec.push_back(&kEnergyScaleHadronSqrtNDBig);
+    vec.push_back(&kEnergyScaleHadronInvSqrtNDBig);
+    //vec.push_back(&kEnergyScaleHadronUBBig);
+    //vec.push_back(&kEnergyScaleHadronSqrtUBBig);
+    //vec.push_back(&kEnergyScaleHadronInvSqrtUBBig);
+    vec.push_back(&kEnergyScaleHadronFDBig);
+    vec.push_back(&kEnergyScaleHadronSqrtFDBig);
+    vec.push_back(&kEnergyScaleHadronInvSqrtFDBig);
+
+    return vec;
+  }
+} // namespace ana

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -1,117 +1,117 @@
 #include "sbnana/CAFAna/Systs/EnergySysts.h"
 
 namespace ana {
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuon(0.02, "EnergyScaleMuon");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonSqrt(0.02, "EnergyScaleMuonSqrt");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonInvSqrt(0.02, "EnergyScaleMuonInvSqrt");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuon(0.02, "EnergyScaleMuon");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonSqrt(0.02, "EnergyScaleMuonSqrt");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonInvSqrt(0.02, "EnergyScaleMuonInvSqrt");
 
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonND(0.02, "EnergyScaleMuonND");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtND(0.02, "EnergyScaleMuonSqrtND");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtND(0.02, "EnergyScaleMuonInvSqrtND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonND(0.02, "EnergyScaleMuonND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtND(0.02, "EnergyScaleMuonSqrtND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtND(0.02, "EnergyScaleMuonInvSqrtND");
 
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonUB(0.02, "EnergyScaleMuonUB");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtUB(0.02, "EnergyScaleMuonSqrtUB");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtUB(0.02, "EnergyScaleMuonInvSqrtUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonUB(0.02, "EnergyScaleMuonUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtUB(0.02, "EnergyScaleMuonSqrtUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtUB(0.02, "EnergyScaleMuonInvSqrtUB");
 
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonFD(0.02, "EnergyScaleMuonFD");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtFD(0.02, "EnergyScaleMuonSqrtFD");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtFD(0.02, "EnergyScaleMuonInvSqrtFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonFD(0.02, "EnergyScaleMuonFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtFD(0.02, "EnergyScaleMuonSqrtFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtFD(0.02, "EnergyScaleMuonInvSqrtFD");
 
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadron(0.05, "EnergyScaleHadron");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronSqrt(0.05, "EnergyScaleHadronSqrt");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronInvSqrt(0.05, "EnergyScaleHadronInvSqrt");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadron(0.05, "EnergyScaleHadron");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronSqrt(0.05, "EnergyScaleHadronSqrt");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronInvSqrt(0.05, "EnergyScaleHadronInvSqrt");
 
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronND(0.05, "EnergyScaleHadronND");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtND(0.05, "EnergyScaleHadronSqrtND");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtND(0.05, "EnergyScaleHadronInvSqrtND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronND(0.05, "EnergyScaleHadronND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtND(0.05, "EnergyScaleHadronSqrtND");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtND(0.05, "EnergyScaleHadronInvSqrtND");
 
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronUB(0.05, "EnergyScaleHadronUB");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtUB(0.05, "EnergyScaleHadronSqrtUB");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtUB(0.05, "EnergyScaleHadronInvSqrtUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronUB(0.05, "EnergyScaleHadronUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtUB(0.05, "EnergyScaleHadronSqrtUB");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtUB(0.05, "EnergyScaleHadronInvSqrtUB");
 
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronFD(0.05, "EnergyScaleHadronFD");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtFD(0.05, "EnergyScaleHadronSqrtFD");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtFD(0.05, "EnergyScaleHadronInvSqrtFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronFD(0.05, "EnergyScaleHadronFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtFD(0.05, "EnergyScaleHadronSqrtFD");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtFD(0.05, "EnergyScaleHadronInvSqrtFD");
 
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonBig(0.05, "EnergyScaleMuonBig");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonSqrtBig(0.05, "EnergyScaleMuonSqrtBig");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonInvSqrtBig(0.05, "EnergyScaleMuonInvSqrtBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonBig(0.05, "EnergyScaleMuonBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonSqrtBig(0.05, "EnergyScaleMuonSqrtBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonInvSqrtBig(0.05, "EnergyScaleMuonInvSqrtBig");
 
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonNDBig(0.05, "EnergyScaleMuonNDBig");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtNDBig(0.05, "EnergyScaleMuonSqrtNDBig");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtNDBig(0.05, "EnergyScaleMuonInvSqrtNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonNDBig(0.05, "EnergyScaleMuonNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtNDBig(0.05, "EnergyScaleMuonSqrtNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtNDBig(0.05, "EnergyScaleMuonInvSqrtNDBig");
 
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonUBBig(0.05, "EnergyScaleMuonUBBig");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtUBBig(0.05, "EnergyScaleMuonSqrtUBBig");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtUBBig(0.05, "EnergyScaleMuonInvSqrtUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonUBBig(0.05, "EnergyScaleMuonUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtUBBig(0.05, "EnergyScaleMuonSqrtUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtUBBig(0.05, "EnergyScaleMuonInvSqrtUBBig");
 
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonFDBig(0.05, "EnergyScaleMuonFDBig");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtFDBig(0.05, "EnergyScaleMuonSqrtFDBig");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtFDBig(0.05, "EnergyScaleMuonInvSqrtFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonFDBig(0.05, "EnergyScaleMuonFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtFDBig(0.05, "EnergyScaleMuonSqrtFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtFDBig(0.05, "EnergyScaleMuonInvSqrtFDBig");
 
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronBig(0.10, "EnergyScaleHadronBig");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronSqrtBig(0.10, "EnergyScaleHadronSqrtBig");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronInvSqrtBig(0.10, "EnergyScaleHadronInvSqrtBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronBig(0.10, "EnergyScaleHadronBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronSqrtBig(0.10, "EnergyScaleHadronSqrtBig");
+   const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronInvSqrtBig(0.10, "EnergyScaleHadronInvSqrtBig");
 
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronNDBig(0.10, "EnergyScaleHadronNDBig");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtNDBig(0.10, "EnergyScaleHadronSqrtNDBig");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtNDBig(0.10, "EnergyScaleHadronInvSqrtNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronNDBig(0.10, "EnergyScaleHadronNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtNDBig(0.10, "EnergyScaleHadronSqrtNDBig");
+   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtNDBig(0.10, "EnergyScaleHadronInvSqrtNDBig");
 
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronUBBig(0.10, "EnergyScaleHadronUBBig");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtUBBig(0.10, "EnergyScaleHadronSqrtUBBig");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtUBBig(0.10, "EnergyScaleHadronInvSqrtUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronUBBig(0.10, "EnergyScaleHadronUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtUBBig(0.10, "EnergyScaleHadronSqrtUBBig");
+   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtUBBig(0.10, "EnergyScaleHadronInvSqrtUBBig");
 
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronFDBig(0.10, "EnergyScaleHadronFDBig");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtFDBig(0.10, "EnergyScaleHadronSqrtFDBig");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtFDBig(0.10, "EnergyScaleHadronInvSqrtFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronFDBig(0.10, "EnergyScaleHadronFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtFDBig(0.10, "EnergyScaleHadronSqrtFDBig");
+   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtFDBig(0.10, "EnergyScaleHadronInvSqrtFDBig");
 
   EnergySystVector GetEnergySysts() {
     // MicroBooNE, ChargedHadron, Neutron, and EM systs

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -1,6 +1,65 @@
 #include "sbnana/CAFAna/Systs/EnergySysts.h"
 
 namespace ana {
+
+  void EnergyScaleSyst::Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const
+  {
+    double scale = uncertainty * sigma;
+    auto baseline_cut = [detector = detector](double baseline){
+      auto all = (detector == EnergyScaleSystDetector::kAll);
+      auto nd = (detector == EnergyScaleSystDetector::kSBND && baseline < 120);
+      auto ub = (detector == EnergyScaleSystDetector::kMicroBooNE && baseline > 120 && baseline < 500);
+      auto fd = (detector == EnergyScaleSystDetector::kICARUS && baseline > 500);
+      return all || nd || ub || fd;
+    };
+    if(sr->truth.iscc && abs(sr->truth.pdg) == 14 && !isnan(sr->fake_reco.nuE) && baseline_cut(sr->truth.baseline)) {
+      double particle_energy = 0.0;
+      switch(part) {
+      case EnergyScaleSystParticle::kMuon:
+        particle_energy += sr->fake_reco.lepton.ke;
+        break;
+      case EnergyScaleSystParticle::kHadron:
+        for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
+          particle_energy += sr->fake_reco.hadrons[i].ke;
+        }
+        break;
+      case EnergyScaleSystParticle::kNeutron:
+        for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
+          if(sr->fake_reco.hadrons[i].pid == 2112) {
+            particle_energy += sr->fake_reco.hadrons[i].ke;
+          }
+        }
+        break;
+      case EnergyScaleSystParticle::kEM:
+        for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
+          if(sr->fake_reco.hadrons[i].pid == 111) {
+            particle_energy += sr->fake_reco.hadrons[i].ke;
+          }
+        }
+        break;
+     case EnergyScaleSystParticle::kChargedHadron:
+        for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
+          auto pid = sr->fake_reco.hadrons[i].pid;
+          if(pid == 2212 || abs(pid) == 211) {
+            particle_energy += sr->fake_reco.hadrons[i].ke;
+          }
+        }
+        break;
+      }
+      switch(term) {
+      case EnergyScaleSystTerm::kConstant:
+        break;
+      case EnergyScaleSystTerm::kSqrt:
+        scale *= std::sqrt(particle_energy);
+        break;
+      case EnergyScaleSystTerm::kInverseSqrt:
+        scale /= std::sqrt(particle_energy + 0.1);
+        break;
+      }
+      sr->fake_reco.nuE += particle_energy * scale;
+    }
+  }
+
    const EnergyScaleSyst kEnergyScaleMuon(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuon");
    const EnergyScaleSyst kEnergyScaleMuonSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonSqrt");
    const EnergyScaleSyst kEnergyScaleMuonInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonInvSqrt");

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -1,117 +1,69 @@
 #include "sbnana/CAFAna/Systs/EnergySysts.h"
 
 namespace ana {
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuon(0.02, "EnergyScaleMuon");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonSqrt(0.02, "EnergyScaleMuonSqrt");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonInvSqrt(0.02, "EnergyScaleMuonInvSqrt");
+   const EnergyScaleSyst kEnergyScaleMuon(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuon");
+   const EnergyScaleSyst kEnergyScaleMuonSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonSqrt");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonInvSqrt");
 
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonND(0.02, "EnergyScaleMuonND");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtND(0.02, "EnergyScaleMuonSqrtND");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtND(0.02, "EnergyScaleMuonInvSqrtND");
+   const EnergyScaleSyst kEnergyScaleMuonND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonND");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonSqrtND");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonInvSqrtND");
 
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonUB(0.02, "EnergyScaleMuonUB");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtUB(0.02, "EnergyScaleMuonSqrtUB");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtUB(0.02, "EnergyScaleMuonInvSqrtUB");
+   const EnergyScaleSyst kEnergyScaleMuonUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonUB");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonSqrtUB");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonInvSqrtUB");
 
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonFD(0.02, "EnergyScaleMuonFD");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtFD(0.02, "EnergyScaleMuonSqrtFD");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtFD(0.02, "EnergyScaleMuonInvSqrtFD");
+   const EnergyScaleSyst kEnergyScaleMuonFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonFD");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonSqrtFD");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonInvSqrtFD");
 
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadron(0.05, "EnergyScaleHadron");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronSqrt(0.05, "EnergyScaleHadronSqrt");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronInvSqrt(0.05, "EnergyScaleHadronInvSqrt");
+   const EnergyScaleSyst kEnergyScaleHadron(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadron");
+   const EnergyScaleSyst kEnergyScaleHadronSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronSqrt");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronInvSqrt");
 
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronND(0.05, "EnergyScaleHadronND");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtND(0.05, "EnergyScaleHadronSqrtND");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtND(0.05, "EnergyScaleHadronInvSqrtND");
+   const EnergyScaleSyst kEnergyScaleHadronND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronND");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronSqrtND");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronInvSqrtND");
 
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronUB(0.05, "EnergyScaleHadronUB");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtUB(0.05, "EnergyScaleHadronSqrtUB");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtUB(0.05, "EnergyScaleHadronInvSqrtUB");
+   const EnergyScaleSyst kEnergyScaleHadronUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronUB");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronSqrtUB");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronInvSqrtUB");
 
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronFD(0.05, "EnergyScaleHadronFD");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtFD(0.05, "EnergyScaleHadronSqrtFD");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtFD(0.05, "EnergyScaleHadronInvSqrtFD");
+   const EnergyScaleSyst kEnergyScaleHadronFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronFD");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronSqrtFD");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronInvSqrtFD");
 
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonBig(0.05, "EnergyScaleMuonBig");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonSqrtBig(0.05, "EnergyScaleMuonSqrtBig");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonInvSqrtBig(0.05, "EnergyScaleMuonInvSqrtBig");
+   const EnergyScaleSyst kEnergyScaleMuonBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonBig");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonSqrtBig");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleMuonInvSqrtBig");
 
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonNDBig(0.05, "EnergyScaleMuonNDBig");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtNDBig(0.05, "EnergyScaleMuonSqrtNDBig");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtNDBig(0.05, "EnergyScaleMuonInvSqrtNDBig");
+   const EnergyScaleSyst kEnergyScaleMuonNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonNDBig");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonSqrtNDBig");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleMuonInvSqrtNDBig");
 
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonUBBig(0.05, "EnergyScaleMuonUBBig");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtUBBig(0.05, "EnergyScaleMuonSqrtUBBig");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtUBBig(0.05, "EnergyScaleMuonInvSqrtUBBig");
+   const EnergyScaleSyst kEnergyScaleMuonUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonUBBig");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonSqrtUBBig");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleMuonInvSqrtUBBig");
 
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonFDBig(0.05, "EnergyScaleMuonFDBig");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtFDBig(0.05, "EnergyScaleMuonSqrtFDBig");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtFDBig(0.05, "EnergyScaleMuonInvSqrtFDBig");
+   const EnergyScaleSyst kEnergyScaleMuonFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonFDBig");
+   const EnergyScaleSyst kEnergyScaleMuonSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonSqrtFDBig");
+   const EnergyScaleSyst kEnergyScaleMuonInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleMuonInvSqrtFDBig");
 
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronBig(0.10, "EnergyScaleHadronBig");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronSqrtBig(0.10, "EnergyScaleHadronSqrtBig");
-   const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronInvSqrtBig(0.10, "EnergyScaleHadronInvSqrtBig");
+   const EnergyScaleSyst kEnergyScaleHadronBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronBig");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronSqrtBig");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.10, "EnergyScaleHadronInvSqrtBig");
 
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronNDBig(0.10, "EnergyScaleHadronNDBig");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtNDBig(0.10, "EnergyScaleHadronSqrtNDBig");
-   const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtNDBig(0.10, "EnergyScaleHadronInvSqrtNDBig");
+   const EnergyScaleSyst kEnergyScaleHadronNDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronNDBig");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtNDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronSqrtNDBig");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtNDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.10, "EnergyScaleHadronInvSqrtNDBig");
 
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronUBBig(0.10, "EnergyScaleHadronUBBig");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtUBBig(0.10, "EnergyScaleHadronSqrtUBBig");
-   const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtUBBig(0.10, "EnergyScaleHadronInvSqrtUBBig");
+   const EnergyScaleSyst kEnergyScaleHadronUBBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronUBBig");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtUBBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronSqrtUBBig");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtUBBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.10, "EnergyScaleHadronInvSqrtUBBig");
 
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronFDBig(0.10, "EnergyScaleHadronFDBig");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtFDBig(0.10, "EnergyScaleHadronSqrtFDBig");
-   const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtFDBig(0.10, "EnergyScaleHadronInvSqrtFDBig");
+   const EnergyScaleSyst kEnergyScaleHadronFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronFDBig");
+   const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronSqrtFDBig");
+   const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronInvSqrtFDBig");
 
   EnergySystVector GetEnergySysts() {
     // MicroBooNE, ChargedHadron, Neutron, and EM systs

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -6,14 +6,13 @@ namespace ana {
   void EnergyScaleSyst::Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const
   {
     double scale = uncertainty * sigma;
-    auto detector_cut = [detector = detector](auto det){
-      bool all = (detector == EnergyScaleSystDetector::kAll);
-      bool nd = (detector == EnergyScaleSystDetector::kSBND && det == caf::kSBND);
-      bool ub = (detector == EnergyScaleSystDetector::kMicroBooNE && det == caf::kUNKNOWN);
-      bool fd = (detector == EnergyScaleSystDetector::kICARUS && det == caf::kICARUS);
-      return all || nd || ub || fd;
-    };
-    if(!sr->truth.iscc || abs(sr->truth.pdg) != 14 || isnan(sr->fake_reco.nuE) || !detector_cut(sr->truth.det)) 
+    auto& det = sr->truth.det;
+    bool all = (detector == EnergyScaleSystDetector::kAll);
+    bool nd = (detector == EnergyScaleSystDetector::kSBND && det == caf::kSBND);
+    bool ub = (detector == EnergyScaleSystDetector::kMicroBooNE && det == caf::kUNKNOWN);
+    bool fd = (detector == EnergyScaleSystDetector::kICARUS && det == caf::kICARUS);
+    bool detector_cut = all || nd || ub || fd;
+    if(!sr->truth.iscc || abs(sr->truth.pdg) != 14 || isnan(sr->fake_reco.nuE) || !detector_cut) 
       return ;
     double particle_energy = 0.0;
     switch(part) {

--- a/sbnana/CAFAna/Systs/EnergySysts.h
+++ b/sbnana/CAFAna/Systs/EnergySysts.h
@@ -109,7 +109,7 @@ namespace ana
   extern const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig;
   extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig;
 
-std::vector<const EnergyScaleSyst*> GetEnergySysts();
-std::vector<const EnergyScaleSyst*> GetBigEnergySysts();
+std::vector<const ISyst*> GetEnergySysts();
+std::vector<const ISyst*> GetBigEnergySysts();
 
 }

--- a/sbnana/CAFAna/Systs/EnergySysts.h
+++ b/sbnana/CAFAna/Systs/EnergySysts.h
@@ -109,13 +109,7 @@ namespace ana
   extern const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig;
   extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig;
 
-  // Vector of energy scale systematics
-  struct EnergySystVector: public std::vector<const ISyst*>
-  {
-
-  };
-
-EnergySystVector GetEnergySysts();
-EnergySystVector GetBigEnergySysts();
+std::vector<const EnergyScaleSyst*> GetEnergySysts();
+std::vector<const EnergyScaleSyst*> GetBigEnergySysts();
 
 }

--- a/sbnana/CAFAna/Systs/EnergySysts.h
+++ b/sbnana/CAFAna/Systs/EnergySysts.h
@@ -3,15 +3,8 @@
 #pragma once
 
 #include "sbnana/CAFAna/Core/ISyst.h"
-#include "sbnana/CAFAna/Core/Utilities.h"
-#include "sbnana/CAFAna/Analysis/ExpInfo.h"
-#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
 
-#include "TFile.h"
-#include "TH1.h"
-#include "TRandom3.h"
-
-#include <cassert>
+#include <vector>
 
 namespace ana
 {

--- a/sbnana/CAFAna/Systs/EnergySysts.h
+++ b/sbnana/CAFAna/Systs/EnergySysts.h
@@ -40,9 +40,11 @@ namespace ana
   class EnergyScaleSyst: public ISyst
   {
   public:
-    EnergyScaleSyst(EnergyScaleSystTerm _term, EnergyScaleSystParticle _part, EnergyScaleSystDetector _detector, double _uncertainty, std::string name) : 
-      ISyst(name, name), term(_term), part(_part), detector(_detector), uncertainty(_uncertainty) {}
-      void Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const override;
+    EnergyScaleSyst(EnergyScaleSystTerm _term, EnergyScaleSystParticle _part, EnergyScaleSystDetector _detector, double _uncertainty, const std::string& name, const std::string& latexName) : 
+      ISyst(name, latexName), term(_term), part(_part), detector(_detector), uncertainty(_uncertainty) {}
+
+    void Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const override;
+
   private:
     EnergyScaleSystTerm term;
     EnergyScaleSystParticle part;

--- a/sbnana/CAFAna/Systs/EnergySysts.h
+++ b/sbnana/CAFAna/Systs/EnergySysts.h
@@ -1,0 +1,240 @@
+//ETW May 2020 Fresh version for SBN
+
+#pragma once
+
+#include "sbnana/CAFAna/Core/ISyst.h"
+#include "sbnana/CAFAna/Core/Utilities.h"
+#include "sbnana/CAFAna/Analysis/ExpInfo.h"
+#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
+
+#include "TFile.h"
+#include "TH1.h"
+#include "TRandom3.h"
+
+#include <cassert>
+
+namespace ana
+{
+
+  enum class EnergyScaleSystTerm {
+    Constant,
+    Sqrt,
+    InverseSqrt
+  };
+
+  enum class EnergyScaleSystParticle {
+    Muon,
+    Hadron,
+    Neutron,
+    EM,
+    ChargedHadron
+  };
+
+  enum class EnergyScaleSystDetector {
+    SBND,
+    MicroBooNE,
+    ICARUS,
+    All
+  };
+
+  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part, EnergyScaleSystDetector detector = EnergyScaleSystDetector::All>
+  class EnergyScaleSyst: public ISyst
+  {
+  public:
+    EnergyScaleSyst(double _uncertainty, std::string name) : 
+      ISyst(name, name), uncertainty(_uncertainty) {}
+    void Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const override
+    {
+      double scale = uncertainty * sigma;
+      auto baseline_cut = [](double baseline){ 
+        auto all = (detector == EnergyScaleSystDetector::All);
+        auto nd = (detector == EnergyScaleSystDetector::SBND && baseline < 120);
+        auto ub = (detector == EnergyScaleSystDetector::MicroBooNE && baseline > 120 && baseline < 500);
+        auto fd = (detector == EnergyScaleSystDetector::ICARUS && baseline > 500);
+        return all || nd || ub || fd; 
+      };
+      if(sr->truth.iscc && abs(sr->truth.pdg) == 14 && !isnan(sr->fake_reco.nuE) && baseline_cut(sr->truth.baseline)) {
+        double particle_energy = 0.0;
+        switch(part) {
+        case EnergyScaleSystParticle::Muon:
+          particle_energy += sr->fake_reco.lepton.ke;
+          break;
+        case EnergyScaleSystParticle::Hadron:
+          for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
+            particle_energy += sr->fake_reco.hadrons[i].ke;
+          }
+          break;
+        case EnergyScaleSystParticle::Neutron:
+          for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
+            if(sr->fake_reco.hadrons[i].pid == 2112) {
+              particle_energy += sr->fake_reco.hadrons[i].ke;
+            }
+          }
+          break;
+        case EnergyScaleSystParticle::EM:
+          for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
+            if(sr->fake_reco.hadrons[i].pid == 111) {
+              particle_energy += sr->fake_reco.hadrons[i].ke;
+            }
+          }
+          break;
+        case EnergyScaleSystParticle::ChargedHadron:
+          for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
+            auto pid = sr->fake_reco.hadrons[i].pid;
+            if(pid == 2212 || abs(pid) == 211) {
+              particle_energy += sr->fake_reco.hadrons[i].ke;
+            }
+          }
+          break;
+        }
+        switch(term) {
+        case EnergyScaleSystTerm::Constant:
+          break;
+        case EnergyScaleSystTerm::Sqrt:
+          scale *= std::sqrt(particle_energy);
+          break;
+        case EnergyScaleSystTerm::InverseSqrt:
+          scale /= std::sqrt(particle_energy + 0.1);
+          break;
+        }
+        sr->fake_reco.nuE += particle_energy * scale;
+      }
+    }
+  private:
+    double uncertainty;
+  };
+
+  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
+  using EnergyScaleSystCorr = EnergyScaleSyst<term, part, EnergyScaleSystDetector::All>;
+
+  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
+  using EnergyScaleSystUncorrND = EnergyScaleSyst<term, part, EnergyScaleSystDetector::SBND>;
+
+  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
+  using EnergyScaleSystUncorrUB = EnergyScaleSyst<term, part, EnergyScaleSystDetector::MicroBooNE>;
+
+  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
+  using EnergyScaleSystUncorrFD = EnergyScaleSyst<term, part, EnergyScaleSystDetector::ICARUS>;
+
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuon;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonSqrt;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonInvSqrt;
+
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtND;
+
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtUB;
+
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtFD;
+
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadron;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronSqrt;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronInvSqrt;
+
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtND;
+
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtUB;
+
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtFD;
+
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonSqrtBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
+                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonInvSqrtBig;
+
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtNDBig;
+
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtUBBig;
+
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtFDBig;
+
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronSqrtBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
+                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronInvSqrtBig;
+
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtNDBig;
+
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtUBBig;
+
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
+                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtFDBig;
+
+  // Vector of energy scale systematics
+  struct EnergySystVector: public std::vector<const ISyst*>
+  {
+
+  };
+
+EnergySystVector GetEnergySysts();
+EnergySystVector GetBigEnergySysts();
+
+}

--- a/sbnana/CAFAna/Systs/EnergySysts.h
+++ b/sbnana/CAFAna/Systs/EnergySysts.h
@@ -37,16 +37,15 @@ namespace ana
     kAll
   };
 
-  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part, EnergyScaleSystDetector detector = EnergyScaleSystDetector::kAll>
   class EnergyScaleSyst: public ISyst
   {
   public:
-    EnergyScaleSyst(double _uncertainty, std::string name) : 
-      ISyst(name, name), uncertainty(_uncertainty) {}
+    EnergyScaleSyst(EnergyScaleSystTerm _term, EnergyScaleSystParticle _part, EnergyScaleSystDetector _detector, double _uncertainty, std::string name) : 
+      ISyst(name, name), term(_term), part(_part), detector(_detector), uncertainty(_uncertainty) {}
     void Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const override
     {
       double scale = uncertainty * sigma;
-      auto baseline_cut = [](double baseline){ 
+      auto baseline_cut = [detector = detector](double baseline){ 
         auto all = (detector == EnergyScaleSystDetector::kAll);
         auto nd = (detector == EnergyScaleSystDetector::kSBND && baseline < 120);
         auto ub = (detector == EnergyScaleSystDetector::kMicroBooNE && baseline > 120 && baseline < 500);
@@ -101,132 +100,75 @@ namespace ana
       }
     }
   private:
+    EnergyScaleSystTerm term;
+    EnergyScaleSystParticle part;
+    EnergyScaleSystDetector detector;
     double uncertainty;
   };
 
-  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
-  using EnergyScaleSystCorr = EnergyScaleSyst<term, part, EnergyScaleSystDetector::kAll>;
+  extern const EnergyScaleSyst kEnergyScaleMuon;
+  extern const EnergyScaleSyst kEnergyScaleMuonSqrt;
+  extern const EnergyScaleSyst kEnergyScaleMuonInvSqrt;
 
-  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
-  using EnergyScaleSystUncorrND = EnergyScaleSyst<term, part, EnergyScaleSystDetector::kSBND>;
+  extern const EnergyScaleSyst kEnergyScaleMuonND;
+  extern const EnergyScaleSyst kEnergyScaleMuonSqrtND;
+  extern const EnergyScaleSyst kEnergyScaleMuonInvSqrtND;
 
-  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
-  using EnergyScaleSystUncorrUB = EnergyScaleSyst<term, part, EnergyScaleSystDetector::kMicroBooNE>;
+  extern const EnergyScaleSyst kEnergyScaleMuonUB;
+  extern const EnergyScaleSyst kEnergyScaleMuonSqrtUB;
+  extern const EnergyScaleSyst kEnergyScaleMuonInvSqrtUB;
 
-  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
-  using EnergyScaleSystUncorrFD = EnergyScaleSyst<term, part, EnergyScaleSystDetector::kICARUS>;
+  extern const EnergyScaleSyst kEnergyScaleMuonFD;
+  extern const EnergyScaleSyst kEnergyScaleMuonSqrtFD;
+  extern const EnergyScaleSyst kEnergyScaleMuonInvSqrtFD;
 
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuon;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonSqrt;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonInvSqrt;
+  extern const EnergyScaleSyst kEnergyScaleHadron;
+  extern const EnergyScaleSyst kEnergyScaleHadronSqrt;
+  extern const EnergyScaleSyst kEnergyScaleHadronInvSqrt;
 
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonND;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtND;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtND;
+  extern const EnergyScaleSyst kEnergyScaleHadronND;
+  extern const EnergyScaleSyst kEnergyScaleHadronSqrtND;
+  extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtND;
 
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonUB;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtUB;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtUB;
+  extern const EnergyScaleSyst kEnergyScaleHadronUB;
+  extern const EnergyScaleSyst kEnergyScaleHadronSqrtUB;
+  extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtUB;
 
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonFD;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtFD;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtFD;
+  extern const EnergyScaleSyst kEnergyScaleHadronFD;
+  extern const EnergyScaleSyst kEnergyScaleHadronSqrtFD;
+  extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtFD;
 
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadron;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronSqrt;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronInvSqrt;
+  extern const EnergyScaleSyst kEnergyScaleMuonBig;
+  extern const EnergyScaleSyst kEnergyScaleMuonSqrtBig;
+  extern const EnergyScaleSyst kEnergyScaleMuonInvSqrtBig;
 
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronND;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtND;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtND;
+  extern const EnergyScaleSyst kEnergyScaleMuonNDBig;
+  extern const EnergyScaleSyst kEnergyScaleMuonSqrtNDBig;
+  extern const EnergyScaleSyst kEnergyScaleMuonInvSqrtNDBig;
 
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronUB;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtUB;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtUB;
+  extern const EnergyScaleSyst kEnergyScaleMuonUBBig;
+  extern const EnergyScaleSyst kEnergyScaleMuonSqrtUBBig;
+  extern const EnergyScaleSyst kEnergyScaleMuonInvSqrtUBBig;
 
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronFD;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtFD;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtFD;
+  extern const EnergyScaleSyst kEnergyScaleMuonFDBig;
+  extern const EnergyScaleSyst kEnergyScaleMuonSqrtFDBig;
+  extern const EnergyScaleSyst kEnergyScaleMuonInvSqrtFDBig;
 
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonBig;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonSqrtBig;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
-                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonInvSqrtBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronSqrtBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtBig;
 
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonNDBig;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtNDBig;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtNDBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronNDBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronSqrtNDBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtNDBig;
 
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonUBBig;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtUBBig;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtUBBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronUBBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronSqrtUBBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtUBBig;
 
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonFDBig;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtFDBig;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtFDBig;
-
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronBig;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronSqrtBig;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
-                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronInvSqrtBig;
-
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronNDBig;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtNDBig;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtNDBig;
-
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronUBBig;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtUBBig;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtUBBig;
-
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronFDBig;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtFDBig;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
-                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtFDBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronFDBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig;
+  extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig;
 
   // Vector of energy scale systematics
   struct EnergySystVector: public std::vector<const ISyst*>

--- a/sbnana/CAFAna/Systs/EnergySysts.h
+++ b/sbnana/CAFAna/Systs/EnergySysts.h
@@ -17,27 +17,27 @@ namespace ana
 {
 
   enum class EnergyScaleSystTerm {
-    Constant,
-    Sqrt,
-    InverseSqrt
+    kConstant,
+    kSqrt,
+    kInverseSqrt
   };
 
   enum class EnergyScaleSystParticle {
-    Muon,
-    Hadron,
-    Neutron,
-    EM,
-    ChargedHadron
+    kMuon,
+    kHadron,
+    kNeutron,
+    kEM,
+    kChargedHadron
   };
 
   enum class EnergyScaleSystDetector {
-    SBND,
-    MicroBooNE,
-    ICARUS,
-    All
+    kSBND,
+    kMicroBooNE,
+    kICARUS,
+    kAll
   };
 
-  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part, EnergyScaleSystDetector detector = EnergyScaleSystDetector::All>
+  template<EnergyScaleSystTerm term, EnergyScaleSystParticle part, EnergyScaleSystDetector detector = EnergyScaleSystDetector::kAll>
   class EnergyScaleSyst: public ISyst
   {
   public:
@@ -47,38 +47,38 @@ namespace ana
     {
       double scale = uncertainty * sigma;
       auto baseline_cut = [](double baseline){ 
-        auto all = (detector == EnergyScaleSystDetector::All);
-        auto nd = (detector == EnergyScaleSystDetector::SBND && baseline < 120);
-        auto ub = (detector == EnergyScaleSystDetector::MicroBooNE && baseline > 120 && baseline < 500);
-        auto fd = (detector == EnergyScaleSystDetector::ICARUS && baseline > 500);
+        auto all = (detector == EnergyScaleSystDetector::kAll);
+        auto nd = (detector == EnergyScaleSystDetector::kSBND && baseline < 120);
+        auto ub = (detector == EnergyScaleSystDetector::kMicroBooNE && baseline > 120 && baseline < 500);
+        auto fd = (detector == EnergyScaleSystDetector::kICARUS && baseline > 500);
         return all || nd || ub || fd; 
       };
       if(sr->truth.iscc && abs(sr->truth.pdg) == 14 && !isnan(sr->fake_reco.nuE) && baseline_cut(sr->truth.baseline)) {
         double particle_energy = 0.0;
         switch(part) {
-        case EnergyScaleSystParticle::Muon:
+        case EnergyScaleSystParticle::kMuon:
           particle_energy += sr->fake_reco.lepton.ke;
           break;
-        case EnergyScaleSystParticle::Hadron:
+        case EnergyScaleSystParticle::kHadron:
           for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
             particle_energy += sr->fake_reco.hadrons[i].ke;
           }
           break;
-        case EnergyScaleSystParticle::Neutron:
+        case EnergyScaleSystParticle::kNeutron:
           for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
             if(sr->fake_reco.hadrons[i].pid == 2112) {
               particle_energy += sr->fake_reco.hadrons[i].ke;
             }
           }
           break;
-        case EnergyScaleSystParticle::EM:
+        case EnergyScaleSystParticle::kEM:
           for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
             if(sr->fake_reco.hadrons[i].pid == 111) {
               particle_energy += sr->fake_reco.hadrons[i].ke;
             }
           }
           break;
-        case EnergyScaleSystParticle::ChargedHadron:
+        case EnergyScaleSystParticle::kChargedHadron:
           for (size_t i = 0; i < sr->fake_reco.hadrons.size(); ++i) {
             auto pid = sr->fake_reco.hadrons[i].pid;
             if(pid == 2212 || abs(pid) == 211) {
@@ -88,12 +88,12 @@ namespace ana
           break;
         }
         switch(term) {
-        case EnergyScaleSystTerm::Constant:
+        case EnergyScaleSystTerm::kConstant:
           break;
-        case EnergyScaleSystTerm::Sqrt:
+        case EnergyScaleSystTerm::kSqrt:
           scale *= std::sqrt(particle_energy);
           break;
-        case EnergyScaleSystTerm::InverseSqrt:
+        case EnergyScaleSystTerm::kInverseSqrt:
           scale /= std::sqrt(particle_energy + 0.1);
           break;
         }
@@ -105,128 +105,128 @@ namespace ana
   };
 
   template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
-  using EnergyScaleSystCorr = EnergyScaleSyst<term, part, EnergyScaleSystDetector::All>;
+  using EnergyScaleSystCorr = EnergyScaleSyst<term, part, EnergyScaleSystDetector::kAll>;
 
   template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
-  using EnergyScaleSystUncorrND = EnergyScaleSyst<term, part, EnergyScaleSystDetector::SBND>;
+  using EnergyScaleSystUncorrND = EnergyScaleSyst<term, part, EnergyScaleSystDetector::kSBND>;
 
   template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
-  using EnergyScaleSystUncorrUB = EnergyScaleSyst<term, part, EnergyScaleSystDetector::MicroBooNE>;
+  using EnergyScaleSystUncorrUB = EnergyScaleSyst<term, part, EnergyScaleSystDetector::kMicroBooNE>;
 
   template<EnergyScaleSystTerm term, EnergyScaleSystParticle part>
-  using EnergyScaleSystUncorrFD = EnergyScaleSyst<term, part, EnergyScaleSystDetector::ICARUS>;
+  using EnergyScaleSystUncorrFD = EnergyScaleSyst<term, part, EnergyScaleSystDetector::kICARUS>;
 
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuon;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonSqrt;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonInvSqrt;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuon;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonSqrt;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonInvSqrt;
 
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonND;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtND;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtND;
 
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonUB;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtUB;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtUB;
 
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonFD;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtFD;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtFD;
 
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadron;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronSqrt;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronInvSqrt;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadron;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronSqrt;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronInvSqrt;
 
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronND;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtND;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtND;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtND;
 
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronUB;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtUB;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtUB;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtUB;
 
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronFD;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtFD;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtFD;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtFD;
 
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonBig;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonSqrtBig;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
-                                   EnergyScaleSystParticle::Muon>        kEnergyScaleMuonInvSqrtBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonSqrtBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
+                                   EnergyScaleSystParticle::kMuon>        kEnergyScaleMuonInvSqrtBig;
 
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonNDBig;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtNDBig;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtNDBig;
 
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonUBBig;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtUBBig;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtUBBig;
 
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonFDBig;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonSqrtFDBig;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Muon>    kEnergyScaleMuonInvSqrtFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonSqrtFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kMuon>    kEnergyScaleMuonInvSqrtFDBig;
 
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Constant, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronBig;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::Sqrt, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronSqrtBig;
-  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::InverseSqrt, 
-                                   EnergyScaleSystParticle::Hadron>      kEnergyScaleHadronInvSqrtBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kConstant, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kSqrt, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronSqrtBig;
+  extern const EnergyScaleSystCorr<EnergyScaleSystTerm::kInverseSqrt, 
+                                   EnergyScaleSystParticle::kHadron>      kEnergyScaleHadronInvSqrtBig;
 
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronNDBig;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtNDBig;
-  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtNDBig;
+  extern const EnergyScaleSystUncorrND<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtNDBig;
 
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronUBBig;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtUBBig;
-  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtUBBig;
+  extern const EnergyScaleSystUncorrUB<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtUBBig;
 
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Constant, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronFDBig;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::Sqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronSqrtFDBig;
-  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::InverseSqrt, 
-                                       EnergyScaleSystParticle::Hadron>  kEnergyScaleHadronInvSqrtFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kConstant, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronSqrtFDBig;
+  extern const EnergyScaleSystUncorrFD<EnergyScaleSystTerm::kInverseSqrt, 
+                                       EnergyScaleSystParticle::kHadron>  kEnergyScaleHadronInvSqrtFDBig;
 
   // Vector of energy scale systematics
   struct EnergySystVector: public std::vector<const ISyst*>


### PR DESCRIPTION
Add some preliminary energy scale systematics in sbnana/CAFAna/Systs/EnergySysts.h(cxx).
This includes correlated and uncorrelated systs for all three detectors.
Currently I'm only using the muon and total hadron energy systs, but the code for charged hadron, neutron, and em systs is there for numu events.
This depends on the fake reco values in the CAFs so they do not work on nue or cosmic events since the fake reco is currently only filled in for numu events.

The value of the uncertainty for each systematic is copied from DUNE, but there are also some "Big" systs included which double the size of the uncertainty.