### PR TITLE
Updates with OscLib v00.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 
 find_package(cetmodules )
-project(sbnana VERSION 09.69.01 LANGUAGES CXX)
+project(sbnana VERSION 09.73.00 LANGUAGES CXX)
 
 # cetbuildtools contains our cmake modules
 

--- a/sbnana/CAFAna/Core/OscCalcSterileApprox.cxx
+++ b/sbnana/CAFAna/Core/OscCalcSterileApprox.cxx
@@ -2,6 +2,7 @@
 
 #include "sbnana/CAFAna/Core/MathUtil.h"
 
+#include "TMD5.h"
 #include "TMath.h"
 
 #include "Math/SpecFunc.h"

--- a/sbnana/CAFAna/Core/OscCalcSterileApprox.cxx
+++ b/sbnana/CAFAna/Core/OscCalcSterileApprox.cxx
@@ -270,6 +270,24 @@ namespace ana
   }
 
   //---------------------------------------------------------------------------
+  void OscCalcSterileApprox::Print(const std::string& prefix) const
+  {
+    std::cout << prefix << "sin^2(2 ThetaMuMu) = ";
+    if (fSinSq2ThetaMuMuSet) std::cout << fSinSq2ThetaMuMu;
+    else                     std::cout << "not set";
+
+    std::cout << '\n' << prefix << "sin^2(2 ThetaMuE) = ";
+    if (fSinSq2ThetaMuESet) std::cout << fSinSq2ThetaMuE;
+    else                    std::cout << "not set";
+
+    std::cout << '\n'  << prefix << "sin^2(2 ThetaEE) = ";
+    if (fSinSq2ThetaEESet) std::cout << fSinSq2ThetaEE;
+    else                   std::cout << "not set";
+
+    std::cout << '\n' << prefix << "L = " << fL << " km" << std::endl;
+  }
+
+  //---------------------------------------------------------------------------
   TMD5* OscCalcSterileApprox::GetParamsHash() const
   {
     TMD5* ret = new TMD5;

--- a/sbnana/CAFAna/Core/OscCalcSterileApprox.h
+++ b/sbnana/CAFAna/Core/OscCalcSterileApprox.h
@@ -24,6 +24,8 @@ namespace ana
 
     virtual OscCalcSterileApprox* Copy() const override;
 
+    virtual void Print(const std::string& prefix = "") const override;
+
     void SetDmsq(double d) {fDmsq = d;}
     double GetDmsq() const {return fDmsq;}
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -252,9 +252,9 @@ libdir	fq_dir		lib
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-ifdhc		v2_6_18		-
-osclib		v00.17		-
-sbnanaobj	v09_20_05	-
+ifdhc		v2_6_19 	-
+osclib		v00.20		-
+sbnanaobj	v09_20_07	-
 sbndata		v01_04		-
 cetmodules	v3_20_00	-	only_for_build
 end_product_list
@@ -312,10 +312,10 @@ end_product_list
 #
 ####################################
 qualifier	sbnanaobj	ifdhc		osclib			sbndata	notes
-c7:debug	c7:debug	c7:p392:debug	c7:n309:stanfree:debug	-nq-	-nq-
-c7:prof		c7:prof		c7:p392:prof	c7:n309:stanfree:prof	-nq-	-nq-
-e20:debug	e20:debug	e20:p392:debug	e20:n309:stanfree:debug	-nq-	-nq-
-e20:prof	e20:prof	e20:p392:prof	e20:n309:stanfree:prof	-nq-	-nq-
+c7:debug	c7:debug	c7:p392:debug	c7:debug:n311:stanfree	-nq-	-nq-
+c7:prof		c7:prof		c7:p392:prof	c7:n311:prof:stanfree	-nq-	-nq-
+e20:debug	e20:debug	e20:p392:debug	debug:e20:n311:stanfree	-nq-	-nq-
+e20:prof	e20:prof	e20:p392:prof	e20:n311:prof:stanfree	-nq-	-nq-
 end_qualifier_list
 ####################################
 


### PR DESCRIPTION
One interface in OscLib was changed by the addition of an abstract function `Print()` to print the current settings on screen/console.
I have made up one for the one class in `sbnana` that implements that interface.

Compiled with GCC (`e20`) only.