### PR TITLE
Bug fixes and Missing Systematics for Oscillation Fits

### DIFF
--- a/sbnana/CAFAna/Analysis/Surface.cxx
+++ b/sbnana/CAFAna/Analysis/Surface.cxx
@@ -580,13 +580,14 @@ namespace ana
       it->Write( TString::Format("hist%d", idx++));
     }
 
+    dir->cd();
+
     if(!fBinMask.empty()){
       const std::vector<double> tmp(fBinMask.begin(), fBinMask.end());
       TVectorD m(tmp.size(), &tmp[0]);
       m.Write("mask");
     }
 
-    dir->cd();
     TObjString(fLogX ? "yes" : "no").Write("logx");
     TObjString(fLogY ? "yes" : "no").Write("logy");
 
@@ -639,6 +640,8 @@ namespace ana
   std::unique_ptr<Surface> Surface::
   LoadFromMulti(const std::vector<TFile*>& files, const std::string& label)
   {
+    DontAddDirectory guard;
+
     std::vector<std::unique_ptr<Surface>> surfs;
     for(TFile* f: files) {
       surfs.push_back(Surface::LoadFrom(f->GetDirectory(label.c_str())));

--- a/sbnana/CAFAna/Core/Binning.h
+++ b/sbnana/CAFAna/Core/Binning.h
@@ -71,5 +71,5 @@ namespace ana
   const Binning kTrueEnergyBins = TrueEnergyBins();
 
   // 2km/GeV is the empirical largest L/E at Icarus
-  const Binning kTrueLOverEBins = Binning::Simple(100, 0, 2);
+  const Binning kTrueLOverEBins = Binning::Simple(200, 0, 2);
 }

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -61,6 +61,79 @@ namespace ana {
    
   }
 
+  void RecoEnergyScaleSyst::Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const
+  {
+    //auto& det = sr->truth.det;
+    bool all = (detector == EnergyScaleSystDetector::kAll);
+    // We'd like to use these, but sr->truth.det doesn't seem to be working correctly right now
+    //bool nd = (detector == EnergyScaleSystDetector::kSBND && det == caf::kSBND);
+    //bool ub = (detector == EnergyScaleSystDetector::kMicroBooNE && det != caf::kSBND && det != caf::kICARUS);
+    //bool fd = (detector == EnergyScaleSystDetector::kICARUS && det == caf::kICARUS);
+    bool nd = (detector == EnergyScaleSystDetector::kSBND && sr->truth.baseline < 120);
+    bool ub = (detector == EnergyScaleSystDetector::kMicroBooNE && sr->truth.baseline > 120 && sr->truth.baseline < 500);
+    bool fd = (detector == EnergyScaleSystDetector::kSBND && sr->truth.baseline > 500);
+    bool detector_cut = all || nd || ub || fd;
+    if(!sr->truth.iscc || abs(sr->truth.pdg) != 14 || isnan(sr->fake_reco.nuE) || !detector_cut) 
+      return ;
+
+    for(auto& pfp: sr->reco.pfp) {
+      if(pfp.trackScore < 0.5) continue;
+      auto& trk = pfp.trk;
+      if(part == EnergyScaleSystParticle::kMuon) {
+        double scaleRange = sigma*uncertainty;
+        double scaleMCS = sigma*uncertainty;
+        switch(term) {
+        case EnergyScaleSystTerm::kConstant:
+          break;
+        case EnergyScaleSystTerm::kSqrt:
+          scaleRange *= std::sqrt(trk.rangeP.p_muon);
+          if(!std::isnan(trk.mcsP.fwdP_muon))
+            scaleMCS *= std::sqrt(trk.mcsP.fwdP_muon);
+          break;
+        case EnergyScaleSystTerm::kInverseSqrt:
+          scaleRange /= std::sqrt(trk.rangeP.p_muon + 0.1);
+          if(!std::isnan(trk.mcsP.fwdP_muon))
+            scaleMCS /= std::sqrt(trk.mcsP.fwdP_muon + 0.1);
+          break;
+        }
+        trk.rangeP.p_muon *= (1+scaleRange);
+        if(!std::isnan(trk.mcsP.fwdP_muon))
+          trk.mcsP.fwdP_muon *= (1+scaleMCS);
+       } else if(part == EnergyScaleSystParticle::kHadron) {
+        double scaleRangeP = sigma*uncertainty;
+        double scaleMCSP = sigma*uncertainty;
+        double scaleRangePi = sigma*uncertainty;
+        double scaleMCSPi = sigma*uncertainty;
+        switch(term) {
+        case EnergyScaleSystTerm::kConstant:
+          break;
+        case EnergyScaleSystTerm::kSqrt:
+          scaleRangeP *= std::sqrt(trk.rangeP.p_proton);
+          if(!std::isnan(trk.mcsP.fwdP_proton))
+            scaleMCSP *= std::sqrt(trk.mcsP.fwdP_proton);
+          scaleRangePi *= std::sqrt(trk.rangeP.p_pion);
+          if(!std::isnan(trk.mcsP.fwdP_pion))
+            scaleMCSPi *= std::sqrt(trk.mcsP.fwdP_pion);
+          break;
+        case EnergyScaleSystTerm::kInverseSqrt:
+          scaleRangeP /= std::sqrt(trk.rangeP.p_proton + 0.1);
+          if(!std::isnan(trk.mcsP.fwdP_proton))
+            scaleMCSP /= std::sqrt(trk.mcsP.fwdP_proton + 0.1);
+          scaleRangePi /= std::sqrt(trk.rangeP.p_pion + 0.1);
+          if(!std::isnan(trk.mcsP.fwdP_pion))
+            scaleMCSPi /= std::sqrt(trk.mcsP.fwdP_pion + 0.1);
+          break;
+        }
+        trk.rangeP.p_proton *= (1+scaleRangeP);
+        if(!std::isnan(trk.mcsP.fwdP_proton))
+          trk.mcsP.fwdP_proton *= (1+scaleMCSP);
+        trk.rangeP.p_pion *= (1+scaleRangePi);
+        if(!std::isnan(trk.mcsP.fwdP_pion))
+          trk.mcsP.fwdP_pion *= (1+scaleMCSPi);
+      }
+    }
+  }
+
    const EnergyScaleSyst kEnergyScaleMuon(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuon", "Correlated linear E_{#mu} scale");
    const EnergyScaleSyst kEnergyScaleMuonSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonSqrt", "Correlated sqrt E_{#mu} scale");
    const EnergyScaleSyst kEnergyScaleMuonInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonInvSqrt", "Correlated inv sqrt E_{#mu} scale");
@@ -124,6 +197,38 @@ namespace ana {
    const EnergyScaleSyst kEnergyScaleHadronFDBig(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronFDBig", "Uncorrelated ICARUS linear E_{had} scale");
    const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronSqrtFDBig", "Uncorrelated ICARUS sqrt E_{had} scale");
    const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.10, "EnergyScaleHadronInvSqrtFDBig", "Uncorrelated ICARUS inv sqrt E_{had} scale");
+
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuon(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuon", "Correlated linear E_{#mu} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonSqrt", "Correlated sqrt E_{#mu} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuonInvSqrt", "Correlated inv sqrt E_{#mu} scale");
+
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonND", "Uncorrelated SBND linear E_{#mu} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonSqrtND", "Uncorrelated SBND sqrt E_{#mu} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kSBND, 0.02, "EnergyScaleMuonInvSqrtND", "Uncorrelated SBND inv sqrt E_{#mu} scale");
+
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonUB", "Uncorrelated MicroBooNE linear E_{#mu} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonSqrtUB", "Uncorrelated MicroBooNE sqrt E_{#mu} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kMicroBooNE, 0.02, "EnergyScaleMuonInvSqrtUB", "Uncorrelated MicroBooNE inv sqrt E_{#mu} scale");
+
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonFD", "Uncorrelated ICARUS linear E_{#mu} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonSqrtFD", "Uncorrelated ICARUS sqrt E_{#mu} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleMuonInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kICARUS, 0.02, "EnergyScaleMuonInvSqrtFD", "Uncorrelated ICARUS inv sqrt E_{#mu} scale");
+
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadron(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadron", "Correlated linear E_{had} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronSqrt(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronSqrt", "Correlated sqrt E_{had} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronInvSqrt(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kAll, 0.05, "EnergyScaleHadronInvSqrt", "Correlated inv sqrt E_{had} scale");
+
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronND(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronND", "Uncorrelated SBND linear E_{had} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronSqrtND(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronSqrtND", "Uncorrelated SBND sqrt E_{had} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronInvSqrtND(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kSBND, 0.05, "EnergyScaleHadronInvSqrtND", "Uncorrelated SBND inv sqrt E_{had} scale");
+
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronUB(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronUB", "Uncorrelated MicroBooNE linear E_{had} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronSqrtUB(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronSqrtUB", "Uncorrelated MicroBooNE sqrt E_{had} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronInvSqrtUB(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kMicroBooNE, 0.05, "EnergyScaleHadronInvSqrtUB", "Uncorrelated MicroBooNE inv sqrt E_{had} scale");
+
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronFD(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronFD", "Uncorrelated ICARUS linear E_{had} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronSqrtFD(EnergyScaleSystTerm::kSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronSqrtFD", "Uncorrelated ICARUS sqrt E_{had} scale");
+   const RecoEnergyScaleSyst kRecoEnergyScaleHadronInvSqrtFD(EnergyScaleSystTerm::kInverseSqrt, EnergyScaleSystParticle::kHadron, EnergyScaleSystDetector::kICARUS, 0.05, "EnergyScaleHadronInvSqrtFD", "Uncorrelated ICARUS inv sqrt E_{had} scale");
 
   std::vector<const ISyst*> GetEnergySysts() {
     // MicroBooNE, ChargedHadron, Neutron, and EM systs
@@ -207,5 +312,26 @@ namespace ana {
             &kEnergyScaleHadronFDBig,
             &kEnergyScaleHadronSqrtFDBig,
             &kEnergyScaleHadronInvSqrtFDBig};
+  }
+
+  std::vector<const ISyst*> GetRecoEnergySysts() {
+    return {&kRecoEnergyScaleMuon,
+            &kRecoEnergyScaleMuonSqrt,
+            &kRecoEnergyScaleMuonInvSqrt,
+            &kRecoEnergyScaleMuonND,
+            &kRecoEnergyScaleMuonSqrtND,
+            &kRecoEnergyScaleMuonInvSqrtND,
+            &kRecoEnergyScaleMuonFD,
+            &kRecoEnergyScaleMuonSqrtFD,
+            &kRecoEnergyScaleMuonInvSqrtFD,
+            &kRecoEnergyScaleHadron,
+            &kRecoEnergyScaleHadronSqrt,
+            &kRecoEnergyScaleHadronInvSqrt,
+            &kRecoEnergyScaleHadronND,
+            &kRecoEnergyScaleHadronSqrtND,
+            &kRecoEnergyScaleHadronInvSqrtND,
+            &kRecoEnergyScaleHadronFD,
+            &kRecoEnergyScaleHadronSqrtFD,
+            &kRecoEnergyScaleHadronInvSqrtFD};
   }
 } // namespace ana

--- a/sbnana/CAFAna/Systs/EnergySysts.h
+++ b/sbnana/CAFAna/Systs/EnergySysts.h
@@ -45,6 +45,21 @@ namespace ana
     double uncertainty;
   };
 
+  class RecoEnergyScaleSyst: public ISyst
+  {
+  public:
+    RecoEnergyScaleSyst(EnergyScaleSystTerm _term, EnergyScaleSystParticle _part, EnergyScaleSystDetector _detector, double _uncertainty, const std::string& name, const std::string& latexName) : 
+      ISyst(name, latexName), term(_term), part(_part), detector(_detector), uncertainty(_uncertainty) {}
+
+    void Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const override;
+
+  private:
+    EnergyScaleSystTerm term;
+    EnergyScaleSystParticle part;
+    EnergyScaleSystDetector detector;
+    double uncertainty;
+  };
+
   extern const EnergyScaleSyst kEnergyScaleMuon;
   extern const EnergyScaleSyst kEnergyScaleMuonSqrt;
   extern const EnergyScaleSyst kEnergyScaleMuonInvSqrt;
@@ -109,7 +124,41 @@ namespace ana
   extern const EnergyScaleSyst kEnergyScaleHadronSqrtFDBig;
   extern const EnergyScaleSyst kEnergyScaleHadronInvSqrtFDBig;
 
-std::vector<const ISyst*> GetEnergySysts();
-std::vector<const ISyst*> GetBigEnergySysts();
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuon;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonSqrt;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonInvSqrt;
+
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonND;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonSqrtND;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonInvSqrtND;
+
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonUB;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonSqrtUB;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonInvSqrtUB;
+
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonFD;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonSqrtFD;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleMuonInvSqrtFD;
+
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadron;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronSqrt;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronInvSqrt;
+
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronND;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronSqrtND;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronInvSqrtND;
+
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronUB;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronSqrtUB;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronInvSqrtUB;
+
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronFD;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronSqrtFD;
+  extern const RecoEnergyScaleSyst kRecoEnergyScaleHadronInvSqrtFD;
+
+  std::vector<const ISyst*> GetEnergySysts();
+  std::vector<const ISyst*> GetBigEnergySysts();
+
+  std::vector<const ISyst*> GetRecoEnergySysts();
 
 }

--- a/sbnana/CAFAna/Systs/Systs.cxx
+++ b/sbnana/CAFAna/Systs/Systs.cxx
@@ -1,0 +1,19 @@
+#include "sbnana/CAFAna/Core/ISyst.h"
+#include "sbnana/CAFAna/Systs/Systs.h"
+
+namespace ana
+{
+
+const MECSyst& GetMECSyst()
+{
+  static const MECSyst msyst;
+  return msyst;
+}
+
+const POTSyst& GetPOTSyst()
+{
+  static const POTSyst psyst;
+  return psyst;
+}
+
+}

--- a/sbnana/CAFAna/Systs/Systs.h
+++ b/sbnana/CAFAna/Systs/Systs.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "sbnana/CAFAna/Core/ISyst.h"
+
+#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
+
+namespace ana
+{
+
+class MECSyst: public ISyst
+{
+  public:
+  MECSyst() : ISyst("mec", "100% MEC Systematic") {}
+  void Shift(double sigma, caf::SRSliceProxy* sr, double& weight) const override
+  {
+    if(sigma < -1) sigma = -1;
+    if(sr->truth.genie_mode == 10) weight *= 1 + sigma;
+  }
+};
+
+const MECSyst& GetMECSyst();
+
+class POTSyst: public ISyst
+{
+  public:
+  POTSyst() : ISyst("potsyst", "2% Systematic on POT") {}
+  void Shift(double sigma, caf::SRSliceProxy* sr, double& weight) const override
+  {
+    weight *= (1.0 + 0.02 * sigma);
+  }
+};
+
+const POTSyst& GetPOTSyst();
+
+}

--- a/sbnana/SBNAna/Cuts/NumuCutsIcarus202208.cxx
+++ b/sbnana/SBNAna/Cuts/NumuCutsIcarus202208.cxx
@@ -8,10 +8,10 @@ namespace ana {
 
 static bool Icarus202208contained(const caf::SRTrackProxy& trk)
 {
-  return ((trk.end.x < -71.1 - 5 && trk.end.x > -369.33 + 5)
-             || (trk.end.x > 71.1 + 5 && trk.end.x < 369.33 - 5))
-           && trk.end.y > -181.7 + 5 && trk.end.y < 134.8 - 5
-           && trk.end.z > -895.95 + 5 && trk.end.z < 895.95 - 5;
+  return ((trk.end.x < -61.94 - 5 && trk.end.x > -358.49 + 5)
+             || (trk.end.x > 61.94 + 5 && trk.end.x < 358.49 - 5))
+           && trk.end.y > -181.86 + 5 && trk.end.y < 134.96 - 5
+           && trk.end.z > -894.95 + 5 && trk.end.z < 894.95 - 5;
 }
 
 const Cut kIcarus202208FMTimeCut = kFMTimeVar > 0 && kFMTimeVar < 1.8;
@@ -20,12 +20,12 @@ const Cut kIcarus202208LongTrackDirCut = kCRLongestTrackDirY > -0.91;
 const Cut kIcarus202208FoundMuon = kIcarus202208MuonIdx >= 0;
 const Cut kIcarus202208RecoFiducial([](const caf::SRSliceProxy* slc) {
       return ( !isnan(slc->vertex.x) &&
-	       ( ( slc->vertex.x < -71.1 - 25 && slc->vertex.x > -369.33 + 25 ) ||
-		 ( slc->vertex.x > 71.1 + 25 && slc->vertex.x < 369.33 - 25 ) ) &&
+	       ( ( slc->vertex.x < -61.94 - 25 && slc->vertex.x > -358.49 + 25 ) ||
+		 ( slc->vertex.x > 61.94 + 25 && slc->vertex.x < 358.49 - 25 ) ) &&
 	       !isnan(slc->vertex.y) &&
-	       ( slc->vertex.y > -181.7 + 25 && slc->vertex.y < 134.8 - 25 ) &&
+	       ( slc->vertex.y > -181.86 + 25 && slc->vertex.y < 134.96 - 25 ) &&
 	       !isnan(slc->vertex.z) &&
-	       ( slc->vertex.z > -895.95 + 30 && slc->vertex.z < 895.95 - 50 ) );
+	       ( slc->vertex.z > -894.95 + 30 && slc->vertex.z < 894.95 - 50 ) );
     });
 
 const Cut kIcarus202208NumuSelection = kIcarus202208RecoFiducial && kIcarus202208FMScoreCut && kIcarus202208FMTimeCut && kIcarus202208LongTrackDirCut && kIcarus202208FoundMuon;

--- a/sbnana/SBNAna/Vars/NumuVarsIcarus202208.cxx
+++ b/sbnana/SBNAna/Vars/NumuVarsIcarus202208.cxx
@@ -31,12 +31,12 @@ const Var kIcarus202208MuonIdx([](const caf::SRSliceProxy* slc) -> int {
         const float Chi2Muon = trk.chi2pid[trk.bestplane].chi2_muon;
   
         const bool Contained = ( !isnan(trk.end.x) &&
-        (( trk.end.x < -71.1 - 5 && trk.end.x > -369.33 + 5 ) ||
-        ( trk.end.x < 71.1 + 5 && trk.end.x > +369.33 - 5 )) &&
+        (( trk.end.x < -61.94 - 5 && trk.end.x > -358.49 + 5 ) ||
+        ( trk.end.x < 61.94 + 5 && trk.end.x > +358.49 - 5 )) &&
         !isnan(trk.end.y) &&
-        ( trk.end.y > -181.7 + 5 && trk.end.y < 134.8 - 5 ) &&
+        ( trk.end.y > -181.86 + 5 && trk.end.y < 134.96 - 5 ) &&
         !isnan(trk.end.z) &&
-        ( trk.end.z > -895.95 + 5 && trk.end.z < 895.95 - 5 ) );
+        ( trk.end.z > -894.95 + 5 && trk.end.z < 894.95 - 5 ) );
         const bool MaybeMuonExiting = ( !Contained && trk.len > 100);
         const bool MaybeMuonContained = ( Contained && Chi2Proton > 60 && Chi2Muon < 30 && trk.len > 50 );
         if ( AtSlice && ( MaybeMuonExiting || MaybeMuonContained ) && trk.len > Longest ) {

--- a/sbnana/SBNAna/Vars/NumuVarsIcarus202208.cxx
+++ b/sbnana/SBNAna/Vars/NumuVarsIcarus202208.cxx
@@ -32,7 +32,7 @@ const Var kIcarus202208MuonIdx([](const caf::SRSliceProxy* slc) -> int {
   
         const bool Contained = ( !isnan(trk.end.x) &&
         (( trk.end.x < -61.94 - 5 && trk.end.x > -358.49 + 5 ) ||
-        ( trk.end.x < 61.94 + 5 && trk.end.x > +358.49 - 5 )) &&
+        ( trk.end.x > 61.94 + 5 && trk.end.x < +358.49 - 5 )) &&
         !isnan(trk.end.y) &&
         ( trk.end.y > -181.86 + 5 && trk.end.y < 134.96 - 5 ) &&
         !isnan(trk.end.z) &&


### PR DESCRIPTION
A variety of bug fixes that I've been making in the fits I do, but which never made it into develop.
- Surface.cxx: Fix LoadFromMulti and SaveTo so that fits split between multiple grid nodes work properly
- NumuVarsIcarus202208/NumuCutsIcarus202208: Fix a typo in muon selection and fiducial volume definition for ICARUS
- Binning.h: Double true L over E binning for oscillations. I've been using 200 bins since 2020 anyway, but the default value in CAFAna is too coarse and fits with this binning **do not** match other fitters.

Missing Systematics
- 2% POT systematic: We've been using this since 2020, but it wasn't in develop so I had to manually add it every time I used a new install of CAFAna.
- 100% MEC systematic: Same comment at POT syst.
- Reco Energy scale systematics: Copy existing energy scale systematics for fake reco to now work with reconstructed momentum as well.