### PR TITLE
Remove explicit dependency on srproxy

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -38,7 +38,6 @@ sbnanaobj        v09_17_06_05
 #SAM tools?
 ifdhc            v2_5_16
 # For CAFAna
-srproxy          v00.34
 osclib           v00.17
 # flux syst histograms etc
 sbndata		 v01_03
@@ -51,11 +50,11 @@ end_product_list
 # We now define allowed qualifiers and the corresponding qualifiers for the dependencies.
 # Make the table by adding columns before "notes".
 
-qualifier     sbnanaobj	      ifdhc   	       srproxy  osclib                  sbndata	notes
-e20:debug     e20:debug	      e20:debug:p392  py3      e20:debug:n309:stanfree  -nq-	-nq-
-e20:prof      e20:prof	      e20:prof:p392   py3      e20:prof:n309:stanfree   -nq-	-nq-
-c7:debug      c7:debug	      c7:debug:p392   py3      c7:debug:n309:stanfree   -nq-	-nq-
-c7:prof       c7:prof	      c7:prof:p392    py3      c7:prof:n309:stanfree    -nq-	-nq-
+qualifier     sbnanaobj	      ifdhc   	      osclib                  sbndata	notes
+e20:debug     e20:debug	      e20:debug:p392  e20:debug:n309:stanfree  -nq-	-nq-
+e20:prof      e20:prof	      e20:prof:p392   e20:prof:n309:stanfree   -nq-	-nq-
+c7:debug      c7:debug	      c7:debug:p392   c7:debug:n309:stanfree   -nq-	-nq-
+c7:prof       c7:prof	      c7:prof:p392    c7:prof:n309:stanfree    -nq-	-nq-
 end_qualifier_list
 
 # Preserve tabs and formatting in emacs and vi / vim:


### PR DESCRIPTION
We pick it up transitively from sbanaobj. This now matches the situation in develop.