### PR TITLE
Update FileListSource to use XRootD

### DIFF
--- a/sbnana/CAFAna/Core/FileListSource.cxx
+++ b/sbnana/CAFAna/Core/FileListSource.cxx
@@ -95,7 +95,7 @@ namespace ana
 
     // If the file is on pnfs rewrite it to an xrootd address
     std::string loc = *fIt;
-    // loc = pnfs2xrootd(loc); // no-op for non /pnfs locations
+    loc = pnfs2xrootd(loc); // no-op for non /pnfs locations
 
     fFile = TFile::Open(loc.c_str()); // This pattern allows xrootd
     assert(fFile);

--- a/sbnana/CAFAna/Core/Utilities.cxx
+++ b/sbnana/CAFAna/Core/Utilities.cxx
@@ -828,9 +828,9 @@ namespace ana
 
     if(loc.rfind("/pnfs/", 0) == 0){ // ie begins with
       if ( onsite && unauth )
-        loc = std::string("root://fndcagpvm01.fnal.gov:1095//pnfs/fnal.gov/usr/")+&loc.c_str()[6];
+        loc = std::string("root://fndcadoor.fnal.gov:1095//pnfs/fnal.gov/usr/")+&loc.c_str()[6];
       else
-        loc = std::string("root://fndcagpvm01.fnal.gov:1094//pnfs/fnal.gov/usr/")+&loc.c_str()[6];
+        loc = std::string("root://fndcadoor.fnal.gov:1094//pnfs/fnal.gov/usr/")+&loc.c_str()[6];
     }
     return loc;
   }


### PR DESCRIPTION
For some reason this was commented out, but we probably want to use XRootD to access files on pnfs.
I also had to update the prefix added to the path in `pnfs2xrootd`.