### PR TITLE
Feature/jlarkin nuedisappearance

### DIFF
--- a/sbnana/CAFAna/Core/OscCalcSterileApprox.h
+++ b/sbnana/CAFAna/Core/OscCalcSterileApprox.h
@@ -4,6 +4,13 @@
 
 namespace ana
 {
+  enum class SterileOscAngles {
+    kNone = 0,
+    kSinSq2ThetaMuMu = 1,
+    kSinSq2ThetaMuE  = (1 << 1),
+    kSinSq2ThetaEE   = (1 << 2)
+  };
+  
   class OscCalcSterileApprox: public osc::IOscCalc
   {
   public:
@@ -20,13 +27,14 @@ namespace ana
     void SetDmsq(double d) {fDmsq = d;}
     double GetDmsq() const {return fDmsq;}
 
-    void SetSinSq2ThetaMuMu(double t) {fSinSq2ThetaMuMu = t;}
-    double GetSinSq2ThetaMuMu() const {return fSinSq2ThetaMuMu;}
+    void SetSinSq2ThetaMuMu(double t);
+    double GetSinSq2ThetaMuMu() const;
 
-    void SetSinSq2ThetaMuE(double t) {fSinSq2ThetaMuE = t;}
-    double GetSinSq2ThetaMuE() const {return fSinSq2ThetaMuE;}
+    void SetSinSq2ThetaMuE(double t);
+    double GetSinSq2ThetaMuE() const;
 
-    double GetSinSq2ThetaEE() const; ///< calculated from the others
+    void SetSinSq2ThetaEE(double t);
+    double GetSinSq2ThetaEE() const;
 
     // TODO - potentially remove L in the brave new L/E future
     void SetL(double L) {fL = L;}
@@ -39,6 +47,10 @@ namespace ana
     double fDmsq;
     double fSinSq2ThetaMuMu;
     double fSinSq2ThetaMuE;
+    double fSinSq2ThetaEE;
+    bool   fSinSq2ThetaMuMuSet = false;
+    bool   fSinSq2ThetaMuESet  = false;
+    bool   fSinSq2ThetaEESet   = false;
     double fL;
   };
 
@@ -75,7 +87,21 @@ namespace ana
     TMD5* GetParamsHash() const override {return calc.GetParamsHash();}
   };
 
-  OscCalcSterileApproxAdjustable* DefaultSterileApproxCalc();
+  inline SterileOscAngles operator|(const SterileOscAngles a, const SterileOscAngles b)
+  {
+    int a_int = static_cast<int>(a);
+    int b_int = static_cast<int>(b);
+    return static_cast<SterileOscAngles>(a_int | b_int);
+  }
+
+  inline SterileOscAngles operator&(const SterileOscAngles a, const SterileOscAngles b)
+  {
+    int a_int = static_cast<int>(a);
+    int b_int = static_cast<int>(b);
+    return static_cast<SterileOscAngles>(a_int & b_int);
+  }
+
+  OscCalcSterileApproxAdjustable* DefaultSterileApproxCalc(SterileOscAngles angles = SterileOscAngles::kSinSq2ThetaMuMu | SterileOscAngles::kSinSq2ThetaMuE);
 
   const OscCalcSterileApprox* DowncastToSterileApprox(const osc::IOscCalc* calc, bool allowFail = false);
   OscCalcSterileApprox* DowncastToSterileApprox(osc::IOscCalc* calc, bool allowFail = false);

--- a/sbnana/CAFAna/Vars/FitVarsSterileApprox.cxx
+++ b/sbnana/CAFAna/Vars/FitVarsSterileApprox.cxx
@@ -39,4 +39,16 @@ namespace ana
   {
     DowncastToSterileApprox(osc)->SetSinSq2ThetaMuE(Clamp(val));
   }
+
+  // --------------------------------------------------------------------------
+  double FitSinSq2ThetaEE::GetValue(const osc::IOscCalcAdjustable* osc) const
+  {
+    return DowncastToSterileApprox(osc)->GetSinSq2ThetaEE();
+  }
+
+  // --------------------------------------------------------------------------
+  void FitSinSq2ThetaEE::SetValue(osc::IOscCalcAdjustable* osc, double val) const
+  {
+    DowncastToSterileApprox(osc)->SetSinSq2ThetaEE(Clamp(val));
+  }
 }

--- a/sbnana/CAFAna/Vars/FitVarsSterileApprox.h
+++ b/sbnana/CAFAna/Vars/FitVarsSterileApprox.h
@@ -58,4 +58,22 @@ namespace ana
   /// \f$ \sin^22\theta_{\mu e} \f$
   const FitSinSq2ThetaMuE kFitSinSq2ThetaMuE = FitSinSq2ThetaMuE();
 
+  //----------------------------------------------------------------------
+  
+  /// \f$ \sin^22\theta_{e e} \f$
+  class FitSinSq2ThetaEE: public IConstrainedFitVar
+  {
+  public:
+    virtual double GetValue(const osc::IOscCalcAdjustable* osc) const;
+    virtual void SetValue(osc::IOscCalcAdjustable* osc, double val) const;
+    virtual std::string ShortName() const {return "ss2thee";}
+    virtual std::string LatexName() const {return "sin^{2}2#theta_{ee}";}
+
+    virtual double LowLimit() const {return 0;}
+    virtual double HighLimit() const {return 1;}
+  };
+
+  /// \f$ \sin^22\theta_{e e} \f$
+  const FitSinSq2ThetaEE kFitSinSq2ThetaEE = FitSinSq2ThetaEE();
+
 } // namespace


### PR DESCRIPTION
Modify OscCalcSterileApprox to allow choosing which 2 angles to use.
Needed for nue disappearance only fits, and joint numu & nue fits with sinsq2thee on one axis of the surface.

This works on the old version of CAFAna (pre-CAF) and was tested by comparing with other fitters, but I never committed the changes to the Github repo.
There are changes in the spectra in the current CAFs compared to those old files so it can't be directly compared, but the nue disappearance only fit and osc/unosc ratio look similar.