### PR TITLE
Broaden 2D spectrum creation

### DIFF
--- a/sbnana/CAFAna/Core/MultiVar.cxx
+++ b/sbnana/CAFAna/Core/MultiVar.cxx
@@ -32,8 +32,12 @@ namespace ana
       const std::vector<double> vbVec = fB(sr);
 
       if(vaVec.size() != vbVec.size())
-        throw std::length_error("MultiVars need to be same size");
-
+	{
+	  std::cout << "MultiVars need to be same size, these two are size " 
+		    << vaVec.size() << " " << vbVec.size() << "respectively." << std::endl;
+	  std::abort();
+	}
+      
       for(unsigned n = 0; n < vaVec.size(); ++n){
         const double va = vaVec.at(n);
         const double vb = vbVec.at(n);

--- a/sbnana/CAFAna/Core/MultiVar.cxx
+++ b/sbnana/CAFAna/Core/MultiVar.cxx
@@ -12,6 +12,65 @@ namespace ana
   {
   }
 
+  //----------------------------------------------------------------------
+  /// Helper for \ref MultiVar2D
+  template<class T> class MultiVar2DFunc
+  {
+  public:
+    MultiVar2DFunc(const _MultiVar<T>& a, const Binning binsa,
+		   const _MultiVar<T>& b, const Binning binsb)
+      : fA(a), fBinsA(binsa),
+        fB(b), fBinsB(binsb)
+    {
+    }
+
+    std::vector<double> operator()(const T* sr) const
+    {
+      std::vector<double> returnVec;
+
+      const std::vector<double> vaVec = fA(sr);
+      const std::vector<double> vbVec = fB(sr);
+
+      if(vaVec.size() != vbVec.size())
+	throw std::length_error("MultiVars need to be same size");
+
+      for(unsigned n = 0; n < vaVec.size(); ++n)
+	{
+	  const double va = vaVec.at(n);
+	  const double vb = vbVec.at(n);
+	  // Since there are no overflow/underflow bins, check the range
+	  if(va < fBinsA.Min() || vb < fBinsB.Min()){ returnVec.push_back(-1); continue;}
+	  if(va > fBinsA.Max() || vb > fBinsB.Max()){ returnVec.push_back(fBinsA.NBins() * fBinsB.NBins()); continue;}
+	      
+	  // FindBin uses root convention, first bin is bin 1, bin 0 is underflow
+	  const int ia = fBinsA.FindBin(va) - 1;
+	  const int ib = fBinsB.FindBin(vb) - 1;
+      
+	  const int i = ia*fBinsB.NBins()+ib;
+	      
+	  returnVec.push_back(i+.5);
+	}
+      return returnVec;
+    }
+  protected:
+    const _MultiVar<T> fA;
+    const Binning fBinsA;
+    const _MultiVar<T> fB;
+    const Binning fBinsB;
+  };
+
+  //----------------------------------------------------------------------
+  template<class T> _MultiVar<T>
+  MultiVar2D(const _MultiVar<T>& a, const Binning& binsa,
+	     const _MultiVar<T>& b, const Binning& binsb)
+  {
+    return _MultiVar<T>(MultiVar2DFunc<T>(a, binsa, b, binsb));
+  }
+
+  // explicitly instantiate the template for the types we know we have
+  template MultiVar MultiVar2D(const MultiVar&, const Binning&, const MultiVar&, const Binning&);
+  template SpillMultiVar MultiVar2D(const SpillMultiVar&, const Binning&, const SpillMultiVar&, const Binning&);
+
   // explicitly instantiate the templates for the types we know we have
   template class _MultiVar<caf::SRSpillProxy>;
   template class _MultiVar<caf::SRSliceProxy>;
@@ -19,4 +78,5 @@ namespace ana
   // Stupid hack to avoid colliding with the IDs of actual Vars. Just count
   // down through negative numbers.
   template<class T> int _MultiVar<T>::fgNextID = -1;
+
 }

--- a/sbnana/CAFAna/Core/MultiVar.cxx
+++ b/sbnana/CAFAna/Core/MultiVar.cxx
@@ -18,7 +18,7 @@ namespace ana
   {
   public:
     MultiVar2DFunc(const _MultiVar<T>& a, const Binning binsa,
-		   const _MultiVar<T>& b, const Binning binsb)
+                   const _MultiVar<T>& b, const Binning binsb)
       : fA(a), fBinsA(binsa),
         fB(b), fBinsB(binsb)
     {
@@ -32,24 +32,24 @@ namespace ana
       const std::vector<double> vbVec = fB(sr);
 
       if(vaVec.size() != vbVec.size())
-	throw std::length_error("MultiVars need to be same size");
+        throw std::length_error("MultiVars need to be same size");
 
       for(unsigned n = 0; n < vaVec.size(); ++n)
-	{
-	  const double va = vaVec.at(n);
-	  const double vb = vbVec.at(n);
-	  // Since there are no overflow/underflow bins, check the range
-	  if(va < fBinsA.Min() || vb < fBinsB.Min()){ returnVec.push_back(-1); continue;}
-	  if(va > fBinsA.Max() || vb > fBinsB.Max()){ returnVec.push_back(fBinsA.NBins() * fBinsB.NBins()); continue;}
-	      
-	  // FindBin uses root convention, first bin is bin 1, bin 0 is underflow
-	  const int ia = fBinsA.FindBin(va) - 1;
-	  const int ib = fBinsB.FindBin(vb) - 1;
+        {
+          const double va = vaVec.at(n);
+          const double vb = vbVec.at(n);
+          // Since there are no overflow/underflow bins, check the range
+          if(va < fBinsA.Min() || vb < fBinsB.Min()){ returnVec.push_back(-1); continue;}
+          if(va > fBinsA.Max() || vb > fBinsB.Max()){ returnVec.push_back(fBinsA.NBins() * fBinsB.NBins()); continue;}
+              
+          // FindBin uses root convention, first bin is bin 1, bin 0 is underflow
+          const int ia = fBinsA.FindBin(va) - 1;
+          const int ib = fBinsB.FindBin(vb) - 1;
       
-	  const int i = ia*fBinsB.NBins()+ib;
-	      
-	  returnVec.push_back(i+.5);
-	}
+          const int i = ia*fBinsB.NBins()+ib;
+              
+          returnVec.push_back(i+.5);
+        }
       return returnVec;
     }
   protected:
@@ -62,7 +62,7 @@ namespace ana
   //----------------------------------------------------------------------
   template<class T> _MultiVar<T>
   MultiVar2D(const _MultiVar<T>& a, const Binning& binsa,
-	     const _MultiVar<T>& b, const Binning& binsb)
+             const _MultiVar<T>& b, const Binning& binsb)
   {
     return _MultiVar<T>(MultiVar2DFunc<T>(a, binsa, b, binsb));
   }

--- a/sbnana/CAFAna/Core/MultiVar.cxx
+++ b/sbnana/CAFAna/Core/MultiVar.cxx
@@ -34,22 +34,21 @@ namespace ana
       if(vaVec.size() != vbVec.size())
         throw std::length_error("MultiVars need to be same size");
 
-      for(unsigned n = 0; n < vaVec.size(); ++n)
-        {
-          const double va = vaVec.at(n);
-          const double vb = vbVec.at(n);
-          // Since there are no overflow/underflow bins, check the range
-          if(va < fBinsA.Min() || vb < fBinsB.Min()){ returnVec.push_back(-1); continue;}
-          if(va > fBinsA.Max() || vb > fBinsB.Max()){ returnVec.push_back(fBinsA.NBins() * fBinsB.NBins()); continue;}
-              
-          // FindBin uses root convention, first bin is bin 1, bin 0 is underflow
-          const int ia = fBinsA.FindBin(va) - 1;
-          const int ib = fBinsB.FindBin(vb) - 1;
-      
-          const int i = ia*fBinsB.NBins()+ib;
-              
-          returnVec.push_back(i+.5);
-        }
+      for(unsigned n = 0; n < vaVec.size(); ++n){
+        const double va = vaVec.at(n);
+        const double vb = vbVec.at(n);
+        // Since there are no overflow/underflow bins, check the range
+        if(va < fBinsA.Min() || vb < fBinsB.Min()){ returnVec.push_back(-1); continue;}
+        if(va > fBinsA.Max() || vb > fBinsB.Max()){ returnVec.push_back(fBinsA.NBins() * fBinsB.NBins()); continue;}
+
+        // FindBin uses root convention, first bin is bin 1, bin 0 is underflow
+        const int ia = fBinsA.FindBin(va) - 1;
+        const int ib = fBinsB.FindBin(vb) - 1;
+
+        const int i = ia*fBinsB.NBins()+ib;
+
+        returnVec.push_back(i+.5);
+      }
       return returnVec;
     }
   protected:

--- a/sbnana/CAFAna/Core/MultiVar.h
+++ b/sbnana/CAFAna/Core/MultiVar.h
@@ -5,7 +5,9 @@
 #include <string>
 #include <vector>
 
-#include "sbnanaobj/StandardRecord/Proxy/FwdDeclare.h"
+#include "sbnana/CAFAna/Core/Binning.h"
+
+#include "sbnana/CAFAna/StandardRecord/Proxy/FwdDeclare.h"
 
 namespace ana
 {
@@ -31,6 +33,11 @@ namespace ana
 
     static int MaxID() {return fgNextID-1;}
   protected:
+    _MultiVar(const std::function<VarFunc_t>& fun, int id)
+      : fFunc(fun), fID(id)
+    {
+    }
+
     std::function<VarFunc_t> fFunc;
 
     int fID;
@@ -40,5 +47,9 @@ namespace ana
 
   typedef _MultiVar<caf::SRSliceProxy> MultiVar;
   typedef _MultiVar<caf::SRSpillProxy> SpillMultiVar;
+
+  template<class T> _MultiVar<T>
+  MultiVar2D(const _MultiVar<T>& a, const Binning& binsa,
+	     const _MultiVar<T>& b, const Binning& binsb);
 
 } // namespace

--- a/sbnana/CAFAna/Core/MultiVar.h
+++ b/sbnana/CAFAna/Core/MultiVar.h
@@ -7,7 +7,7 @@
 
 #include "sbnana/CAFAna/Core/Binning.h"
 
-#include "sbnana/CAFAna/StandardRecord/Proxy/FwdDeclare.h"
+#include "sbnanaobj/StandardRecord/Proxy/FwdDeclare.h"
 
 namespace ana
 {

--- a/sbnana/CAFAna/Core/MultiVar.h
+++ b/sbnana/CAFAna/Core/MultiVar.h
@@ -50,6 +50,6 @@ namespace ana
 
   template<class T> _MultiVar<T>
   MultiVar2D(const _MultiVar<T>& a, const Binning& binsa,
-	     const _MultiVar<T>& b, const Binning& binsb);
+             const _MultiVar<T>& b, const Binning& binsb);
 
 } // namespace

--- a/sbnana/CAFAna/Core/Spectrum.cxx
+++ b/sbnana/CAFAna/Core/Spectrum.cxx
@@ -157,6 +157,30 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& label, SpectrumLoaderBase& loader,
+                     const Binning& binsx, const MultiVar& varx,
+                     const Binning& binsy, const MultiVar& vary,
+                     const SpillCut& spillcut,
+		     const Cut& cut,
+                     const SystShifts& shift,
+                     const Var& wei)
+    : Spectrum(label, "", loader, binsx, varx, binsy, vary, spillcut, cut, shift, wei)
+  {
+    // TODO do we want this variant when there's one with a labelY just below?
+  }
+
+  //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& label, SpectrumLoaderBase& loader,
+                     const Binning& binsx, const SpillMultiVar& varx,
+                     const Binning& binsy, const SpillMultiVar& vary,
+                     const SpillCut& spillcut,
+                     const SpillVar& wei)
+    : Spectrum(label, "", loader, binsx, varx, binsy, vary, spillcut, wei)
+  {
+    // TODO do we want this variant when there's one with a labelY just below?
+  }
+
+  //----------------------------------------------------------------------
   Spectrum::Spectrum(SpectrumLoaderBase& loader,
                      const HistAxis& xAxis,
                      const HistAxis& yAxis,
@@ -189,6 +213,38 @@ namespace ana
     Var multiDVar = Var2D(varx, binsx, vary, binsy);
 
     loader.AddSpectrum(*this, multiDVar, spillcut, cut, shift, wei);
+  }
+
+  //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& xLabel,
+		     const std::string& yLabel,
+		     SpectrumLoaderBase& loader,
+                     const Binning& binsx, const MultiVar& varx,
+                     const Binning& binsy, const MultiVar& vary,
+                     const SpillCut& spillcut,
+		     const Cut& cut,
+                     const SystShifts& shift,
+                     const Var& wei)
+    : Spectrum({xLabel, yLabel}, {binsx, binsy})
+  {
+    MultiVar multiDVar = MultiVar2D(varx, binsx, vary, binsy);
+
+    loader.AddSpectrum(*this, multiDVar, spillcut, cut, shift, wei);
+  }
+
+  //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& xLabel,
+		     const std::string& yLabel,
+		     SpectrumLoaderBase& loader,
+                     const Binning& binsx, const SpillMultiVar& varx,
+                     const Binning& binsy, const SpillMultiVar& vary,
+                     const SpillCut& spillcut,
+                     const SpillVar& wei)
+    : Spectrum({xLabel, yLabel}, {binsx, binsy})
+  {
+    SpillMultiVar multiDVar = MultiVar2D(varx, binsx, vary, binsy);
+
+    loader.AddSpectrum(*this, multiDVar, spillcut, wei);
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/Spectrum.cxx
+++ b/sbnana/CAFAna/Core/Spectrum.cxx
@@ -158,6 +158,17 @@ namespace ana
 
   //----------------------------------------------------------------------
   Spectrum::Spectrum(const std::string& label, SpectrumLoaderBase& loader,
+                     const Binning& binsx, const SpillVar& varx,
+                     const Binning& binsy, const SpillVar& vary,
+                     const SpillCut& spillcut,
+                     const SpillVar& wei)
+    : Spectrum(label, "", loader, binsx, varx, binsy, vary, spillcut, wei)
+  {
+    // TODO do we want this variant when there's one with a labelY just below?
+  }
+
+  //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& label, SpectrumLoaderBase& loader,
                      const Binning& binsx, const MultiVar& varx,
                      const Binning& binsy, const MultiVar& vary,
                      const SpillCut& spillcut,
@@ -213,6 +224,21 @@ namespace ana
     Var multiDVar = Var2D(varx, binsx, vary, binsy);
 
     loader.AddSpectrum(*this, multiDVar, spillcut, cut, shift, wei);
+  }
+
+  //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& xLabel,
+                     const std::string& yLabel,
+                     SpectrumLoaderBase& loader,
+                     const Binning& binsx, const SpillVar& varx,
+                     const Binning& binsy, const SpillVar& vary,
+                     const SpillCut& spillcut,
+                     const SpillVar& wei)
+    : Spectrum({xLabel, yLabel}, {binsx, binsy})
+  {
+    SpillVar multiDVar = Var2D(varx, binsx, vary, binsy);
+
+    loader.AddSpectrum(*this, multiDVar, spillcut, wei);
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/Spectrum.cxx
+++ b/sbnana/CAFAna/Core/Spectrum.cxx
@@ -161,7 +161,7 @@ namespace ana
                      const Binning& binsx, const MultiVar& varx,
                      const Binning& binsy, const MultiVar& vary,
                      const SpillCut& spillcut,
-		     const Cut& cut,
+                     const Cut& cut,
                      const SystShifts& shift,
                      const Var& wei)
     : Spectrum(label, "", loader, binsx, varx, binsy, vary, spillcut, cut, shift, wei)
@@ -200,8 +200,8 @@ namespace ana
 
   //----------------------------------------------------------------------
   Spectrum::Spectrum(const std::string& xLabel,
-		     const std::string& yLabel,
-		     SpectrumLoaderBase& loader,
+                     const std::string& yLabel,
+                     SpectrumLoaderBase& loader,
                      const Binning& binsx, const Var& varx,
                      const Binning& binsy, const Var& vary,
                      const SpillCut& spillcut,
@@ -217,12 +217,12 @@ namespace ana
 
   //----------------------------------------------------------------------
   Spectrum::Spectrum(const std::string& xLabel,
-		     const std::string& yLabel,
-		     SpectrumLoaderBase& loader,
+                     const std::string& yLabel,
+                     SpectrumLoaderBase& loader,
                      const Binning& binsx, const MultiVar& varx,
                      const Binning& binsy, const MultiVar& vary,
                      const SpillCut& spillcut,
-		     const Cut& cut,
+                     const Cut& cut,
                      const SystShifts& shift,
                      const Var& wei)
     : Spectrum({xLabel, yLabel}, {binsx, binsy})
@@ -234,8 +234,8 @@ namespace ana
 
   //----------------------------------------------------------------------
   Spectrum::Spectrum(const std::string& xLabel,
-		     const std::string& yLabel,
-		     SpectrumLoaderBase& loader,
+                     const std::string& yLabel,
+                     SpectrumLoaderBase& loader,
                      const Binning& binsx, const SpillMultiVar& varx,
                      const Binning& binsy, const SpillMultiVar& vary,
                      const SpillCut& spillcut,
@@ -256,7 +256,7 @@ namespace ana
                      const Cut& cut,
                      const SystShifts& shift,
                      const Var& wei,
-		     ESparse sparse)
+                     ESparse sparse)
     : Spectrum(label, "", "", loader, binsx, varx, binsy, vary, binsz, varz, spillcut, cut, shift, wei, sparse)
   {
     // TODO do we want this variant when there's one with a labelY and labelZ
@@ -265,9 +265,9 @@ namespace ana
 
   //----------------------------------------------------------------------
   Spectrum::Spectrum(const std::string& xLabel,
-		     const std::string& yLabel,
-		     const std::string& zLabel,
-		     SpectrumLoaderBase& loader,
+                     const std::string& yLabel,
+                     const std::string& zLabel,
+                     SpectrumLoaderBase& loader,
                      const Binning& binsx, const Var& varx,
                      const Binning& binsy, const Var& vary,
                      const Binning& binsz, const Var& varz,
@@ -275,7 +275,7 @@ namespace ana
                      const Cut& cut,
                      const SystShifts& shift,
                      const Var& wei,
-		     ESparse sparse)
+                     ESparse sparse)
     : Spectrum({xLabel, yLabel, zLabel}, {binsx, binsy, binsz}, sparse)
   {
     Var multiDVar = Var3D(varx, binsx, vary, binsy, varz, binsz);
@@ -292,7 +292,7 @@ namespace ana
                      const Cut& cut,
                      const SystShifts& shift,
                      const Var& wei,
-		     ESparse sparse)
+                     ESparse sparse)
     : Spectrum(xAxis.GetLabels()[0], loader,
                xAxis.GetBinnings()[0], xAxis.GetVars()[0],
                yAxis.GetBinnings()[0], yAxis.GetVars()[0],
@@ -448,7 +448,7 @@ namespace ana
       const double xmin = bins1D.Min();
       const double xmax = bins1D.Max();
       fHistSparse = new THnSparseD(UniqueName().c_str(), UniqueName().c_str(),
-				   1, &nbins, &xmin, &xmax);
+                                   1, &nbins, &xmin, &xmax);
 
       // Ensure errors get accumulated properly
       fHistSparse->Sumw2();
@@ -493,9 +493,9 @@ namespace ana
                       << "Did you mean to pass kLivetime to ToTH1()?";
           }
           std::cout << std::endl;
-	  //          abort();
-	  //	  fPOT = 1e18;
-	  ret->Scale(pot/1e18); //hack while we add spill tree
+          //          abort();
+          //      fPOT = 1e18;
+          ret->Scale(pot/1e18); //hack while we add spill tree
         }
       }
     }
@@ -646,7 +646,7 @@ namespace ana
 
   //----------------------------------------------------------------------
   double Spectrum::Integral(double exposure, double* err,
-			    EExposureType expotype) const
+                            EExposureType expotype) const
   {
     const double ratio = (expotype == kPOT) ? exposure/fPOT : exposure/fLivetime;
 
@@ -695,12 +695,12 @@ namespace ana
 
     if(ret.fHist){
       for(int i = 0; i < ret.fHist->GetNbinsX()+2; ++i){
-	ret.fHist->SetBinContent(i, rnd.Poisson(ret.fHist->GetBinContent(i)));
+        ret.fHist->SetBinContent(i, rnd.Poisson(ret.fHist->GetBinContent(i)));
       }
     }
     if(ret.fHistSparse){
       for(int i = 0; i < ret.fHistSparse->GetNbins(); ++i)
-	ret.fHistSparse->SetBinContent(i, rnd.Poisson(ret.fHistSparse->GetBinContent(i)));
+        ret.fHistSparse->SetBinContent(i, rnd.Poisson(ret.fHistSparse->GetBinContent(i)));
     }
 
     // Drop old errors, which are based on the MC statistics, and create new
@@ -719,9 +719,9 @@ namespace ana
     Spectrum ret = *this;
     if(fPOT > 0){
       if(ret.fHist)
-	ret.fHist->Scale(pot/fPOT);
+        ret.fHist->Scale(pot/fPOT);
       if(ret.fHistSparse)
-	ret.fHistSparse->Scale(pot/fPOT);
+        ret.fHistSparse->Scale(pot/fPOT);
     }
     if(fLivetime > 0) ret.fLivetime *= pot/fPOT;
     ret.fPOT = pot;

--- a/sbnana/CAFAna/Core/Spectrum.h
+++ b/sbnana/CAFAna/Core/Spectrum.h
@@ -2,6 +2,7 @@
 
 #include "sbnana/CAFAna/Core/Binning.h"
 #include "sbnana/CAFAna/Core/Var.h"
+#include "sbnana/CAFAna/Core/MultiVar.h"
 #include "sbnana/CAFAna/Core/Cut.h"
 #include "sbnana/CAFAna/Core/HistAxis.h"
 #include "sbnana/CAFAna/Core/SpectrumLoaderBase.h"
@@ -115,6 +116,22 @@ namespace ana
              const SystShifts& shift = kNoShift,
              const Var& wei = kUnweighted);
 
+    /// 2D Spectrum of two MultiVars
+    Spectrum(const std::string& label, SpectrumLoaderBase& loader,
+             const Binning& binsx, const MultiVar& varx,
+             const Binning& binsy, const MultiVar& vary,
+             const SpillCut& spillcut,
+	     const Cut& cut,
+             const SystShifts& shift = kNoShift,
+             const Var& wei = kUnweighted);
+
+    /// 2D Spectrum of two SpillMultiVars
+    Spectrum(const std::string& label, SpectrumLoaderBase& loader,
+             const Binning& binsx, const SpillMultiVar& varx,
+             const Binning& binsy, const SpillMultiVar& vary,
+             const SpillCut& spillcut,
+             const SpillVar& wei = kSpillUnweighted);
+
     /// 2D Spectrum taking 2 HistAxis
     Spectrum(SpectrumLoaderBase& loader,
              const HistAxis& xAxis,
@@ -133,6 +150,24 @@ namespace ana
 	     const Cut& cut,
 	     const SystShifts& shift = kNoShift,
 	     const Var& wei = kUnweighted);
+
+    Spectrum(const std::string& xLabel,
+	     const std::string& yLabel,
+	     SpectrumLoaderBase& loader,
+	     const Binning& binsx, const MultiVar& varx,
+	     const Binning& binsy, const MultiVar& vary,
+             const SpillCut& spillcut,
+	     const Cut& cut,
+             const SystShifts& shift = kNoShift,
+	     const Var& wei = kUnweighted);
+
+    Spectrum(const std::string& xLabel,
+	     const std::string& yLabel,
+	     SpectrumLoaderBase& loader,
+	     const Binning& binsx, const SpillMultiVar& varx,
+	     const Binning& binsy, const SpillMultiVar& vary,
+             const SpillCut& spillcut,
+	     const SpillVar& wei = kSpillUnweighted);
 
     /// 3D Spectrum of three Vars
     Spectrum(const std::string& label, SpectrumLoaderBase& loader,

--- a/sbnana/CAFAna/Core/Spectrum.h
+++ b/sbnana/CAFAna/Core/Spectrum.h
@@ -121,7 +121,7 @@ namespace ana
              const Binning& binsx, const MultiVar& varx,
              const Binning& binsy, const MultiVar& vary,
              const SpillCut& spillcut,
-	     const Cut& cut,
+             const Cut& cut,
              const SystShifts& shift = kNoShift,
              const Var& wei = kUnweighted);
 
@@ -142,32 +142,32 @@ namespace ana
              const Var& wei = kUnweighted);
 
     Spectrum(const std::string& xLabel,
-	     const std::string& yLabel,
-	     SpectrumLoaderBase& loader,
-	     const Binning& binsx, const Var& varx,
-	     const Binning& binsy, const Var& vary,
+             const std::string& yLabel,
+             SpectrumLoaderBase& loader,
+             const Binning& binsx, const Var& varx,
+             const Binning& binsy, const Var& vary,
              const SpillCut& spillcut,
-	     const Cut& cut,
-	     const SystShifts& shift = kNoShift,
-	     const Var& wei = kUnweighted);
-
-    Spectrum(const std::string& xLabel,
-	     const std::string& yLabel,
-	     SpectrumLoaderBase& loader,
-	     const Binning& binsx, const MultiVar& varx,
-	     const Binning& binsy, const MultiVar& vary,
-             const SpillCut& spillcut,
-	     const Cut& cut,
+             const Cut& cut,
              const SystShifts& shift = kNoShift,
-	     const Var& wei = kUnweighted);
+             const Var& wei = kUnweighted);
 
     Spectrum(const std::string& xLabel,
-	     const std::string& yLabel,
-	     SpectrumLoaderBase& loader,
-	     const Binning& binsx, const SpillMultiVar& varx,
-	     const Binning& binsy, const SpillMultiVar& vary,
+             const std::string& yLabel,
+             SpectrumLoaderBase& loader,
+             const Binning& binsx, const MultiVar& varx,
+             const Binning& binsy, const MultiVar& vary,
              const SpillCut& spillcut,
-	     const SpillVar& wei = kSpillUnweighted);
+             const Cut& cut,
+             const SystShifts& shift = kNoShift,
+             const Var& wei = kUnweighted);
+
+    Spectrum(const std::string& xLabel,
+             const std::string& yLabel,
+             SpectrumLoaderBase& loader,
+             const Binning& binsx, const SpillMultiVar& varx,
+             const Binning& binsy, const SpillMultiVar& vary,
+             const SpillCut& spillcut,
+             const SpillVar& wei = kSpillUnweighted);
 
     /// 3D Spectrum of three Vars
     Spectrum(const std::string& label, SpectrumLoaderBase& loader,
@@ -178,12 +178,12 @@ namespace ana
              const Cut& cut,
              const SystShifts& shift = kNoShift,
              const Var& wei = kUnweighted,
-	     ESparse sparse = kDense);
+             ESparse sparse = kDense);
 
     Spectrum(const std::string& xLabel,
-	     const std::string& yLabel,
-	     const std::string& zLabel,
-	     SpectrumLoaderBase& loader,
+             const std::string& yLabel,
+             const std::string& zLabel,
+             SpectrumLoaderBase& loader,
              const Binning& binsx, const Var& varx,
              const Binning& binsy, const Var& vary,
              const Binning& binsz, const Var& varz,
@@ -191,18 +191,18 @@ namespace ana
              const Cut& cut,
              const SystShifts& shift = kNoShift,
              const Var& wei = kUnweighted,
-	     ESparse sparse = kDense);
+             ESparse sparse = kDense);
 
     /// 3D Spectrum taking 3 HistAxis
     Spectrum(SpectrumLoaderBase& loader,
              const HistAxis& xAxis,
              const HistAxis& yAxis,
-	     const HistAxis& zAxis,
+             const HistAxis& zAxis,
              const SpillCut& spillcut,
              const Cut& cut,
              const SystShifts& shift = kNoShift,
              const Var& wei = kUnweighted,
-	     ESparse sparse = kDense);
+             ESparse sparse = kDense);
 
 
     virtual ~Spectrum();
@@ -239,13 +239,13 @@ namespace ana
 
     /// Spectrum must be 2D to obtain TH2
     TH2*  ToTH2     (double exposure, EExposureType expotype = kPOT,
-		     EBinType bintype = kBinContent) const;
+                     EBinType bintype = kBinContent) const;
     /// Spectrum must be 2D to obtain TH2. Normalized to X axis.
     TH2*  ToTH2NormX(double exposure, EExposureType expotype = kPOT) const;
 
     /// Spectrum must be 3D to obtain TH3
     TH3*  ToTH3     (double exposure, EExposureType expotype = kPOT,
-		     EBinType bintype = kBinContent) const;
+                     EBinType bintype = kBinContent) const;
 
     /// Function decides what is the appropriate projection based on fBins, and does that
     TH1*  ToTHX     (double exposure, bool force1D = false, EExposureType expotype = kPOT) const;
@@ -256,7 +256,7 @@ namespace ana
     /// \param err      The statistical error on this total (optional)
     /// \param expotype What the first parameter represents
     double Integral(double exposure, double* err = 0,
-		    EExposureType expotype = kPOT) const;
+                    EExposureType expotype = kPOT) const;
 
     /// \brief Return mean of 1D histogram
     double Mean() const;

--- a/sbnana/CAFAna/Core/Spectrum.h
+++ b/sbnana/CAFAna/Core/Spectrum.h
@@ -116,6 +116,13 @@ namespace ana
              const SystShifts& shift = kNoShift,
              const Var& wei = kUnweighted);
 
+    /// 2D Spectrum of two SpillVars
+    Spectrum(const std::string& label, SpectrumLoaderBase& loader,
+             const Binning& binsx, const SpillVar& varx,
+             const Binning& binsy, const SpillVar& vary,
+             const SpillCut& spillcut,
+             const SpillVar& wei = kSpillUnweighted);
+
     /// 2D Spectrum of two MultiVars
     Spectrum(const std::string& label, SpectrumLoaderBase& loader,
              const Binning& binsx, const MultiVar& varx,
@@ -150,6 +157,14 @@ namespace ana
              const Cut& cut,
              const SystShifts& shift = kNoShift,
              const Var& wei = kUnweighted);
+
+    Spectrum(const std::string& xLabel,
+             const std::string& yLabel,
+             SpectrumLoaderBase& loader,
+             const Binning& binsx, const SpillVar& varx,
+             const Binning& binsy, const SpillVar& vary,
+             const SpillCut& spillcut,
+             const SpillVar& wei = kSpillUnweighted);
 
     Spectrum(const std::string& xLabel,
              const std::string& yLabel,

--- a/sbnana/CAFAna/Core/Utilities.cxx
+++ b/sbnana/CAFAna/Core/Utilities.cxx
@@ -431,7 +431,7 @@ namespace ana
     // Make sure it's compatible with having been made with this binning
     assert(h1->GetNbinsX() == binsx.NBins()*binsy.NBins());
 
-    TH2* ret = MakeTH2D("", UniqueName().c_str(), binsx, binsy);
+    TH2* ret = MakeTH2D(UniqueName().c_str(), "", binsx, binsy);
 
     for(int i = 0; i < h1->GetNbinsX(); ++i){
       const double val = h1->GetBinContent(i+1);


### PR DESCRIPTION
I noticed while trying to make a plot recently that there is no support for 2D plots using `SpillVar`, `MultiVar` or `SpillMultiVar`. This PR utilises the current infrastructure for `Var`s to allow for the creation of spectrums of such types.

I also noticed that the function in Utilities that converts the Spectrum to a TH2 has the title and name fields inverted, I have corrected this.

Below is an example of a dE/dx residual range curve for contained muons created using the SpillMutliVar functionality.
![dEdx_ResRange_ContainedMuons](https://user-images.githubusercontent.com/68423730/163384604-a3de7398-207d-4796-b550-34b7bc706e6b.png)


