### PR TITLE
Feature/rh incremental loader

### DIFF
--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -225,6 +225,15 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  unsigned int SpectrumLoader::Nevents()
+  {
+    TFile* f = GetNextFile();
+    TTree* tr = (TTree*)f->Get("recTree");
+
+    return tr->GetEntries();
+  }
+
+  //----------------------------------------------------------------------
   /// Helper for \ref HandleRecord
   template<class T, class U, class V> class CutVarCache
   {

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -154,7 +154,7 @@ namespace ana
       delete prog;
     }
 
-    StoreExposures(); // also triggers the POT printout
+    // StoreExposures(); // also triggers the POT printout
 
     fHistDefs.RemoveLoader(this);
     fHistDefs.Clear();
@@ -214,7 +214,7 @@ namespace ana
     long Nentries = tr->GetEntries();
     if (max_entries != 0 && max_entries < Nentries) Nentries = max_entries;
 
-    tr->LoadTree(N);
+    tr->LoadTree(N); // Only want a specific event from the TTree
 
     // If there is no husk field there is no concept of husk events
     if(!has_husk) sr.hdr.husk = false;

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -211,17 +211,12 @@ namespace ana
 
     //    FloatingExceptionOnNaN fpnan;
 
-    long Nentries = tr->GetEntries();
-    if (max_entries != 0 && max_entries < Nentries) Nentries = max_entries;
-
     tr->LoadTree(N); // Only want a specific event from the TTree
 
     // If there is no husk field there is no concept of husk events
     if(!has_husk) sr.hdr.husk = false;
 
     HandleRecord(&sr);
-
-    if(prog) prog->SetProgress(double(N)/Nentries);
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/SpectrumLoader.h
+++ b/sbnana/CAFAna/Core/SpectrumLoader.h
@@ -30,6 +30,7 @@ namespace ana
 
     virtual void Go() override;
     virtual void Select(unsigned int N = 0);
+    unsigned int Nevents();
 
   protected:
     SpectrumLoader(DataSource src = kBeam);

--- a/sbnana/CAFAna/Core/SpectrumLoader.h
+++ b/sbnana/CAFAna/Core/SpectrumLoader.h
@@ -29,6 +29,7 @@ namespace ana
     virtual ~SpectrumLoader();
 
     virtual void Go() override;
+    virtual void Select(unsigned int N = 0);
 
   protected:
     SpectrumLoader(DataSource src = kBeam);
@@ -42,6 +43,7 @@ namespace ana
     SpectrumLoader& operator=(const SpectrumLoader&) = delete;
 
     virtual void HandleFile(TFile* f, Progress* prog = 0);
+    virtual void HandleFile(TFile* f, Progress* prog, unsigned int N);
 
     virtual void HandleRecord(caf::SRSpillProxy* sr);
 


### PR DESCRIPTION
Reopening this Pull Request. I added a different way of accessing the recoTree one spill at a time with `SpectrumLoader::Select(unsigned int N)` which grabs the Nth spill. This accesses an overloaded `SpectrumLoader::HandleFile` by passing the Nth spill to load. Also adds a SpectrumLoader method that retrieves the number of spills in the CAF files being loaded in.