### PR TITLE
Feature/rh incremental loader

### DIFF
--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -225,6 +225,15 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  unsigned int SpectrumLoader::Nevents()
+  {
+    TFile* f = GetNextFile();
+    TTree* tr = (TTree*)f->Get("recTree");
+
+    return tr->GetEntries();
+  }
+
+  //----------------------------------------------------------------------
   /// Helper for \ref HandleRecord
   template<class T, class U, class V> class CutVarCache
   {

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -154,7 +154,7 @@ namespace ana
       delete prog;
     }
 
-    StoreExposures(); // also triggers the POT printout
+    // StoreExposures(); // also triggers the POT printout
 
     fHistDefs.RemoveLoader(this);
     fHistDefs.Clear();
@@ -214,7 +214,7 @@ namespace ana
     long Nentries = tr->GetEntries();
     if (max_entries != 0 && max_entries < Nentries) Nentries = max_entries;
 
-    tr->LoadTree(N);
+    tr->LoadTree(N); // Only want a specific event from the TTree
 
     // If there is no husk field there is no concept of husk events
     if(!has_husk) sr.hdr.husk = false;

--- a/sbnana/CAFAna/Core/SpectrumLoader.h
+++ b/sbnana/CAFAna/Core/SpectrumLoader.h
@@ -30,6 +30,7 @@ namespace ana
 
     virtual void Go() override;
     virtual void Select(unsigned int N = 0);
+    unsigned int Nevents();
 
   protected:
     SpectrumLoader(DataSource src = kBeam);

--- a/sbnana/CAFAna/Core/SpectrumLoader.h
+++ b/sbnana/CAFAna/Core/SpectrumLoader.h
@@ -29,6 +29,7 @@ namespace ana
     virtual ~SpectrumLoader();
 
     virtual void Go() override;
+    virtual void Select(unsigned int N = 0);
 
   protected:
     SpectrumLoader(DataSource src = kBeam);
@@ -42,6 +43,7 @@ namespace ana
     SpectrumLoader& operator=(const SpectrumLoader&) = delete;
 
     virtual void HandleFile(TFile* f, Progress* prog = 0);
+    virtual void HandleFile(TFile* f, Progress* prog, unsigned int N);
 
     virtual void HandleRecord(caf::SRSpillProxy* sr);
 


### PR DESCRIPTION
I added an alternative `SpectrumLoader::Go()` method called `SpectrumLoader::Select(unsigned int N)` that grabs a single spill from the CAF files by index value of `N`. This would be very useful for my caf based event display so I could grab one event at a time without storing all the information in terribly long nested vectors. I also added an overload for `SpectrumLoader::HandleFile` to perform this specific action when the event index `N` is passed to it. 
I think this would also be a useful addition in general, though I can't think of other uses besides event displays.