### PR TITLE
Add demo for using CRUMBS in the CAF framework

### DIFF
--- a/sbnana/SBNAna/anademo/CRUMBS_demo/CRUMBS_demo.C
+++ b/sbnana/SBNAna/anademo/CRUMBS_demo/CRUMBS_demo.C
@@ -1,0 +1,53 @@
+#include "sbnana/CAFAna/Core/Spectrum.h"
+#include "sbnana/CAFAna/Core/SpectrumLoader.h"
+#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
+
+using namespace ana;
+
+#include "CRUMBS_helper.h"
+#include "TCanvas.h"
+#include "TH1D.h"
+
+void CRUMBS_demo()
+{
+  const std::string inputFile = "./example.flat.caf.root";
+
+  SpectrumLoader loader(inputFile);
+
+  const double gPOT = 6.6e20;
+  const Binning binsCRUMBSScore = Binning::Simple(20,-1,1);
+  const Binning binsSliceNTracks = Binning::Simple(10,0,10);
+
+  Spectrum specCRUMBSScore = Spectrum("CRUMBS Score", binsCRUMBSScore, loader, kCRUMBSScore, kNoSpillCut, kNonUnambiguousSlice);
+  Spectrum specBestCRUMBSScore = Spectrum("Best CRUMBS Score", binsCRUMBSScore, loader, kBestCRUMBSScore, kHasNonUnambiguousSlice);
+  Spectrum specBestCRUMBSSliceNTracks = Spectrum("# Tracks", binsSliceNTracks, loader, kBestCRUMBSSliceNTracks, kHasNonUnambiguousSlice && kBestCRUMBSSliceCut);
+
+  loader.Go();
+
+  TCanvas *canCRUMBSScore = new TCanvas("canCRUMBSScore","canCRUMBSScore");
+  canCRUMBSScore->cd();
+
+  TH1D* histCRUMBSScore = specCRUMBSScore.ToTH1(gPOT);
+  histCRUMBSScore->SetLineWidth(4);
+  histCRUMBSScore->SetLineColor(kMagenta+2);
+  histCRUMBSScore->Draw("hist");
+
+  TCanvas *canBestCRUMBSScore = new TCanvas("canBestCRUMBSScore","canBestCRUMBSScore");
+  canBestCRUMBSScore->cd();
+
+  TH1D* histBestCRUMBSScore = specBestCRUMBSScore.ToTH1(gPOT);
+  histBestCRUMBSScore->SetLineWidth(4);
+  histBestCRUMBSScore->SetLineColor(kMagenta+2);
+  histBestCRUMBSScore->Draw("hist");
+
+  TCanvas *canBestCRUMBSSliceNTracks = new TCanvas("canBestCRUMBSSliceNTracks","canBestCRUMBSSliceNTracks");
+  canBestCRUMBSSliceNTracks->cd();
+
+  TH1D* histBestCRUMBSSliceNTracks = specBestCRUMBSSliceNTracks.ToTH1(gPOT);
+  histBestCRUMBSSliceNTracks->SetLineWidth(4);
+  histBestCRUMBSSliceNTracks->SetLineColor(kMagenta+2);
+  histBestCRUMBSSliceNTracks->Draw("hist");
+}
+  
+
+  

--- a/sbnana/SBNAna/anademo/CRUMBS_demo/CRUMBS_helper.h
+++ b/sbnana/SBNAna/anademo/CRUMBS_demo/CRUMBS_helper.h
@@ -1,0 +1,70 @@
+const Cut kNonUnambiguousSlice([](const caf::SRSliceProxy *slc)
+     {
+       return !slc->is_clear_cosmic;
+     });
+
+const SpillCut kHasNonUnambiguousSlice([](const caf::SRSpillProxy *sr)
+     {
+       bool hasNonUnam = false;
+       for(auto const &slc : sr->slc)
+	 {
+	   hasNonUnam |= !slc.is_clear_cosmic;
+	 }
+
+       return hasNonUnam;
+     });
+
+const Var kCRUMBSScore = SIMPLEVAR(crumbs_result.score);
+
+const SpillVar kBestCRUMBSScore([](const caf::SRSpillProxy *sr) -> double
+     {
+       double bestValue = -std::numeric_limits<double>::max();
+       
+       for(auto const &slc : sr->slc)
+	 {
+	   if(!slc.is_clear_cosmic)
+	     {
+	       if(slc.crumbs_result.score > bestValue)
+		 bestValue = slc.crumbs_result.score;
+	     }
+	 }
+       
+       return bestValue;
+     });
+
+const SpillVar kBestCRUMBSSliceID([](const caf::SRSpillProxy *sr) -> double
+     {
+       unsigned id      = 0;
+       unsigned bestId  = std::numeric_limits<unsigned>::max();
+       double bestValue = -std::numeric_limits<double>::max();
+
+       for(auto const &slc : sr->slc)
+	 {
+	   if(!slc.is_clear_cosmic)
+	     {
+	       if(slc.crumbs_result.score > bestValue)
+		 {
+		   bestValue = slc.crumbs_result.score;
+		   bestId    = id;
+		 }
+	     }
+	   ++id;
+	 }
+
+       return bestId;
+     });
+
+const SpillVar kBestCRUMBSSliceNTracks([](const caf::SRSpillProxy *sr) -> float
+     {
+       return sr->slc[kBestCRUMBSSliceID(sr)].reco.ntrk;
+     });
+
+const Cut kCRUMBSCut([](const caf::SRSliceProxy *slc)
+     {
+       return slc->crumbs_result.score > -0.05;
+     });
+
+const SpillCut kBestCRUMBSSliceCut([](const caf::SRSpillProxy *sr)
+     {
+       return sr->slc[kBestCRUMBSSliceID(sr)].crumbs_result.score > -0.05;
+     });


### PR DESCRIPTION
Whilst writing a technote for CRUMBS I have also been producing a couple of tutorial / how-to guide sections. One of these describes harnessing the CRUMBS score in CAFAna Cuts and Vars. I thought it would be useful to provide a header file and plotting script (that are described in the technote) as a mini-demo.

These aren't meant to be exactly the Cuts / Vars that someone would use in their analysis but along with the description in the note they should help people set up their own cuts using CRUMBS.