### PR TITLE
NuMI Flux Sysematics Update

### DIFF
--- a/sbnana/CAFAna/Systs/NuMIFluxSysts.cxx
+++ b/sbnana/CAFAna/Systs/NuMIFluxSysts.cxx
@@ -11,55 +11,77 @@
 #include <cstdlib>
 #include <iostream>
 
-namespace ana
-{
+namespace ana {
+  NuMIFluxSyst::NuMIFluxSyst(const std::string& dir,
+                             const std::string& prefix,
+                             const std::string& name,
+                             const std::string& fluxFile /* = "" */)
+    : ISyst("numi_" + name, "NuMI flux: " + name)
+    , fHistName(dir + "/" + prefix + name)
+    , fName(name)
+    , fScale()
+  {
+    if (!fluxFile.empty()) { fFluxFilePath = fluxFile; }
+    else {
+      const char* sbndata = std::getenv("SBNDATA_DIR");
+      if (!sbndata) {
+        std::cout << "NuMIPpfxFluxWeight: $SBNDATA_DIR environment variable not set. Please setup "
+                     "the sbndata product."
+                  << std::endl;
+        std::abort();
+      }
+
+      fFluxFilePath = std::string(sbndata) +
+                     "beamData/NuMIdata/2023-07-31_out_450.37_7991.98_79512.66_QEL11.root";
+    }
+  }
 
   //----------------------------------------------------------------------
   NuMIFluxSyst::~NuMIFluxSyst()
   {
-    for(int i = 0; i < 2; ++i)
-      for(int j = 0; j < 2; ++j)
-        for(int k = 0; k < 2; ++k)
+    for (int i = 0; i < 2; ++i)
+      for (int j = 0; j < 2; ++j)
+        for (int k = 0; k < 2; ++k)
           delete fScale[i][j][k];
   }
 
   //----------------------------------------------------------------------
   void NuMIFluxSyst::Shift(double sigma, caf::SRSliceProxy* slc, double& weight) const
   {
-    if(slc->truth.index < 0) return; // No neutrino
+    if (slc->truth.index < 0) return; // No neutrino
 
     // TODO switch to regular detector flag as soon as it's filled reliably
-    if(slc->truth.baseline < 500){
-      std::cout << "Using NuMIFluxSyst on what appears not to be an icarus file (baseline = " << slc->truth.baseline << ")!" << std::endl;
+    if (slc->truth.baseline < 500) {
+      std::cout << "Using NuMIFluxSyst on what appears not to be an icarus file (baseline = "
+                << slc->truth.baseline << ")!" << std::endl;
       abort();
     }
 
-    if(!fScale[0][0][0]){
-      const char* sbndata = getenv("SBNDATA_DIR");
-      if(!sbndata){
-        std::cout << "NuMIFluxSysts: $SBNDATA_DIR environment variable not set. Please setup the sbndata product." << std::endl;
+    if (!fScale[0][0][0]) {
+      TFile f(fFluxFilePath.c_str());
+      if (f.IsZombie()) {
+        std::cout << "NuMIFluxSysts: Failed to open " << fFluxFilePath << std::endl;
         abort();
       }
 
-      const std::string fname = std::string(sbndata) + "/beamData/NuMIdata/" + fluxFileName.data();
-
-      TFile f(fname.c_str());
-      if(f.IsZombie()){
-        std::cout << "NuMIFluxSysts: Failed to open " << fname << std::endl;
-        abort();
-      }
-
-      for(int hcIdx: {0, 1}){
-        for(int flavIdx: {0, 1}){
-          for(int signIdx: {0, 1}){
+      for (int hcIdx : {0, 1}) {
+        for (int flavIdx : {0, 1}) {
+          for (int signIdx : {0, 1}) {
             std::string hName = fHistName;
-            if(hcIdx == 0) hName += "_fhc"; else hName += "_rhc";
-            if(flavIdx == 0) hName += "_nue"; else hName += "_numu";
-            if(signIdx == 1) hName += "bar";
+            if (hcIdx == 0)
+              hName += "_fhc";
+            else
+              hName += "_rhc";
+            if (flavIdx == 0)
+              hName += "_nue";
+            else
+              hName += "_numu";
+            if (signIdx == 1) hName += "bar";
 
             TH1* h = (TH1*)f.Get(hName.c_str());
-            if(!h){
-              std::cout << "NuMIFluxSysts: failed to find " << hName << " in " << f.GetName() << std::endl;
+            if (!h) {
+              std::cout << "NuMIFluxSysts: failed to find " << hName << " in " << f.GetName()
+                        << std::endl;
               abort();
             }
             h = (TH1*)h->Clone(UniqueName().c_str());
@@ -72,7 +94,7 @@ namespace ana
     } // end if
 
     const int flav = abs(slc->truth.initpdg);
-    if(flav != 12 && flav != 14) return;
+    if (flav != 12 && flav != 14) return;
 
     const int hcIdx = 0; // TODO TODO always FHC
     const int flavIdx = (flav == 12) ? 0 : 1;
@@ -83,67 +105,68 @@ namespace ana
 
     const int bin = h->FindBin(slc->truth.E);
 
-    if(bin == 0 || bin == h->GetNbinsX()+1) return;
+    if (bin == 0 || bin == h->GetNbinsX() + 1) return;
 
     // BH -- attempt to not change any weight if the value is inf or nan, just continue with weight as-is...
-    if( std::isinf(h->GetBinContent(bin)) || std::isnan(h->GetBinContent(bin)) ) weight *= 1;
-    else weight *= 1 + sigma*h->GetBinContent(bin);
+    if (std::isinf(h->GetBinContent(bin)) || std::isnan(h->GetBinContent(bin)))
+      weight *= 1;
+    else
+      weight *= 1 + sigma * h->GetBinContent(bin);
   }
 
   //----------------------------------------------------------------------
   const NuMIFluxSyst* GetNuMIFluxSyst(const std::string& dir,
-                                                              const std::string& prefix,
-                                                              const std::string& name)
+                                      const std::string& prefix,
+                                      const std::string& name,
+                                      const std::string& fluxFile /* = "" */)
   {
     // Make sure we always give the same one back
     static std::map<std::string, const NuMIFluxSyst*> cache;
 
-    const std::string key = dir+"/"+prefix+name;
-    if(cache.count(key) == 0) cache[key] = new NuMIFluxSyst(dir, prefix, name);
+    const std::string key = dir + "/" + prefix + name;
+    if (cache.count(key) == 0) cache[key] = new NuMIFluxSyst(dir, prefix, name, fluxFile);
 
     return cache[key];
+  }
+
+  const ISyst* GetNuMIFluxStatisticalUncertainty()
+  {
+    return GetNuMIFluxSyst("statistical_uncertainties", "h", "stat");
   }
 
   //----------------------------------------------------------------------
   std::vector<const ISyst*> GetNuMIHadronProductionFluxSysts()
   {
-    const std::vector<std::string> syst_names =
-      {
-        "att",
-        "mesinc",
-        "nCpi",
-        "nuAlFe",
-        "nua",
-        "others",
-        "pCnu",
-        "pCpi"
-      };
+    /* Tony W: These should not be used directly for syst shifts; prefer to use the PCA form.
+     * The HP fractional uncertainties are only included for completeness.
+     */
+    const std::vector<std::string> syst_names = {
+      "att", "mesinc", "nCpi", "nuAlFe", "nua", "others", "pCnu", "pCpi"};
 
     std::vector<const ISyst*> ret;
-    for(std::string name: syst_names)
-      ret.push_back(GetNuMIFluxSyst("fractional_uncertainties/hadron/"+name, "hfrac_hadron_", name));
+    for (const auto& name : syst_names)
+      ret.push_back(
+        GetNuMIFluxSyst("fractional_uncertainties/hadron" + name, "hfrac_hadron_", name));
     return ret;
   }
 
   //----------------------------------------------------------------------
   std::vector<const ISyst*> GetNuMIBeamlineFluxSysts()
   {
-    const std::vector<std::string> syst_names =
-      {
-        "beam_div",
-        "beam_shift_minus_y",
-        "beam_shift_plus_y",
-        "beam_shift_x",
-        "beam_spot",
-        "horn1_x",
-        "horn1_y",
-        "horn_current_plus",
-        "water_layer"
-      };
+    const std::vector<std::string> syst_names = {"beam_div",
+                                                 "beam_power",
+                                                 "beam_shift_y_minus",
+                                                 "beam_shift_y_plus",
+                                                 "beam_shift_x",
+                                                 "beam_spot",
+                                                 "horn1_x",
+                                                 "horn1_y",
+                                                 "horn_current_plus",
+                                                 "water_layer"};
 
     std::vector<const ISyst*> ret;
-    for(std::string name: syst_names)
-      ret.push_back(GetNuMIFluxSyst("fractional_uncertainties/beam/"+name, "hfrac_beam_", name));
+    for (const auto& name : syst_names)
+      ret.push_back(GetNuMIFluxSyst("beam_systematic_shifts", "hsyst_beam_", name));
     return ret;
   }
 
@@ -151,9 +174,8 @@ namespace ana
   std::vector<const ISyst*> GetNuMIPCAFluxSysts(unsigned int Npcs)
   {
     std::vector<const ISyst*> ret;
-    for(unsigned int i = 0; i < Npcs; ++i){
-      ret.push_back(GetNuMIFluxSyst("pca/principal_components",
-                                                "h", "pc_"+std::to_string(i)));
+    for (unsigned int i = 0; i < Npcs; ++i) {
+      ret.push_back(GetNuMIFluxSyst("pca/principal_components", "h", "pc_" + std::to_string(i)));
     }
     return ret;
   }
@@ -163,7 +185,9 @@ namespace ana
   {
     std::vector<const ISyst*> ret = GetNuMIBeamlineFluxSysts();
     std::vector<const ISyst*> add = GetNuMIPCAFluxSysts(Npcs);
+    const ISyst* stat = GetNuMIFluxStatisticalUncertainty();
     ret.insert(ret.end(), add.begin(), add.end());
+    ret.push_back(stat);
     return ret;
   }
 } // namespace ana

--- a/sbnana/CAFAna/Systs/NuMIFluxSysts.cxx
+++ b/sbnana/CAFAna/Systs/NuMIFluxSysts.cxx
@@ -41,12 +41,13 @@ namespace ana
         abort();
       }
 
-    const std::string fname = std::string(sbndata)+"/beamData/NuMIdata/2023-06-30_out_450.37_7991.98_79512.66_QEL11.root";
-    TFile f(fname.c_str());
-    if(f.IsZombie()){
-      std::cout << "NuMIFluxSysts: Failed to open " << fname << std::endl;
-      abort();
-    }
+      const std::string fname = std::string(sbndata) + "/beamData/NuMIdata/" + fluxFileName.data();
+
+      TFile f(fname.c_str());
+      if(f.IsZombie()){
+        std::cout << "NuMIFluxSysts: Failed to open " << fname << std::endl;
+        abort();
+      }
 
       for(int hcIdx: {0, 1}){
         for(int flavIdx: {0, 1}){
@@ -114,7 +115,6 @@ namespace ana
         "nuAlFe",
         "nua",
         "others",
-        "pCQEL",
         "pCnu",
         "pCpi"
       };

--- a/sbnana/CAFAna/Systs/NuMIFluxSysts.h
+++ b/sbnana/CAFAna/Systs/NuMIFluxSysts.h
@@ -3,18 +3,13 @@
 #include "sbnana/CAFAna/Core/ISyst.h"
 
 #include <string>
-#include <string_view>
 #include <vector>
 
 class TH1;
 
-namespace ana
-{
+namespace ana {
 
-  class NuMIFluxSyst : public ISyst
-  {
-    static constexpr std::string_view fluxFileName = "2023-07-06_out_450.37_7991.98_79512.66_QEL11.root";
-
+  class NuMIFluxSyst : public ISyst {
   public:
     virtual ~NuMIFluxSyst();
 
@@ -23,26 +18,27 @@ namespace ana
   protected:
     friend const NuMIFluxSyst* GetNuMIFluxSyst(const std::string&,
                                                const std::string&,
+                                               const std::string&,
                                                const std::string&);
 
     NuMIFluxSyst(const std::string& dir,
-                             const std::string& prefix,
-                             const std::string& name)
-      : ISyst("numi_"+name, "NuMI flux: "+name),
-        fHistName(dir+"/"+prefix+name), fName(name), fScale()
-    {
-    }
+                 const std::string& prefix,
+                 const std::string& name,
+                 const std::string& fluxFile = "");
 
-    std::string fHistName, fName;
+    std::string fHistName, fName, fFluxFilePath;
 
     mutable TH1* fScale[2][2][2]; // [fhc/rhc][nue/numu][nu/nubar]
   };
 
   const NuMIFluxSyst* GetNuMIFluxSyst(const std::string& dir,
                                       const std::string& prefix,
-                                      const std::string& name);
+                                      const std::string& name,
+                                      const std::string& fluxFile = "");
 
   /// These are envelopes not real systs. TODO make clearer in naming
+  const ISyst* GetNuMIFluxStatisticalUncertainty();
+
   std::vector<const ISyst*> GetNuMIHadronProductionFluxSysts();
 
   std::vector<const ISyst*> GetNuMIBeamlineFluxSysts();

--- a/sbnana/CAFAna/Systs/NuMIFluxSysts.h
+++ b/sbnana/CAFAna/Systs/NuMIFluxSysts.h
@@ -2,6 +2,8 @@
 
 #include "sbnana/CAFAna/Core/ISyst.h"
 
+#include <string>
+#include <string_view>
 #include <vector>
 
 class TH1;
@@ -11,6 +13,8 @@ namespace ana
 
   class NuMIFluxSyst : public ISyst
   {
+    static constexpr std::string_view fluxFileName = "2023-07-06_out_450.37_7991.98_79512.66_QEL11.root";
+
   public:
     virtual ~NuMIFluxSyst();
 
@@ -18,8 +22,8 @@ namespace ana
 
   protected:
     friend const NuMIFluxSyst* GetNuMIFluxSyst(const std::string&,
-                                                                       const std::string&,
-                                                                       const std::string&);
+                                               const std::string&,
+                                               const std::string&);
 
     NuMIFluxSyst(const std::string& dir,
                              const std::string& prefix,
@@ -35,8 +39,8 @@ namespace ana
   };
 
   const NuMIFluxSyst* GetNuMIFluxSyst(const std::string& dir,
-                                                              const std::string& prefix,
-                                                              const std::string& name);
+                                      const std::string& prefix,
+                                      const std::string& name);
 
   /// These are envelopes not real systs. TODO make clearer in naming
   std::vector<const ISyst*> GetNuMIHadronProductionFluxSysts();

--- a/sbnana/CAFAna/Systs/NuMIFluxSysts.h
+++ b/sbnana/CAFAna/Systs/NuMIFluxSysts.h
@@ -18,12 +18,12 @@ namespace ana
 
   protected:
     friend const NuMIFluxSyst* GetNuMIFluxSyst(const std::string&,
-                                               const std::string&,
-                                               const std::string&);
+                                                                       const std::string&,
+                                                                       const std::string&);
 
     NuMIFluxSyst(const std::string& dir,
-                 const std::string& prefix,
-                 const std::string& name)
+                             const std::string& prefix,
+                             const std::string& name)
       : ISyst("numi_"+name, "NuMI flux: "+name),
         fHistName(dir+"/"+prefix+name), fName(name), fScale()
     {
@@ -35,8 +35,8 @@ namespace ana
   };
 
   const NuMIFluxSyst* GetNuMIFluxSyst(const std::string& dir,
-                                      const std::string& prefix,
-                                      const std::string& name);
+                                                              const std::string& prefix,
+                                                              const std::string& name);
 
   /// These are envelopes not real systs. TODO make clearer in naming
   std::vector<const ISyst*> GetNuMIHadronProductionFluxSysts();

--- a/sbnana/SBNAna/Vars/NuMIFlux.cxx
+++ b/sbnana/SBNAna/Vars/NuMIFlux.cxx
@@ -1,0 +1,81 @@
+#include "sbnana/SBNAna/Vars/NuMIFlux.h"
+
+#include "sbnana/CAFAna/Core/Utilities.h"
+
+#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
+
+#include "TFile.h"
+#include "TH1.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+
+namespace ana
+{
+
+  //// ----------------------------------------------
+
+  NuMIPpfxFluxWeight::NuMIPpfxFluxWeight()
+  {
+    const char* sbndata = std::getenv("SBNDATA_DIR");
+    if(!sbndata){
+      std::cout << "NuMIPpfxFluxWeight: $SBNDATA_DIR environment variable not set. Please setup the sbndata product." << std::endl;
+      std::abort();
+    }
+
+    const std::string fname = std::string(sbndata)+"/beamData/NuMIdata/2023-06-30_out_450.37_7991.98_79512.66_QEL11.root";
+    TFile f(fname.c_str());
+    if(f.IsZombie()){
+      std::cout << "NuMIPpfxFluxWeight: Failed to open " << fname << std::endl;
+      std::abort();
+    }
+
+    for(int hcIdx: {0, 1}){
+      for(int flavIdx: {0, 1}){
+        for(int signIdx: {0, 1}){
+	  std::string      hNamePPFX = "ppfx_flux_weights/hweights_";
+          if(hcIdx == 0)   hNamePPFX += "fhc_"; else hNamePPFX += "rhc_";
+          if(flavIdx == 0) hNamePPFX += "nue";  else hNamePPFX += "numu";
+          if(signIdx == 1) hNamePPFX += "bar";
+
+          TH1* h_ppfx = (TH1*)f.Get( hNamePPFX.c_str() );
+          if(!h_ppfx){
+	    std::cout << "NuMIPpfxFluxWeight: failed to find " << hNamePPFX << " in " << f.GetName() << std::endl;
+	    std::abort();
+          }
+          h_ppfx = (TH1*)h_ppfx->Clone(UniqueName().c_str());
+          h_ppfx->SetDirectory(0);
+
+          this->fWeight[hcIdx][flavIdx][signIdx] = h_ppfx;
+        }
+      }
+    }
+  }
+
+  //// ----------------------------------------------
+
+  const Var kGetNuMIFluxWeight( [](const caf::SRSliceProxy* slc) -> double
+	      {
+		if ( slc->truth.index < 0 || abs(slc->truth.initpdg) == 16 ) return 1.0;
+
+		if ( !FluxWeightNuMI.fWeight[0][0][0] ) {
+		  std::cout << "Trying to access un-available weight array..." << std::endl;
+		  std::abort();
+		}
+
+		unsigned int hcIdx = 0; // assume always FHC for now...
+		unsigned int flavIdx = ( abs(slc->truth.initpdg) == 12 ) ? 0 : 1;
+		unsigned int signIdx = ( slc->truth.initpdg > 0 ) ? 0 : 1;
+
+		TH1* h = FluxWeightNuMI.fWeight[hcIdx][flavIdx][signIdx];
+		assert(h);
+
+		const int bin = h->FindBin( slc->truth.E );
+		if(bin == 0 || bin == h->GetNbinsX()+1) return 1.0;
+		return h->GetBinContent(bin);
+	      });
+
+  //// ----------------------------------------------
+
+}

--- a/sbnana/SBNAna/Vars/NuMIFlux.cxx
+++ b/sbnana/SBNAna/Vars/NuMIFlux.cxx
@@ -11,71 +11,88 @@
 #include <cstdlib>
 #include <iostream>
 
-namespace ana
-{
+namespace ana {
 
   //// ----------------------------------------------
-
   NuMIPpfxFluxWeight::NuMIPpfxFluxWeight()
   {
-    const char* sbndata = getenv("SBNDATA_DIR");
-    if(!sbndata){
-      std::cout << "NuMIFluxSysts: $SBNDATA_DIR environment variable not set. Please setup the sbndata product." << std::endl;
-      abort();
-    }
-
-    const std::string fname = std::string(sbndata) + "/beamData/NuMIdata/" + fluxFileName.data();
-
-    TFile f(fname.c_str());
-    if(f.IsZombie()){
-      std::cout << "NuMIPpfxFluxWeight: Failed to open " << fname << std::endl;
+    const char* sbndata = std::getenv("SBNDATA_DIR");
+    if (!sbndata) {
+      std::cout << "NuMIPpfxFluxWeight: $SBNDATA_DIR environment variable not set. Please setup "
+                   "the sbndata product."
+                << std::endl;
       std::abort();
     }
 
-    for(int hcIdx: {0, 1}){
-      for(int flavIdx: {0, 1}){
-        for(int signIdx: {0, 1}){
-	  std::string      hNamePPFX = "ppfx_flux_weights/hweights_";
-          if(hcIdx == 0)   hNamePPFX += "fhc_"; else hNamePPFX += "rhc_";
-          if(flavIdx == 0) hNamePPFX += "nue";  else hNamePPFX += "numu";
-          if(signIdx == 1) hNamePPFX += "bar";
+    fFluxFilePath = std::string(sbndata) +
+                   "beamData/NuMIdata/2023-07-31_out_450.37_7991.98_79512.66_QEL11.root";
 
-          TH1* h_ppfx = (TH1*)f.Get( hNamePPFX.c_str() );
-          if(!h_ppfx){
-	    std::cout << "NuMIPpfxFluxWeight: failed to find " << hNamePPFX << " in " << f.GetName() << std::endl;
-	    std::abort();
+    TFile f(fFluxFilePath.c_str());
+    if (f.IsZombie()) {
+      std::cout << "NuMIPpfxFluxWeight: Failed to open " << fFluxFilePath << std::endl;
+      std::abort();
+    }
+
+    for (int hcIdx : {0, 1}) {
+      for (int flavIdx : {0, 1}) {
+        for (int signIdx : {0, 1}) {
+          std::string hNamePPFX = "ppfx_flux_weights/hweights_";
+          if (hcIdx == 0)
+            hNamePPFX += "fhc_";
+          else
+            hNamePPFX += "rhc_";
+          if (flavIdx == 0)
+            hNamePPFX += "nue";
+          else
+            hNamePPFX += "numu";
+          if (signIdx == 1) hNamePPFX += "bar";
+
+          TH1* h_ppfx = (TH1*)f.Get(hNamePPFX.c_str());
+          if (!h_ppfx) {
+            std::cout << "NuMIPpfxFluxWeight: failed to find " << hNamePPFX << " in " << f.GetName()
+                      << std::endl;
+            std::abort();
           }
           h_ppfx = (TH1*)h_ppfx->Clone(UniqueName().c_str());
           h_ppfx->SetDirectory(0);
 
-          this->fWeight[hcIdx][flavIdx][signIdx] = h_ppfx;
+          fWeight[hcIdx][flavIdx][signIdx] = h_ppfx;
         }
       }
     }
   }
 
+  NuMIPpfxFluxWeight::~NuMIPpfxFluxWeight()
+  {
+    for (int i = 0; i < 2; ++i)
+      for (int j = 0; j < 2; ++j)
+        for (int k = 0; k < 2; ++k)
+          delete fWeight[i][j][k];
+  }
+
   //// ----------------------------------------------
 
-  const Var kGetNuMIFluxWeight( [](const caf::SRSliceProxy* slc) -> double
-	      {
-		if ( slc->truth.index < 0 || abs(slc->truth.initpdg) == 16 ) return 1.0;
+  const Var kGetNuMIFluxWeight([](const caf::SRSliceProxy* slc) -> double {
+    if (slc->truth.index < 0 || abs(slc->truth.initpdg) == 16) return 1.0;
 
-		if ( !FluxWeightNuMI.fWeight[0][0][0] ) {
-		  std::cout << "Trying to access un-available weight array..." << std::endl;
-		  std::abort();
-		}
+    if (!FluxWeightNuMI.fWeight[0][0][0]) {
+      std::cout << "Trying to access un-available weight array..." << std::endl;
+      std::abort();
+    }
 
-		unsigned int hcIdx = 0; // assume always FHC for now...
-		unsigned int flavIdx = ( abs(slc->truth.initpdg) == 12 ) ? 0 : 1;
-		unsigned int signIdx = ( slc->truth.initpdg > 0 ) ? 0 : 1;
+    unsigned int hcIdx = 0; // assume always FHC for now...
+    unsigned int flavIdx = (abs(slc->truth.initpdg) == 12) ? 0 : 1;
+    unsigned int signIdx = (slc->truth.initpdg > 0) ? 0 : 1;
 
-		TH1* h = FluxWeightNuMI.fWeight[hcIdx][flavIdx][signIdx];
-		assert(h);
+    TH1* h = FluxWeightNuMI.fWeight[hcIdx][flavIdx][signIdx];
+    assert(h);
 
-		const int bin = h->FindBin( slc->truth.E );
-		if(bin == 0 || bin == h->GetNbinsX()+1) return 1.0;
-		return h->GetBinContent(bin);
-	      });
+    const int bin = h->FindBin(slc->truth.E);
+
+    if (bin == 0 || bin == h->GetNbinsX() + 1) return 1.0;
+    if (std::isinf(h->GetBinContent(bin)) || std::isnan(h->GetBinContent(bin))) return 1.0;
+    return h->GetBinContent(bin);
+  });
 
   //// ----------------------------------------------
 

--- a/sbnana/SBNAna/Vars/NuMIFlux.cxx
+++ b/sbnana/SBNAna/Vars/NuMIFlux.cxx
@@ -18,13 +18,14 @@ namespace ana
 
   NuMIPpfxFluxWeight::NuMIPpfxFluxWeight()
   {
-    const char* sbndata = std::getenv("SBNDATA_DIR");
+    const char* sbndata = getenv("SBNDATA_DIR");
     if(!sbndata){
-      std::cout << "NuMIPpfxFluxWeight: $SBNDATA_DIR environment variable not set. Please setup the sbndata product." << std::endl;
-      std::abort();
+      std::cout << "NuMIFluxSysts: $SBNDATA_DIR environment variable not set. Please setup the sbndata product." << std::endl;
+      abort();
     }
 
-    const std::string fname = std::string(sbndata)+"/beamData/NuMIdata/2023-06-30_out_450.37_7991.98_79512.66_QEL11.root";
+    const std::string fname = std::string(sbndata) + "/beamData/NuMIdata/" + fluxFileName.data();
+
     TFile f(fname.c_str());
     if(f.IsZombie()){
       std::cout << "NuMIPpfxFluxWeight: Failed to open " << fname << std::endl;

--- a/sbnana/SBNAna/Vars/NuMIFlux.h
+++ b/sbnana/SBNAna/Vars/NuMIFlux.h
@@ -1,0 +1,24 @@
+// BH - 2023
+// HEAVILY based on NuMI flux syst, and thanks to Tony Wood for discussing the right histograms to use
+
+#pragma once
+
+#include "sbnana/CAFAna/Core/Var.h"
+
+class TH1;
+
+namespace ana
+{
+
+  class NuMIPpfxFluxWeight
+  {
+  public:
+    NuMIPpfxFluxWeight();
+    mutable TH1* fWeight[2][2][2]; // [fhc/rhc][nue/numu][nu/nubar]
+  };
+
+  // set up to use the flux weight
+  NuMIPpfxFluxWeight FluxWeightNuMI;
+  extern const Var kGetNuMIFluxWeight;
+
+}

--- a/sbnana/SBNAna/Vars/NuMIFlux.h
+++ b/sbnana/SBNAna/Vars/NuMIFlux.h
@@ -5,8 +5,7 @@
 
 #include "sbnana/CAFAna/Core/Var.h"
 
-#include <string_view>
-
+#include <string>
 
 class TH1;
 
@@ -15,15 +14,17 @@ namespace ana
 
   class NuMIPpfxFluxWeight
   {
-    static constexpr std::string_view fluxFileName = "2023-07-06_out_450.37_7991.98_79512.66_QEL11.root";
-
   public:
     NuMIPpfxFluxWeight();
+    ~NuMIPpfxFluxWeight();
     mutable TH1* fWeight[2][2][2]; // [fhc/rhc][nue/numu][nu/nubar]
+
+  protected:
+    std::string fFluxFilePath;
   };
 
   // set up to use the flux weight
-  NuMIPpfxFluxWeight FluxWeightNuMI;
+  static const NuMIPpfxFluxWeight FluxWeightNuMI;
   extern const Var kGetNuMIFluxWeight;
 
 }

--- a/sbnana/SBNAna/Vars/NuMIFlux.h
+++ b/sbnana/SBNAna/Vars/NuMIFlux.h
@@ -5,6 +5,9 @@
 
 #include "sbnana/CAFAna/Core/Var.h"
 
+#include <string_view>
+
+
 class TH1;
 
 namespace ana
@@ -12,6 +15,8 @@ namespace ana
 
   class NuMIPpfxFluxWeight
   {
+    static constexpr std::string_view fluxFileName = "2023-07-06_out_450.37_7991.98_79512.66_QEL11.root";
+
   public:
     NuMIPpfxFluxWeight();
     mutable TH1* fWeight[2][2][2]; // [fhc/rhc][nue/numu][nu/nubar]


### PR DESCRIPTION
This PR tied closely with [sbndata PR#4 Update NuMI flux file to latest version](https://github.com/SBNSoftware/sbndata/pull/4).

The updates here are necessary to access data correctly from the flux file in the above PR, as the internal structure of the file has undergone several revisions.

Specific Updates:
- The file name referencing the file from `sbndata` that needs to be accessed has been moved from a local variable of `NuMIFluxSyst::Shift` to a private member variable of the `NuMIFluxSyst` class as a whole. My opinion is that it will be easier to locate and update down the line, this way. Although, I'm not a fan of having the filename hard-coded into the class, as it has to be updated separately in the new `NuMIPpfxWeight` class, but I don't have a better solution at the moment.
- @brucehoward-physics wrote a `NuMIPpfxWeight` class and corresponding `Var` to facilitate extracting the NuMI flux weights, so I've incorporated that into this PR. Just as a simple test that it's working as expected, I've pulled a small distribution of flux weights:

![image](https://github.com/SBNSoftware/sbnana/assets/69479110/b87c9748-7b08-4fe0-a75f-25aacbca5596)

Other modifications:
- `attenuation` has been renamed to `att`
- `beam_divergence` --> `beam_div`
- `horn1_position_xy` separated into `horn1_x` and `horn1_y`
- `horn_current` --> `horn_current_plus` (the -2kA sample found to be consistent with statistical fluctuations, so we dropped it)
- `horn2_position_xy` removed
- `beam_spot_size` --> `beam_spot`
- `beam_shift_minus_y` and `beam_shift_plus_y` split from `beam_shift_xy` (x-shift samples dropped; consistent with stat. flucts.)
- `B_field` removed

Again to check that this update still works as expected, below are a selection of true neutrino energy spectra varied according to the various systematics.

![numi_beam_div](https://github.com/SBNSoftware/sbnana/assets/69479110/4df837d4-a4c8-4383-a08e-a135c2237e3b)
![numi_beam_shift_minus_y](https://github.com/SBNSoftware/sbnana/assets/69479110/51ed7c72-3fe0-4b7b-94da-de5c2b14ad68)
![numi_beam_shift_plus_y](https://github.com/SBNSoftware/sbnana/assets/69479110/cccc6d97-d098-4709-bd9d-d3313103a1b9)
![numi_beam_shift_x](https://github.com/SBNSoftware/sbnana/assets/69479110/16ab3e76-3b0d-455c-8da8-3b77f4c8455c)
![numi_beam_spot](https://github.com/SBNSoftware/sbnana/assets/69479110/3509fcbc-cf38-4bd3-a4de-51d2ac233fb7)
![numi_horn1_x](https://github.com/SBNSoftware/sbnana/assets/69479110/bce3f745-4c95-4f74-8d9c-9440786da6db)
![numi_horn1_y](https://github.com/SBNSoftware/sbnana/assets/69479110/24e0f135-47ce-47d0-9a28-07978a494e2e)
![numi_horn_current_plus](https://github.com/SBNSoftware/sbnana/assets/69479110/9b0f3956-1f03-44ad-a53b-9ddf7661702c)
![numi_pc_0](https://github.com/SBNSoftware/sbnana/assets/69479110/2b399c11-bc5b-48d0-9355-f99a84729395)
![numi_pc_1](https://github.com/SBNSoftware/sbnana/assets/69479110/27cf2499-f51c-46bc-b397-1c3c67990f3b)
![numi_pc_2](https://github.com/SBNSoftware/sbnana/assets/69479110/4fe002d1-0fd9-48a0-9b6e-7a2c0ebe5b3a)
![numi_pc_3](https://github.com/SBNSoftware/sbnana/assets/69479110/56bf5c95-f95f-4a55-a7ea-250df73cd230)
![numi_pc_4](https://github.com/SBNSoftware/sbnana/assets/69479110/f7d34e08-1a86-4db7-916a-4a84b49bf41c)
![numi_water_layer](https://github.com/SBNSoftware/sbnana/assets/69479110/a36269f1-7989-4d06-b23a-bc8ea8971e7e)
