### PR TITLE
Feature/howard trees with cov rebased

### DIFF
--- a/sbnana/CAFAna/Core/Cut.cxx
+++ b/sbnana/CAFAna/Core/Cut.cxx
@@ -97,6 +97,16 @@ namespace ana
   template SpillCut operator||<caf::SRSpillProxy>(const SpillCut& a, const SpillCut& b);
 
   //----------------------------------------------------------------------
+  template<class T> bool operator<(const _Cut<T>& a, const _Cut<T>& b)
+  {
+    return a.ID() < b.ID();
+  }
+
+  // Make sure all versions get generated
+  template bool operator< <caf::SRSliceProxy>(const Cut& a, const Cut& b);
+  template bool operator< <caf::SRSpillProxy>(const SpillCut& a, const SpillCut& b);
+
+  //----------------------------------------------------------------------
   template<class T> _Cut<T> operator!(const _Cut<T>& a)
   {
     static std::map<int, int> ids;

--- a/sbnana/CAFAna/Core/Cut.h
+++ b/sbnana/CAFAna/Core/Cut.h
@@ -19,6 +19,9 @@ namespace ana
                                              const _Cut<T>& b);
   template<class T> _Cut<T> operator||(const _Cut<T>& a,
                                              const _Cut<T>& b);
+  template<class T> bool operator<(const _Cut<T>& a,
+                                         const _Cut<T>& b); // for map-making
+
   template<class T> _Cut<T> operator!(const _Cut<T>& a);
 
   typedef double (ExposureFunc_t)(const caf::SRSpill* spill);

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -464,6 +464,7 @@ namespace ana
     } // end for spillcut
 
     // Weights trees
+    // Sigma knobs
     for ( auto& [spillcut, shiftmap] : fNSigmasTreeDefs ) {
       const bool spillpass = spillcut(sr);
       // Cut failed, skip all the histograms that depend on it

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -484,7 +484,7 @@ namespace ana
               std::map<std::string, std::vector<double>> headerVals;
               std::map<std::string, std::vector<double>> recordVals;
               for ( auto& [syst, systname] : treemapIt->second ) {
-                for ( int sigma=-treemapIt->first->NSigma(); sigma<=treemapIt->first->NSigma(); ++sigma ) {
+                for ( int sigma=treemapIt->first->NSigmaLo(systname); sigma<=treemapIt->first->NSigmaHi(systname); ++sigma ) {
 
                   // Need to provide a clean slate for each new set of systematic
                   // shifts to work from. Copying the whole StandardRecord is pretty

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -463,6 +463,68 @@ namespace ana
       } // end for tree
     } // end for spillcut
 
+    // Weights trees
+    for ( auto& [spillcut, shiftmap] : fNSigmasTreeDefs ) {
+      const bool spillpass = spillcut(sr);
+      // Cut failed, skip all the histograms that depend on it
+      if(!spillpass) continue;
+
+      unsigned int idxSlice = 0; // in case we want to save the slice number to the tree
+      // NB: We DON'T keep track of Nominal Cut/Var/etc. because we want to shift/reset shifts for the weight saving... We sacrifice potential speed here by choice.
+      for( caf::SRSliceProxy& slc: sr->slc ) {
+        for ( auto& [shift, cutmap] : shiftmap ) {
+          for ( auto& [cut, treemap] : cutmap ) {
+            const bool pass = cut(&slc);
+            // Cut failed, skip all the histograms that depended on it
+            if(!pass) continue;
+
+            for ( std::map<NSigmasTree*, std::map<const ISyst*, std::string>>::iterator treemapIt=treemap.begin(); treemapIt!=treemap.end(); ++treemapIt ) {
+
+              std::map<std::string, std::vector<double>> headerVals;
+              std::map<std::string, std::vector<double>> recordVals;
+              for ( auto& [syst, systname] : treemapIt->second ) {
+                for ( int sigma=-treemapIt->first->NSigma(); sigma<=treemapIt->first->NSigma(); ++sigma ) {
+
+                  // Need to provide a clean slate for each new set of systematic
+                  // shifts to work from. Copying the whole StandardRecord is pretty
+                  // expensive, so modify it in place and revert it afterwards.
+                  caf::SRProxySystController::BeginTransaction();
+
+                  double systWeight = 1;
+                  // Can special-case nominal to not pay cost of Shift()
+                  if(!shift.IsNominal()){
+                    shift.Shift(&slc, systWeight);
+                  }
+
+                  // Now shift for the weight we want to save
+                  const SystShifts& shiftSigma = SystShifts(syst,sigma);
+                  double systWeightSigma = 1;
+                  shiftSigma.Shift(&slc, systWeightSigma);
+
+                  recordVals[systname].push_back(systWeightSigma);
+
+                  // Reset shifts to get the next sigma
+                  caf::SRProxySystController::Rollback();
+                }
+              }
+              // If fSaveRunSubrunEvt then fill these entries...
+              if ( treemapIt->first->SaveRunSubEvent() ) {
+                headerVals["Run/i"].push_back( sr->hdr.run );
+                headerVals["Subrun/i"].push_back( sr->hdr.subrun );
+                headerVals["Evt/i"].push_back( sr->hdr.evt );
+              }
+              if ( treemapIt->first->SaveSliceNum() ) {
+                headerVals["Slice/i"].push_back( idxSlice );
+              }
+
+              treemapIt->first->UpdateEntries(headerVals,recordVals);
+            } // end for tree
+          } // end for cut
+        } // end for shift
+        idxSlice+=1;
+      } // end for slice
+    } // end for spillcut
+
   }
 
   //----------------------------------------------------------------------
@@ -521,6 +583,17 @@ namespace ana
     for ( auto& [spillcut, treemap] : fSpillTreeDefs ) {
       for ( std::map<Tree*, std::map<SpillVarOrMultiVar, std::string>>::iterator treemapIt=treemap.begin(); treemapIt!=treemap.end(); ++treemapIt ) {
         treemapIt->first->UpdateExposure(fPOT,fNReadouts);
+      }
+    }
+
+    // NSigmasTrees
+    for ( auto& [spillcut, shiftmap] : fNSigmasTreeDefs ) {
+      for ( auto& [shift, cutmap] : shiftmap ) {
+        for ( auto& [cut, treemap] : cutmap ) {
+          for ( std::map<NSigmasTree*, std::map<const ISyst*, std::string>>::iterator treemapIt=treemap.begin(); treemapIt!=treemap.end(); ++treemapIt ) {
+            treemapIt->first->UpdateExposure(fPOT,fNReadouts);
+          }
+        }
       }
     }
 

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -329,7 +329,7 @@ namespace ana
       // Cut failed, skip all the histograms that depend on it
       if(!spillpass) continue;
 
-      //unsigned int idxSlice = 0; // testing
+      unsigned int idxSlice = 0; // in case we want to save the slice number to the tree
       for( caf::SRSliceProxy& slc: sr->slc ) {
         // Some shifts only adjust the weight, so they're effectively nominal,
         // but aren't grouped with the other nominal histograms. Keep track of
@@ -393,11 +393,16 @@ namespace ana
                 //idxVar+=1;
               } // end for var/varname
               // If fSaveRunSubrunEvt then fill these entries...
-              if ( treemapIt->first->SaveRunSubEvent() ) {
+              if ( treemapIt->first->SaveRunSubEvent() || treemapIt->first->SaveSliceNum() ) {
                 for ( unsigned int idxRun=0; idxRun<numEntries; ++idxRun ) {
-                  recordVals["Run/i"].push_back( sr->hdr.run );
-                  recordVals["Subrun/i"].push_back( sr->hdr.subrun );
-                  recordVals["Evt/i"].push_back( sr->hdr.evt );
+                  if ( treemapIt->first->SaveRunSubEvent() ) {
+                    recordVals["Run/i"].push_back( sr->hdr.run );
+                    recordVals["Subrun/i"].push_back( sr->hdr.subrun );
+                    recordVals["Evt/i"].push_back( sr->hdr.evt );
+                  }
+                  if ( treemapIt->first->SaveSliceNum() ) {
+                    recordVals["Slice/i"].push_back( idxSlice );
+                  }
                 }
               }
               treemapIt->first->UpdateEntries(recordVals);
@@ -412,7 +417,7 @@ namespace ana
 
           //idxShift+=1;
         } // end for shift
-        //idxSlice+=1;
+        idxSlice+=1;
       } // end for slice
       //idxSpillCut+=1;
     } // end for spillcut

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -349,6 +349,44 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddTree(Tree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<SpillVar>& vars,
+                                   const SpillCut& spillcut)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Tree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fSpillTreeDefs[spillcut][&tree][ vars.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddTree(Tree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<SpillMultiVar>& vars,
+                                   const SpillCut& spillcut)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Tree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fSpillTreeDefs[spillcut][&tree][ vars.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
   void SpectrumLoaderBase::
   RemoveReweightableSpectrum(ReweightableSpectrum* spect)
   {

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -387,6 +387,27 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddNSigmasTree(NSigmasTree& tree,
+                                          const std::vector<std::string>& labels,
+                                          const std::vector<const ISyst*>& systsToStore,
+                                          const SpillCut& spillcut,
+                                          const Cut& cut,
+                                          const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add WeightsTree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fNSigmasTreeDefs[spillcut][shift][cut][&tree][ systsToStore.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
   void SpectrumLoaderBase::
   RemoveReweightableSpectrum(ReweightableSpectrum* spect)
   {

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -395,7 +395,7 @@ namespace ana
                                           const SystShifts& shift)
   {
     if(fGone){
-      std::cerr << "Error: can't add WeightsTree after the call to Go()" << std::endl;
+      std::cerr << "Error: can't add NSigmasTree after the call to Go()" << std::endl;
       abort();
     }
 

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -408,6 +408,29 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddNUniversesTree(NUniversesTree& tree,
+                                             const std::vector<std::string>& labels,
+                                             const std::vector<std::vector<Var>>& univKnobs,
+                                             const SpillCut& spillcut,
+                                             const Cut& cut,
+                                             const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add NUniversesTree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      std::vector<VarOrMultiVar> vecVarOrMultiVar;
+      for ( unsigned int idxUniv=0; idxUniv<univKnobs.at(idx).size(); ++idxUniv ) vecVarOrMultiVar.push_back( univKnobs.at(idx).at(idxUniv) );
+      fNUniversesTreeDefs[spillcut][shift][cut][&tree][ vecVarOrMultiVar ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
   void SpectrumLoaderBase::
   RemoveReweightableSpectrum(ReweightableSpectrum* spect)
   {

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -7,6 +7,7 @@
 #include "sbnana/CAFAna/Core/Spectrum.h"
 #include "sbnana/CAFAna/Core/Utilities.h"
 #include "sbnana/CAFAna/Core/WildcardSource.h"
+#include "sbnana/CAFAna/Core/Tree.h"
 
 #include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
 
@@ -303,6 +304,48 @@ namespace ana
     fHistDefs[spillcut][shift][slicecut][wei][var].rwSpects.push_back(&spect);
 
     spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddTree(Tree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<Var>& vars,
+                                   const SpillCut& spillcut,
+                                   const Cut& cut,
+                                   const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Tree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fTreeDefs[spillcut][shift][cut][&tree][ vars.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddTree(Tree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<MultiVar>& vars,
+                                   const SpillCut& spillcut,
+                                   const Cut& cut,
+                                   const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Tree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fTreeDefs[spillcut][shift][cut][&tree][ vars.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -27,6 +27,7 @@ namespace ana
   class Tree;
   class WeightsTree;
   class NSigmasTree;
+  class NUniversesTree;
 
   /// Is this data-file representing beam spills or cosmic spills?
   enum DataSource{
@@ -126,6 +127,14 @@ namespace ana
                                 const SpillCut& spillcut,
                                 const Cut& cut,
                                 const SystShifts& shift);
+
+    /// For use by the constructors of \ref NUniversesTree class
+    virtual void AddNUniversesTree(NUniversesTree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<std::vector<Var>>& univKnobs,
+                                   const SpillCut& spillcut,
+                                   const Cut& cut,
+                                   const SystShifts& shift);
 
     /// Load all the registered spectra
     virtual void Go() = 0;
@@ -266,6 +275,8 @@ namespace ana
     std::map<SpillCut, std::map<Tree*, std::map<SpillVarOrMultiVar, std::string>>> fSpillTreeDefs;
     // And a version that saves up the syst weights used to make event-by-event splines
     std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NSigmasTree*, std::map<const ISyst*, std::string>>>>> fNSigmasTreeDefs;
+    // And a version that saves up universe-based systematic weights to make event-by-event weight lists
+    std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NUniversesTree*, std::map<std::vector<VarOrMultiVar>, std::string>>>>> fNUniversesTreeDefs;
   };
 
   // For map-making
@@ -347,6 +358,13 @@ namespace ana
                         const SpillCut& spillcut,
                         const Cut& cut,
                         const SystShifts& shift) override {}
+
+    void AddNUniversesTree(NUniversesTree& tree,
+                           const std::vector<std::string>& labels,
+                           const std::vector<std::vector<Var>>& univKnobs,
+                           const SpillCut& spillcut,
+                           const Cut& cut,
+                           const SystShifts& shift) override {}
   };
   /// \brief Dummy loader that doesn't load any files
   ///

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -25,6 +25,7 @@ namespace ana
   class Spectrum;
   class ReweightableSpectrum;
   class Tree;
+  class WeightsTree;
   class NSigmasTree;
 
   /// Is this data-file representing beam spills or cosmic spills?

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -25,6 +25,7 @@ namespace ana
   class Spectrum;
   class ReweightableSpectrum;
   class Tree;
+  class NSigmasTree;
 
   /// Is this data-file representing beam spills or cosmic spills?
   enum DataSource{
@@ -116,6 +117,14 @@ namespace ana
                          const std::vector<std::string>& labels,
                          const std::vector<SpillMultiVar>& vars,
                          const SpillCut& spillcut);
+
+    /// For use by the constructors of \ref NSigmasTree class
+    virtual void AddNSigmasTree(NSigmasTree& tree,
+                                const std::vector<std::string>& labels,
+                                const std::vector<const ISyst*>& systsToStore,
+                                const SpillCut& spillcut,
+                                const Cut& cut,
+                                const SystShifts& shift);
 
     /// Load all the registered spectra
     virtual void Go() = 0;
@@ -254,6 +263,8 @@ namespace ana
     //       map. But otherwise, let's keep it the same way...
     std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<Tree*, std::map<VarOrMultiVar, std::string>>>>> fTreeDefs;
     std::map<SpillCut, std::map<Tree*, std::map<SpillVarOrMultiVar, std::string>>> fSpillTreeDefs;
+    // And a version that saves up the syst weights used to make event-by-event splines
+    std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NSigmasTree*, std::map<const ISyst*, std::string>>>>> fNSigmasTreeDefs;
   };
 
   // For map-making
@@ -328,6 +339,13 @@ namespace ana
                  const std::vector<std::string>& labels,
                  const std::vector<SpillMultiVar>& vars,
                  const SpillCut& spillcut) override {}
+
+    void AddNSigmasTree(NSigmasTree& tree,
+                        const std::vector<std::string>& labels,
+                        const std::vector<const ISyst*>& systsToStore,
+                        const SpillCut& spillcut,
+                        const Cut& cut,
+                        const SystShifts& shift) override {}
   };
   /// \brief Dummy loader that doesn't load any files
   ///

--- a/sbnana/CAFAna/Core/SystShifts.cxx
+++ b/sbnana/CAFAna/Core/SystShifts.cxx
@@ -166,4 +166,11 @@ namespace ana
 
     return ret;
   }
+
+  //----------------------------------------------------------------------
+  bool operator<(const SystShifts& a, const SystShifts& b)
+  {
+    return a.ID() < b.ID();
+  }
+
 }

--- a/sbnana/CAFAna/Core/SystShifts.h
+++ b/sbnana/CAFAna/Core/SystShifts.h
@@ -58,5 +58,7 @@ namespace ana
     static int fgNextID;
   };
 
+  bool operator< (const SystShifts& a, const SystShifts& b);
+
   const SystShifts kNoShift = SystShifts::Nominal();
 }

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -336,7 +336,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
-  void CovarianceMatrixTree::SaveTo( TDirectory* dir ) const
+  void CovarianceMatrixTree::SaveToDebug( TDirectory* dir, bool shouldSaveUniverses ) const
   {
     assert(fOrderedBranchNames.size() >= 2); // need at least a weight label and a key for the binning...
 
@@ -559,7 +559,24 @@ namespace ana
 
     cvHist->Write( "cvHist" );
 
+    if ( shouldSaveUniverses ) {
+      for ( unsigned int idxU = 0; idxU < fNUniverses; ++idxU ) {
+        TH1D *univHist = new TH1D("CVHist",";x;y",nBins,0,nBins);
+        for ( unsigned int idxUnivHist=0; idxUnivHist<nBins; ++idxUnivHist ) {
+          univHist->SetBinContent(idxUnivHist+1,binCts.at(idxU).at(idxUnivHist));
+        }
+        univHist->Write( TString::Format("hUniverse_%i",idxU) );
+        univHist->~TH1D();
+      }
+    }
+
     tmp->cd();
+  }
+
+  //----------------------------------------------------------------------
+  void CovarianceMatrixTree::SaveTo( TDirectory* dir ) const
+  {
+    this->SaveToDebug( dir, false );
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -7,7 +7,6 @@
 #include "TH2D.h"
 #include "TGraph.h"
 #include "TSpline.h"
-#include "TClonesArray.h"
 
 #include <cassert>
 #include <cmath>
@@ -871,129 +870,6 @@ namespace ana
       }
 
       theTree.Fill();
-    }
-
-    theTree.Write();
-
-    tmp->cd();
-  }
-
-  //----------------------------------------------------------------------
-  void NSigmasTree::SaveToTCA( TDirectory* dir ) const
-  {
-    std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;
-    std::cout << "  " << fNEntries << " Entries" << std::endl;
-    std::cout << "  For " << fPOT << " POT and " << fLivetime << " Livetime" << std::endl;
-    std::cout << "  Containing " << fOrderedBranchWeightNames.size() << " TClonesArrays (of length 1) per entry..." << std::endl;
-
-    // Check (and assert) that the branches all have fNEntries
-    for ( auto const& [branch, values] : fBranchEntries ){
-      assert( (long long)values.size() == fNEntries );
-    }
-    for ( auto const& [branch, weightVecs] : fBranchWeightEntries ){
-      assert( (long long)weightVecs.size() == fNEntries );
-    }
-
-    TDirectory *tmp = gDirectory;
-    dir->cd();
-
-    TH1D thePOT("POT","POT",1,0,1);
-    thePOT.SetBinContent(1,fPOT);
-    thePOT.Write();
-
-    TH1D theLivetime("Livetime","Livetime",1,0,1);
-    theLivetime.SetBinContent(1,fLivetime);
-    theLivetime.Write();
-
-    TTree theTree( fTreeName.c_str(), fTreeName.c_str() );
-
-    const int NBranches = fOrderedBranchNames.size();
-
-    bool treatAsInt[ NBranches ];
-    bool treatAsLong[ NBranches ];
-
-    double entryValsDouble[ NBranches ];
-    int entryValsInt[ NBranches ];
-    long long entryValsLong[ NBranches ];
-
-    for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
-      if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
-        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
-                        &entryValsInt[idxBranch] );
-        treatAsInt[idxBranch] = true;
-        treatAsLong[idxBranch] = false;
-      }
-      else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
-        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
-                        &entryValsInt[idxBranch] );
-        treatAsInt[idxBranch] = true;
-        treatAsLong[idxBranch] = false;
-      }
-      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
-        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
-                        &entryValsLong[idxBranch] );
-        treatAsInt[idxBranch] = false;
-        treatAsLong[idxBranch] = true;
-      }
-      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
-        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
-                        &entryValsLong[idxBranch] );
-        treatAsInt[idxBranch] = false;
-        treatAsLong[idxBranch] = true;
-      }
-      else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
-        std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
-        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
-        treatAsInt[idxBranch] = false;
-        treatAsLong[idxBranch] = false;
-      }
-      else {
-        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
-        treatAsInt[idxBranch] = false;
-        treatAsLong[idxBranch] = false;
-      }
-    }
-
-    std::map<std::string, TClonesArray> graphsArr;
-    for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
-      graphsArr[ fOrderedBranchWeightNames.at(idxBranchWeight) ] = TClonesArray("TGraph",1);
-      theTree.Branch( fOrderedBranchWeightNames.at(idxBranchWeight).c_str(), &graphsArr[ fOrderedBranchWeightNames.at(idxBranchWeight) ] );
-    }
-
-    // Loop over entries
-    for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
-      // Fill up the vals for the standard value branches
-      for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
-        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
-        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
-        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
-        else {
-          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
-        }
-      }
-      // Make the graphs
-      for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
-        const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
-        double sigmasArr[NSigmas];
-        for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
-          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + int(idxSigma));
-        }
-
-        double weightsArr[NSigmas];
-        unsigned int idxVal = 0;
-        for ( auto const& val : fBranchWeightEntries.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at( idxEntry ) ) {
-          weightsArr[ idxVal ] = val;
-          idxVal+=1;
-        }
-        new( graphsArr[ fOrderedBranchWeightNames.at(idxBranchWeight) ][0] ) TGraph(NSigmas,sigmasArr,weightsArr);
-      }
-
-      theTree.Fill();
-
-      for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
-        graphsArr[ fOrderedBranchWeightNames.at(idxBranchWeight) ].Clear("C");
-      }
-
     }
 
     theTree.Write();

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -677,7 +677,15 @@ namespace ana
   //----------------------------------------------------------------------
   void WeightsTree::MergeTree( const Tree& inTree )
   {
-    assert( this->fSaveRunSubEvt && this->fSaveSliceNum && inTree.fSaveRunSubEvt && inTree.fSaveSliceNum );
+    // RunSubEvt must be saved
+    assert( this->fSaveRunSubEvt && inTree.fSaveRunSubEvt );
+    // Tree with SpilVar or TruthVar does not require SliceNum to be saved.
+    // But if either of "This" or "inTree" does save SliceNum, then both should have it saved
+    bool SliceNumIsSaved = false;
+    if( this->fSaveSliceNum || inTree.fSaveSliceNum ){
+      assert( this->fSaveSliceNum && inTree.fSaveSliceNum );
+      SliceNumIsSaved = true;
+    }
 
     // This requires the branches to agree and be in the same order...
     // Someone could write a more complicated version but right now this is the foreseen use.
@@ -686,8 +694,10 @@ namespace ana
       // Entries must be the same
       assert( this->fBranchEntries.at("Run/i").at(idx) == inTree.fBranchEntries.at("Run/i").at(idx) &&
               this->fBranchEntries.at("Subrun/i").at(idx) == inTree.fBranchEntries.at("Subrun/i").at(idx) &&
-              this->fBranchEntries.at("Evt/i").at(idx) == inTree.fBranchEntries.at("Evt/i").at(idx) &&
-              this->fBranchEntries.at("Slice/i").at(idx) == inTree.fBranchEntries.at("Slice/i").at(idx) );
+              this->fBranchEntries.at("Evt/i").at(idx) == inTree.fBranchEntries.at("Evt/i").at(idx) );
+      if(SliceNumIsSaved){
+        assert( this->fBranchEntries.at("Slice/i").at(idx) == inTree.fBranchEntries.at("Slice/i").at(idx) );
+      }
     }
 
     std::vector<std::string> branchesToFill;

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -855,7 +855,7 @@ namespace ana
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         double sigmasArr[NSigmas];
         for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
-          sigmasArr[idxSigma] = double((-1*NSigmas)+int(idxSigma));
+          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + idxSigma);
         }
 
         double weightsArr[NSigmas];
@@ -977,7 +977,7 @@ namespace ana
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         double sigmasArr[NSigmas];
         for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
-          sigmasArr[idxSigma] = double((-1*NSigmas)+int(idxSigma));
+          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + idxSigma);
         }
 
         double weightsArr[NSigmas];

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -7,6 +7,7 @@
 #include "TH2D.h"
 #include "TGraph.h"
 #include "TSpline.h"
+#include "TClonesArray.h"
 
 #include <cassert>
 #include <cmath>
@@ -835,7 +836,7 @@ namespace ana
 
     TSpline3 *splinesArr[NBranchesWeights];
     for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
-      splinesArr[idxBranchWeight] = nullptr;
+      splinesArr[ idxBranchWeight ] = nullptr;
       theTree.Branch( fOrderedBranchWeightNames.at(idxBranchWeight).c_str(), &splinesArr[idxBranchWeight] );
     }
 
@@ -850,7 +851,7 @@ namespace ana
           if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
         }
       }
-      // Make the splines
+      // Fill the splines
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         double sigmasArr[NSigmas];
@@ -870,6 +871,129 @@ namespace ana
       }
 
       theTree.Fill();
+    }
+
+    theTree.Write();
+
+    tmp->cd();
+  }
+
+  //----------------------------------------------------------------------
+  void NSigmasTree::SaveToTCA( TDirectory* dir ) const
+  {
+    std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;
+    std::cout << "  " << fNEntries << " Entries" << std::endl;
+    std::cout << "  For " << fPOT << " POT and " << fLivetime << " Livetime" << std::endl;
+    std::cout << "  Containing " << fOrderedBranchWeightNames.size() << " TClonesArrays (of length 1) per entry..." << std::endl;
+
+    // Check (and assert) that the branches all have fNEntries
+    for ( auto const& [branch, values] : fBranchEntries ){
+      assert( (long long)values.size() == fNEntries );
+    }
+    for ( auto const& [branch, weightVecs] : fBranchWeightEntries ){
+      assert( (long long)weightVecs.size() == fNEntries );
+    }
+
+    TDirectory *tmp = gDirectory;
+    dir->cd();
+
+    TH1D thePOT("POT","POT",1,0,1);
+    thePOT.SetBinContent(1,fPOT);
+    thePOT.Write();
+
+    TH1D theLivetime("Livetime","Livetime",1,0,1);
+    theLivetime.SetBinContent(1,fLivetime);
+    theLivetime.Write();
+
+    TTree theTree( fTreeName.c_str(), fTreeName.c_str() );
+
+    const int NBranches = fOrderedBranchNames.size();
+
+    bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
+    double entryValsDouble[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
+
+    for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
+      if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
+                        &entryValsInt[idxBranch] );
+        treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
+                        &entryValsInt[idxBranch] );
+        treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
+        std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
+      }
+      else {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
+      }
+    }
+
+    std::map<std::string, TClonesArray> graphsArr;
+    for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+      graphsArr[ fOrderedBranchWeightNames.at(idxBranchWeight) ] = TClonesArray("TGraph",1);
+      theTree.Branch( fOrderedBranchWeightNames.at(idxBranchWeight).c_str(), &graphsArr[ fOrderedBranchWeightNames.at(idxBranchWeight) ] );
+    }
+
+    // Loop over entries
+    for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
+      // Fill up the vals for the standard value branches
+      for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
+      }
+      // Make the graphs
+      for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+        const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
+        double sigmasArr[NSigmas];
+        for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
+          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + int(idxSigma));
+        }
+
+        double weightsArr[NSigmas];
+        unsigned int idxVal = 0;
+        for ( auto const& val : fBranchWeightEntries.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at( idxEntry ) ) {
+          weightsArr[ idxVal ] = val;
+          idxVal+=1;
+        }
+        new( graphsArr[ fOrderedBranchWeightNames.at(idxBranchWeight) ][0] ) TGraph(NSigmas,sigmasArr,weightsArr);
+      }
+
+      theTree.Fill();
+
+      for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+        graphsArr[ fOrderedBranchWeightNames.at(idxBranchWeight) ].Clear("C");
+      }
+
     }
 
     theTree.Write();
@@ -1003,7 +1127,7 @@ namespace ana
     std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;
     std::cout << "  " << fNEntries << " Entries" << std::endl;
     std::cout << "  For " << fPOT << " POT and " << fLivetime << " Livetime" << std::endl;
-    std::cout << "  Containing " << fOrderedBranchWeightNames.size() << " splines per entry..." << std::endl;
+    std::cout << "  Containing " << fOrderedBranchWeightNames.size() << " values per entry..." << std::endl;
 
     // Check (and assert) that the branches all have fNEntries
     for ( auto const& [branch, values] : fBranchEntries ){

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -855,7 +855,7 @@ namespace ana
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         double sigmasArr[NSigmas];
         for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
-          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + idxSigma);
+          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + int(idxSigma));
         }
 
         double weightsArr[NSigmas];
@@ -977,7 +977,7 @@ namespace ana
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         double sigmasArr[NSigmas];
         for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
-          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + idxSigma);
+          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + int(idxSigma));
         }
 
         double weightsArr[NSigmas];

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -1,0 +1,118 @@
+#include "sbnana/CAFAna/Core/Tree.h"
+
+#include "TDirectory.h"
+#include "TBranch.h"
+#include "TTree.h"
+
+#include <cassert>
+
+namespace ana
+{
+
+  //----------------------------------------------------------------------
+  // Constructor for a set of Vars, typical usage for a Selected Tree
+  Tree::Tree( const std::string name, const std::vector<std::string>& labels,
+              SpectrumLoaderBase& loader,
+              const std::vector<Var>& vars, const SpillCut& spillcut,
+              const Cut& cut, const SystShifts& shift )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+  {
+    assert( labels.size() == vars.size() );
+
+    for ( unsigned int i=0; i<labels.size(); ++i ) {
+      fOrderedBranchNames.push_back( labels.at(i) );
+      fBranchEntries[labels.at(i)] = {};
+    }
+
+    loader.AddTree( *this, labels, vars, spillcut, cut, shift );
+  }
+
+  //----------------------------------------------------------------------
+  // Constructor for a set of MultiVars
+  Tree::Tree( const std::string name, const std::vector<std::string>& labels,
+              SpectrumLoaderBase& loader,
+              const std::vector<MultiVar>& vars, const SpillCut& spillcut,
+              const Cut& cut, const SystShifts& shift )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+  {
+    assert( labels.size() == vars.size() );
+
+    for ( unsigned int i=0; i<labels.size(); ++i ) {
+      fOrderedBranchNames.push_back( labels.at(i) );
+      fBranchEntries[labels.at(i)] = {};
+    }
+
+    loader.AddTree( *this, labels, vars, spillcut, cut, shift );
+  }
+
+  //----------------------------------------------------------------------
+  // Constructor for a set of SpillVars
+  Tree::Tree( const std::string name, const std::vector<std::string>& labels,
+              SpectrumLoaderBase& loader,
+              const std::vector<Var>& vars, const SpillCut& spillcut)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+  {
+    assert( labels.size() == vars.size() );
+
+    for ( unsigned int i=0; i<labels.size(); ++i ) {
+      fOrderedBranchNames.push_back( labels.at(i) );
+      fBranchEntries[labels.at(i)] = {};
+    }
+
+    loader.AddTree( *this, labels, vars, spillcut, cut, shift );
+  }
+
+  //----------------------------------------------------------------------
+  // Add an entry to a branch
+  void Tree::AddEntry( const std::string name, const double val )
+  {
+    assert ( fBranchEntries.find(name) != fBranchEntries.end() );
+  
+    fBranchEntries.at(name).push_back(val);
+  }
+
+  //----------------------------------------------------------------------
+  // Save to a ROOT file directory as a TTree -- similar to Spectrum::SaveTo()
+  void Tree::SaveTo( TDirectory* dir ) const
+  {
+    std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;
+    std::cout << "  " << fNEntries << " Entries" << std::endl;
+    std::cout << "  For " << fPOT << " POT and " << fLivetime << " Livetime" << std::endl;
+    if ( fNEntries>=1 ) {
+      std::cout << "  Sample:" << std::endl;
+      for ( auto const& [key, value] : fBranchEntries ) {
+        std::cout << "    " << key << " has first value " << value.at(0) << std::endl;
+      }
+    }
+    else {
+      std::cout << "    Double checking --> " << fOrderedBranchNames.at(0)
+                << " has size " <<  fBranchEntries.at( fOrderedBranchNames.at(0) ).size() << std::endl;
+    }
+
+    TDirectory *tmp = gDirectory;
+    dir->cd();
+
+    TTree theTree( fTreeName.c_str(), fTreeName.c_str() );
+
+    const int NBranches = fOrderedBranchNames.size();
+    double entryVals[ NBranches ];
+
+    for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
+      theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryVals[idxBranch] );
+    }
+
+    // Loop over entries
+    for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
+      // Fill up the vals
+      for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
+        entryVals[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+      }
+      theTree.Fill();
+    }
+
+    theTree.Write();
+
+    tmp->cd();
+  }
+
+}

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -4,6 +4,7 @@
 #include "TBranch.h"
 #include "TTree.h"
 #include "TH1D.h"
+#include "TH2D.h"
 #include "TGraph.h"
 #include "TSpline.h"
 
@@ -256,6 +257,356 @@ namespace ana
     theTree.Write();
 
     tmp->cd();
+  }
+
+  //----------------------------------------------------------------------
+  CovarianceMatrixTree::CovarianceMatrixTree( const std::string name, const std::vector<std::string>& labels, const std::string weightLabel,
+                                              const std::vector< std::vector<std::pair<std::string,std::pair<double,double>>> >& binning,
+                                              SpectrumLoaderBase& loader, const std::vector<SpillMultiVar>& vars, const unsigned int nUniverses,
+                                              const SpillCut& spillcut )
+    : Tree(name,labels,loader,vars,spillcut,false),fWeightLabel(weightLabel),fNUniverses(nUniverses)
+  {
+    assert( labels.size() == vars.size() );
+    fWeights = {};
+
+    // Reconstruct a binning map from the passed vector:
+    unsigned int idxBin = 1;
+    for ( auto const& binCuts : binning ) {
+      fBinning[idxBin] = binCuts;
+      idxBin+=1;
+    }
+
+    // Check that the cuts make sense:
+    // Logic: any cut that appears in the first bin must appear in the rest, and
+    //        nothing can appear in a latter bin that isn't in the first
+    // TODO: we DO NOT check that no two bins have the same cuts...
+    // TODO: also we DO NOT check, but assume later, that if it's a one-value bin
+    //       in the first case then it's always this way...
+    std::set<std::string> tmpCuts;
+
+    for ( auto const& [bin, cuts] : fBinning ) {
+      if ( tmpCuts.size()==0 ) {
+        for ( auto const& cut : cuts ) {
+          assert(tmpCuts.find(cut.first)==tmpCuts.end());
+          tmpCuts.emplace( cut.first );
+        }
+      }
+      else {
+        assert(cuts.size()==tmpCuts.size());
+        for ( auto const& cut : cuts ) {
+          assert(tmpCuts.find(cut.first)!=tmpCuts.end());
+        }
+      }
+    }
+    assert(tmpCuts.size()!=0);
+  }
+
+  //----------------------------------------------------------------------
+  void CovarianceMatrixTree::UpdateEntries( const std::map<std::string, std::vector<double>> valsMap )
+  {
+    unsigned int idxBranch = 0;
+    unsigned int previousSize=0;
+    for ( auto const& [name, vals] : valsMap ) {
+      if ( idxBranch>0 && name.compare(fWeightLabel)!=0 ) assert(previousSize == vals.size());
+      else if ( idxBranch>0 && name.compare(fWeightLabel)==0 ) assert(previousSize == vals.size()/fNUniverses);
+
+      if ( name.compare(fWeightLabel)!=0 ) {
+        assert ( fBranchEntries.find(name) != fBranchEntries.end() );
+        previousSize = vals.size();
+        fBranchEntries.at(name).insert(fBranchEntries.at(name).end(),vals.begin(),vals.end());
+        idxBranch+=1;
+      }
+      else {
+        previousSize = vals.size()/fNUniverses;
+        std::vector<double> thisWts;        
+        for ( unsigned int idxWt=0; idxWt < vals.size(); ++idxWt ) {
+          thisWts.push_back( vals.at(idxWt) );
+          if ( thisWts.size() == fNUniverses ) {
+            fWeights.push_back(thisWts);
+            thisWts.clear();
+          }
+        }
+        // Still fill the main branch
+        fBranchEntries.at(name).insert(fBranchEntries.at(name).end(),vals.begin(),vals.end());
+      }
+    }
+
+    fNEntries+=(long long)previousSize;
+  }
+
+  //----------------------------------------------------------------------
+  void CovarianceMatrixTree::SaveTo( TDirectory* dir ) const
+  {
+    assert(fOrderedBranchNames.size() >= 2); // need at least a weight label and a key for the binning...
+
+    // Pick a random key and double check the sizes make sense
+    std::string key = fOrderedBranchNames.at(0);
+    if ( key.compare(fWeightLabel)==0 ) key = fOrderedBranchNames.at(1);
+    assert( fNEntries==(long long)fWeights.size() && fBranchEntries.at(key).size()==fWeights.size() );
+
+    std::cout << "SAVING a covariance matrix for the variable labeled " << fWeightLabel << " with binning:" << std::endl;
+    PrintBinning();
+
+    TDirectory *tmp = gDirectory;
+    dir->cd();
+
+    TH1D thePOT("POT","POT",1,0,1);
+    thePOT.SetBinContent(1,fPOT);
+    thePOT.Write();
+
+    TH1D theLivetime("Livetime","Livetime",1,0,1);
+    theLivetime.SetBinContent(1,fLivetime);
+    theLivetime.Write();
+
+    // Make the covariance matrix
+    const unsigned int nBins = fBinning.size();
+
+    // construct the bins to sum weights
+    std::vector<std::vector<double>> binCts;
+    for ( unsigned int idxU = 0; idxU < fNUniverses; ++idxU ) {
+      std::vector<double> binCtsU;
+      for ( unsigned int idxB = 0; idxB < nBins; ++idxB ) {
+        binCtsU.push_back(0.);
+      }
+      binCts.push_back( binCtsU );
+    }
+
+    // fill them 
+    for ( unsigned int idxEntry = 0; idxEntry < fNEntries; ++idxEntry ) {
+      // determine bin:
+      int theBin = 0;
+      for ( auto const& [bin, cuts] : fBinning ) {
+        bool failedCut = false;
+        for ( auto const& cut : cuts ) {
+          if ( failedCut ) continue;
+          assert( fBranchEntries.find(cut.first)!=fBranchEntries.end() );
+          const double loVal = cut.second.first;
+          const double hiVal = cut.second.second;
+          // Treat as long ints if needed
+          if ( cut.first.find("/i")!=std::string::npos ||
+               cut.first.find("/I")!=std::string::npos ) {
+            const int loValI = std::lround(loVal);
+            const int hiValI = std::lround(hiVal);
+            const int thisVal = std::lround( fBranchEntries.at(cut.first).at(idxEntry) );
+            if ( loValI==hiValI ) {
+              if ( thisVal!=loValI ) {
+                failedCut = true;
+              }
+            }
+            else if ( thisVal <= loValI || thisVal > hiValI ){
+              failedCut = true;
+            }
+          }
+          else if ( cut.first.find("/l")!=std::string::npos ||
+                    cut.first.find("/L")!=std::string::npos ) {
+            const long long loValI = std::lround(loVal);
+            const long long hiValI = std::lround(hiVal);
+            const long long thisVal = std::lround( fBranchEntries.at(cut.first).at(idxEntry) );
+            if ( loValI==hiValI ) {
+              if ( thisVal!=loValI ) {
+                failedCut = true;
+              }
+            }
+            else if ( thisVal <= loValI || thisVal > hiValI ){
+              failedCut = true;
+            }
+          }
+          // double check if the lo and hi are the same
+          else if ( fabs(hiVal-loVal) < std::numeric_limits<double>::epsilon() ) {
+            std::cout << "WARNING!!! You may have been expecting " << cut.first << " to be an integer but it's being treated like a double!" << std::endl;
+            const double thisVal = fBranchEntries.at(cut.first).at(idxEntry);
+            if ( fabs(thisVal-loVal) > std::numeric_limits<double>::epsilon() ) failedCut = true;
+          }
+          // else check the range, inclusive on high edge
+          else {
+            const double thisVal = fBranchEntries.at(cut.first).at(idxEntry);
+            if ( thisVal <= loVal || thisVal > hiVal ){
+              failedCut = true;
+            }
+          }
+        }
+        // if got to the end of cuts and we pass, then this is our bin
+        if( !failedCut ){
+          theBin = bin;
+          break;
+        }
+      }
+      // if under- or over-flow then skip this event
+      if ( theBin == 0 ) continue;
+
+      // fill for each universe:
+      for ( unsigned int idxU = 0; idxU < fNUniverses; ++idxU ) {
+        //if ( idxEntry < 10 ) std::cout << "idxEntry " << idxEntry << ": filling bin " << theBin << " with value " << (fWeights.at(idxEntry).at(idxU)-1.) << " for universe " << idxU << std::endl;
+        binCts.at(idxU).at(theBin-1)+=(fWeights.at(idxEntry).at(idxU)); // Was thinking to subtract 1 to make it relative contributions but it's all relative to the mean so I think I don't want to do that...
+      }
+    }
+
+    // Make the vector of means
+    std::vector<double> means;
+    for ( unsigned int idxB = 0; idxB < nBins; ++idxB ) {
+      double sum = 0.;
+      for ( unsigned int idxU = 0; idxU < fNUniverses; ++idxU ){
+        sum+=binCts.at(idxU).at(idxB);
+      }
+
+      means.push_back( sum / fNUniverses );
+    }
+
+    // To make the correlation matrix we also want standard deviations
+    std::vector<double> sigmas;
+    for ( unsigned int idxB = 0; idxB < nBins; ++idxB ) {
+      double sum = 0.;
+      for ( unsigned int idxU = 0; idxU < fNUniverses; ++idxU ){
+        sum+=std::pow(binCts.at(idxU).at(idxB)-means.at(idxB),2);
+      }
+
+      sigmas.push_back( std::sqrt(sum / (fNUniverses-1)) );
+    }
+
+    //std::cout << "Means and sigmas per bin:" << std::endl;
+    //for ( unsigned int idxB = 0; idxB < nBins; ++idxB ) {
+    //  std::cout << "Bin " << idxB+1 << ", mean: " << means.at(idxB) << ", sigma: " << sigmas.at(idxB) << std::endl;
+    //}
+
+    // Now make a TH2D to write the covariance (using formula as in Forumula 10 of sbn-doc-27384):
+    TH2D *h_cov_mtx = new TH2D( TString::Format("hCovMtx_%s",fWeightLabel.c_str()), ";bins;bins", nBins, 1, nBins+1, nBins, 1, nBins+1 );
+
+    for ( unsigned int xBin=1; xBin<=nBins; ++xBin ) {
+      for ( unsigned int yBin=1; yBin<=nBins; ++yBin ) {
+        double cov = 0.;
+        for ( unsigned int idxU = 0; idxU < fNUniverses; ++idxU ) {
+          //if ( xBin < 3 ) std::cout << "xBin " << xBin << ", yBin " << yBin << ": Adding to covariance " << ((binCts.at(idxU).at(xBin-1)-means.at(xBin-1))*(binCts.at(idxU).at(yBin-1)-means.at(yBin-1))) << " for universe " << idxU << std::endl;
+          cov+=((binCts.at(idxU).at(xBin-1)-means.at(xBin-1))*(binCts.at(idxU).at(yBin-1)-means.at(yBin-1)));
+        }
+        cov/=(fNUniverses-1);
+
+        h_cov_mtx->SetBinContent(xBin,yBin,cov);
+      }
+    }
+
+    h_cov_mtx->Write();
+
+    // and using the documentation in https://root.cern/doc/master/group__Matrix.html
+    // Let's also save this as a TMatrixD
+    // TODO: do I need to save overflow/underflow?
+    TArrayD tarray(nBins*nBins);
+
+    for ( unsigned int xBin=1; xBin<=nBins; ++xBin ) {
+      const unsigned int row = xBin-1;
+      for ( unsigned int yBin=1; yBin<=nBins; ++yBin ) {
+        const unsigned int column = yBin-1;
+        const double val = h_cov_mtx->GetBinContent(xBin,yBin);
+        tarray[nBins*row+column] = val;
+      }
+    }
+
+    TMatrixD cov_mtx(nBins,nBins);
+    cov_mtx.SetMatrixArray(tarray.GetArray());
+
+    cov_mtx.Write( TString::Format("hCovMtx_%s",fWeightLabel.c_str()) );
+
+    // And correlation matrix, by way of Corr(X,Y) = Cov(X,Y)/Sigma(X)Sigma(Y)
+    // See e.g. PDG 2018, Chapter 39 Page 25, or https://en.wikipedia.org/wiki/Correlation#Correlation_matrices
+    TH2D *h_corr_mtx = new TH2D( TString::Format("hCorrMtx_%s",fWeightLabel.c_str()), ";bins;bins", nBins, 1, nBins+1, nBins, 1, nBins+1 );
+
+    for ( unsigned int xBin=1; xBin<=nBins; ++xBin ) {
+      for ( unsigned int yBin=1; yBin<=nBins; ++yBin ) {
+        double corr = h_cov_mtx->GetBinContent(xBin,yBin) / (sigmas[xBin-1]*sigmas[yBin-1]);
+
+        h_corr_mtx->SetBinContent(xBin,yBin,corr);
+      }
+    }
+
+    h_corr_mtx->Write();
+
+    TArrayD tarray_corr(nBins*nBins);
+    for ( unsigned int xBin=1; xBin<=nBins; ++xBin ) {
+      const unsigned int row = xBin-1;
+      for ( unsigned int yBin=1; yBin<=nBins; ++yBin ) {
+        const unsigned int column = yBin-1;
+        const double val = h_corr_mtx->GetBinContent(xBin,yBin);
+        tarray_corr[nBins*row+column] = val;
+      }
+    }
+    TMatrixD corr_mtx(nBins,nBins);
+    corr_mtx.SetMatrixArray(tarray_corr.GetArray());
+
+    corr_mtx.Write( TString::Format("hCorrMtx_%s",fWeightLabel.c_str()) );
+
+    tmp->cd();
+  }
+
+  //----------------------------------------------------------------------
+  void CovarianceMatrixTree::PrintBinning() const
+  {
+    std::vector<std::string> cutNames;
+    std::vector<bool> treatAsInt;
+    std::vector<bool> treatAsLong;
+    std::vector<bool> treatOnlyLo;
+
+    for ( auto const& [bin, cuts] : fBinning ) {
+      if ( cutNames.size()==0 ) {
+        std::string HdrString = "variables: ";
+        for ( auto const& cut : cuts ) {
+          cutNames.push_back( cut.first );
+
+          if ( cut.first.find("/i")!=std::string::npos ||
+               cut.first.find("/I")!=std::string::npos ) {
+            treatAsInt.push_back(true);
+            treatAsLong.push_back(false);
+            int checkLo = std::lround(cut.second.first);
+            int checkHi = std::lround(cut.second.second);
+            if ( checkLo==checkHi ) treatOnlyLo.push_back(true);
+            else treatOnlyLo.push_back(false);
+
+            HdrString+=(cut.first+" ");
+          }
+          else if ( cut.first.find("/l")!=std::string::npos ||
+                    cut.first.find("/L")!=std::string::npos ) {
+            treatAsInt.push_back(false);
+            treatAsLong.push_back(true);
+            long long checkLo = std::lround(cut.second.first);
+            long long checkHi = std::lround(cut.second.second);
+            if ( checkLo==checkHi ) treatOnlyLo.push_back(true);
+            else treatOnlyLo.push_back(false);
+
+            HdrString+=(cut.first+" ");
+          }
+          else {
+            treatAsInt.push_back(false);
+            treatAsLong.push_back(false);
+            treatOnlyLo.push_back(false);
+            HdrString+=(cut.first+" "+cut.first+" ");
+          }
+        }
+        std::cout << HdrString << std::endl;
+      }
+
+      std::string BinString;
+      for ( unsigned int idxCut = 0; idxCut<cutNames.size(); ++idxCut ) {
+        auto const& cut = fBinning.at(bin).at(idxCut);
+        const double loVal = cut.second.first;
+        const double hiVal = cut.second.second;
+
+        if ( treatAsInt[idxCut] ) { 
+          const int loValI = std::lround(loVal);
+          const int hiValI = std::lround(hiVal);
+
+          if ( treatOnlyLo[idxCut] ) BinString+=(std::to_string(loValI)+" ");
+          else BinString+=(std::to_string(loValI)+" "+std::to_string(hiValI)+" ");
+        }
+        else if ( treatAsLong[idxCut] ) { 
+          const long long loValI = std::lround(loVal);
+          const long long hiValI = std::lround(hiVal);
+
+          if ( treatOnlyLo[idxCut] ) BinString+=(std::to_string(loValI)+" ");
+          else BinString+=(std::to_string(loValI)+" "+std::to_string(hiValI)+" ");
+        }
+        else BinString+=(std::to_string(loVal)+" "+std::to_string(hiVal)+" ");
+      }
+      std::cout << BinString << std::endl;
+
+    }
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -561,7 +561,7 @@ namespace ana
 
     if ( shouldSaveUniverses ) {
       for ( unsigned int idxU = 0; idxU < fNUniverses; ++idxU ) {
-        TH1D *univHist = new TH1D("CVHist",";x;y",nBins,0,nBins);
+        TH1D *univHist = new TH1D( TString::Format("hUniverse_%i",idxU) ,";x;y",nBins,0,nBins);
         for ( unsigned int idxUnivHist=0; idxUnivHist<nBins; ++idxUnivHist ) {
           univHist->SetBinContent(idxUnivHist+1,binCts.at(idxU).at(idxUnivHist));
         }

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -452,6 +452,126 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void NSigmasTree::SaveToGraphs( TDirectory* dir ) const
+  {
+    std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;
+    std::cout << "  " << fNEntries << " Entries" << std::endl;
+    std::cout << "  For " << fPOT << " POT and " << fLivetime << " Livetime" << std::endl;
+    std::cout << "  Containing " << fOrderedBranchWeightNames.size() << " graphs per entry..." << std::endl;
+
+    // Check (and assert) that the branches all have fNEntries
+    for ( auto const& [branch, values] : fBranchEntries ){
+      assert( (long long)values.size() == fNEntries );
+    }
+    for ( auto const& [branch, weightVecs] : fBranchWeightEntries ){
+      assert( (long long)weightVecs.size() == fNEntries );
+    }
+
+    TDirectory *tmp = gDirectory;
+    dir->cd();
+
+    TH1D thePOT("POT","POT",1,0,1);
+    thePOT.SetBinContent(1,fPOT);
+    thePOT.Write();
+
+    TH1D theLivetime("Livetime","Livetime",1,0,1);
+    theLivetime.SetBinContent(1,fLivetime);
+    theLivetime.Write();
+
+    TTree theTree( fTreeName.c_str(), fTreeName.c_str() );
+
+    const int NBranches = fOrderedBranchNames.size();
+
+    bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
+    double entryValsDouble[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
+
+    for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
+      if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
+                        &entryValsInt[idxBranch] );
+        treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
+                        &entryValsInt[idxBranch] );
+        treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
+        std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
+      }
+      else {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
+      }
+    }
+
+    const int NBranchesWeights = fOrderedBranchWeightNames.size();
+    const int NSigmas = 2*fNSigma+1;
+
+    double sigmasArr[NSigmas];
+    for ( unsigned int idxSigma=0; idxSigma<2*fNSigma+1; ++idxSigma ) {
+      sigmasArr[idxSigma] = double((-1*int(fNSigma))+int(idxSigma));
+    }
+
+    TGraph *graphsArr[NBranchesWeights];
+    for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+      graphsArr[idxBranchWeight] = nullptr;
+      theTree.Branch( fOrderedBranchWeightNames.at(idxBranchWeight).c_str(), &graphsArr[idxBranchWeight] );
+    }
+
+    // Loop over entries
+    for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
+      // Fill up the vals for the standard value branches
+      for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
+      }
+      // Make the graphs
+      for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+        double weightsArr[NSigmas];
+        unsigned int idxVal = 0;
+        for ( auto const& val : fBranchWeightEntries.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at( idxEntry ) ) {
+          weightsArr[ idxVal ] = val;
+          idxVal+=1;
+        }
+        graphsArr[ idxBranchWeight ] = new TGraph(NSigmas,sigmasArr,weightsArr);
+      }
+
+      theTree.Fill();
+    }
+
+    theTree.Write();
+
+    tmp->cd();
+  }
+
+  //----------------------------------------------------------------------
   void NSigmasTree::SaveTo( TDirectory* dir ) const
   {
     std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -16,14 +16,24 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<Var>& vars, const SpillCut& spillcut,
-              const Cut& cut, const SystShifts& shift )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
   {
     assert( labels.size() == vars.size() );
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );
       fBranchEntries[labels.at(i)] = {};
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut, cut, shift );
@@ -34,14 +44,24 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<MultiVar>& vars, const SpillCut& spillcut,
-              const Cut& cut, const SystShifts& shift )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
   {
     assert( labels.size() == vars.size() );
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );
       fBranchEntries[labels.at(i)] = {};
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut, cut, shift );
@@ -51,14 +71,24 @@ namespace ana
   // Constructor for a set of SpillVars
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
-              const std::vector<SpillVar>& vars, const SpillCut& spillcut)
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+              const std::vector<SpillVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
   {
     assert( labels.size() == vars.size() );
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );
       fBranchEntries[labels.at(i)] = {};
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut );
@@ -68,14 +98,24 @@ namespace ana
   // Constructor for a set of SpillMultiVars
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
-              const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut)
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+              const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
   {
     assert( labels.size() == vars.size() );
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );
       fBranchEntries[labels.at(i)] = {};
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut );

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -195,28 +195,47 @@ namespace ana
     const int NBranches = fOrderedBranchNames.size();
 
     bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
     double entryValsDouble[ NBranches ];
-    long long entryValsInt[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
 
     for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
       if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
         std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
       else {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
     }
 
@@ -224,8 +243,12 @@ namespace ana
     for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
       // Fill up the vals
       for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
-        if ( !treatAsInt[idxBranch] ) entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
-        else                          entryValsInt[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
       }
       theTree.Fill();
     }
@@ -338,28 +361,47 @@ namespace ana
     const int NBranches = fOrderedBranchNames.size();
 
     bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
     double entryValsDouble[ NBranches ];
-    long long entryValsInt[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
 
     for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
       if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
         std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
       else {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
     }
 
@@ -381,8 +423,12 @@ namespace ana
     for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
       // Fill up the vals for the standard value branches
       for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
-        if ( !treatAsInt[idxBranch] ) entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
-        else                          entryValsInt[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
       }
       // Make the splines
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
@@ -437,28 +483,47 @@ namespace ana
     const int NBranches = fOrderedBranchNames.size();
 
     bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
     double entryValsDouble[ NBranches ];
-    long long entryValsInt[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
 
     for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
       if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
         std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
       else {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
     }
 
@@ -479,8 +544,12 @@ namespace ana
     for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
       // Fill up the vals for the standard value branches
       for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
-        if ( !treatAsInt[idxBranch] ) entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
-        else                          entryValsInt[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
       }
       // Save the weights
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
@@ -551,28 +620,47 @@ namespace ana
     const int NBranches = fOrderedBranchNames.size();
 
     bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
     double entryValsDouble[ NBranches ];
-    long long entryValsInt[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
 
     for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
       if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
         std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
       else {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
     }
 
@@ -591,8 +679,12 @@ namespace ana
     for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
       // Fill up the vals for the standard value branches
       for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
-        if ( !treatAsInt[idxBranch] ) entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
-        else                          entryValsInt[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
       }
       // Save the weights
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -16,8 +16,8 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<Var>& vars, const SpillCut& spillcut,
-              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
+              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt, const bool saveSliceNum )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum)
   {
     assert( labels.size() == vars.size() );
 
@@ -34,6 +34,10 @@ namespace ana
       fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
       fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
       fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
+    }
+    if ( saveSliceNum ) {
+      assert( fBranchEntries.find("Slice/i") == fBranchEntries.end() );
+      fOrderedBranchNames.push_back( "Slice/i" ); fBranchEntries["Slice/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut, cut, shift );
@@ -44,8 +48,8 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<MultiVar>& vars, const SpillCut& spillcut,
-              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
+              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt, const bool saveSliceNum )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum)
   {
     assert( labels.size() == vars.size() );
 
@@ -63,6 +67,10 @@ namespace ana
       fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
       fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
+    if ( saveSliceNum ) {
+      assert( fBranchEntries.find("Slice/i") == fBranchEntries.end() );
+      fOrderedBranchNames.push_back( "Slice/i" ); fBranchEntries["Slice/i"] = {};
+    }
 
     loader.AddTree( *this, labels, vars, spillcut, cut, shift );
   }
@@ -72,7 +80,7 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<SpillVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false)
   {
     assert( labels.size() == vars.size() );
 
@@ -99,7 +107,7 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false)
   {
     assert( labels.size() == vars.size() );
 
@@ -139,7 +147,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
-  // Add an entry to a branch
+  // Update branch exposure
   void Tree::UpdateExposure( const double pot, const double livetime )
   {
     fPOT+=pot;

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -109,6 +109,7 @@ namespace ana
                  const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
+    void SaveToGraphs( TDirectory* dir ) const;
   };
 
   class NUniversesTree : public WeightsTree

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -76,6 +76,7 @@ namespace ana
                           const SpillCut& spillcut );
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
     void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap ) override;
+    void SaveToDebug( TDirectory* dir, bool shouldSaveUniverses = true ) const;
     void SaveTo( TDirectory* dir ) const override;
     void PrintBinning() const;
   private:

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -140,6 +140,7 @@ namespace ana
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;
+    void SaveToTCA( TDirectory* dir ) const; // save to TClonesArray
   };
 
   class NUniversesTree : public WeightsTree

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -114,8 +114,8 @@ namespace ana
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::map< std::string, std::vector<std::vector<double>>> fBranchWeightEntries;
-    std::map< std::string, unsigned int> fNSigmasLo;
-    std::map< std::string, unsigned int> fNSigmasHi;
+    std::map< std::string, int> fNSigmasLo;
+    std::map< std::string, int> fNSigmasHi;
     std::map< std::string, unsigned int> fNWeightsExpected;
     //std::map< std::string, std::vector<double>> fNWeightsThrows; // stores the expected ordering of NSigmas per knob or universe throws per knob.
     std::string fTreeName;

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -140,7 +140,6 @@ namespace ana
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;
-    void SaveToTCA( TDirectory* dir ) const; // save to TClonesArray
   };
 
   class NUniversesTree : public WeightsTree

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -140,6 +140,7 @@ namespace ana
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;
+    void SaveToTClonesArrays( TDirectory* dir ) const;
   };
 
   class NUniversesTree : public WeightsTree

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -40,10 +40,10 @@ namespace ana
           SpectrumLoaderBase& loader,
           const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut );
     // Add functionality to update the protected stuff from elsewhere
-    void AddEntry( const std::string name, const double val ); // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
-    void UpdateNEntries( const long long val ) { fNEntries+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
-    void UpdatePOT( const double val ) { fPOT+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
-    void UpdateLivetime( const double val ) { fLivetime+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    /// Function to update protected members (the branches). DO NOT USE outside of the filling.
+    void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap );
+    /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
+    void UpdateExposure ( const double pot, const double livetime );
     // Utilities
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -41,7 +41,7 @@ namespace ana
           const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt = false );
     // Add functionality to update the protected stuff from elsewhere
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
-    void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap );
+    virtual void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap );
     /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
     void UpdateExposure ( const double pot, const double livetime );
     // Utilities
@@ -52,7 +52,7 @@ namespace ana
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
-    void SaveTo( TDirectory* dir ) const;
+    virtual void SaveTo( TDirectory* dir ) const;
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::string fTreeName;
@@ -83,7 +83,6 @@ namespace ana
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
-    virtual void SaveToSplines( TDirectory* dir ) const = 0;
     virtual void SaveTo( TDirectory* dir ) const = 0;
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
@@ -108,8 +107,21 @@ namespace ana
                  SpectrumLoaderBase& loader,
                  const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
                  const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
-    void SaveToSplines( TDirectory* dir ) const override;
-    void SaveTo( TDirectory* dir ) const override {SaveToSplines(dir);} // TODO: update this to save a Tree of std::vector<double> instead of splines if desired...
+    void SaveTo( TDirectory* dir ) const override;
+    void SaveToSplines( TDirectory* dir ) const;
+  };
+
+  class NUniversesTree : public WeightsTree
+  {
+  public:
+    /// constructor with a vector of vectors of \ref Var corresponding to a number of universes for which we want to extract weights
+    NUniversesTree( const std::string name, const std::vector<std::string>& labels,
+                    SpectrumLoaderBase& loader,
+                    const std::vector<std::vector<Var>>& univsKnobs, const unsigned int nUniverses,
+                    const SpillCut& spillcut,
+                    const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    void SaveTo( TDirectory* dir ) const override;
+    unsigned int NUniverses() const {return fNSigma;}
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -54,6 +54,7 @@ namespace ana
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     virtual void SaveTo( TDirectory* dir ) const;
   protected:
+    friend class WeightsTree;
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::string fTreeName;
     std::vector<std::string> fOrderedBranchNames;
@@ -69,7 +70,11 @@ namespace ana
   {
   public:
     WeightsTree( const std::string name, const std::vector<std::string>& labels,
-                 const unsigned int nSigma, const bool saveRunSubEvt, const bool saveSliceNum, const unsigned int nWeightsExpected );
+                 const std::vector<unsigned int>& nWeights, const bool saveRunSubEvt, const bool saveSliceNum );
+    WeightsTree( const std::string name, const std::vector<std::string>& labels,
+                 const std::vector<std::pair<int,int>>& nSigma, const bool saveRunSubEvt, const bool saveSliceNum );
+    /// Function to merge the WeightsTree with a Tree, assuming both have fSaveRunSubEvt and fSaveSliceNum set to true
+    void MergeTree( const Tree& inTree );
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
     void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap, const std::map<std::string, std::vector<double>> weightMap );
     /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
@@ -78,7 +83,9 @@ namespace ana
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
-    int NSigma() const {return fNSigma;} // return as an int, then -NSigma to NSigma means something
+    int NSigmaLo(const std::string& systToNSigma) const {return fNSigmasLo.at(systToNSigma);}
+    int NSigmaHi(const std::string& systToNSigma) const {return fNSigmasHi.at(systToNSigma);}
+    unsigned int NWeights(const std::string& systToNWts) const {return fNWeightsExpected.at(systToNWts);}
     bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
@@ -87,6 +94,10 @@ namespace ana
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::map< std::string, std::vector<std::vector<double>>> fBranchWeightEntries;
+    std::map< std::string, unsigned int> fNSigmasLo;
+    std::map< std::string, unsigned int> fNSigmasHi;
+    std::map< std::string, unsigned int> fNWeightsExpected;
+    //std::map< std::string, std::vector<double>> fNWeightsThrows; // stores the expected ordering of NSigmas per knob or universe throws per knob.
     std::string fTreeName;
     std::vector<std::string> fOrderedBranchNames;
     std::vector<std::string> fOrderedBranchWeightNames;
@@ -95,8 +106,6 @@ namespace ana
     double fLivetime;
     bool fSaveRunSubEvt;
     bool fSaveSliceNum;
-    unsigned int fNSigma;
-    unsigned int fNWeightsExpected;
   };
 
   class NSigmasTree : public WeightsTree
@@ -105,8 +114,9 @@ namespace ana
     /// constructor with a vector of \ref ISyst
     NSigmasTree( const std::string name, const std::vector<std::string>& labels,
                  SpectrumLoaderBase& loader,
-                 const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
-                 const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+                 const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
+                 const SpillCut& spillcut,
+                 const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;
@@ -118,11 +128,10 @@ namespace ana
     /// constructor with a vector of vectors of \ref Var corresponding to a number of universes for which we want to extract weights
     NUniversesTree( const std::string name, const std::vector<std::string>& labels,
                     SpectrumLoaderBase& loader,
-                    const std::vector<std::vector<Var>>& univsKnobs, const unsigned int nUniverses,
+                    const std::vector<std::vector<Var>>& univsKnobs, const std::vector<unsigned int>& nUniverses,
                     const SpillCut& spillcut,
                     const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     void SaveTo( TDirectory* dir ) const override;
-    unsigned int NUniverses() const {return fNSigma;}
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -25,20 +25,20 @@ namespace ana
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<Var>& vars, const SpillCut& spillcut,
-          const Cut& cut, const SystShifts& shift = kNoShift );
+          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
     /// constructor with a vector of \ref MultiVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<MultiVar>& vars, const SpillCut& spillcut,
-          const Cut& cut, const SystShifts& shift = kNoShift );
+          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
     /// constructor with a vector of \ref SpillVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
-          const std::vector<SpillVar>& vars, const SpillCut& spillcut );
+          const std::vector<SpillVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt = false );
     /// constructor with a vector of \ref SpillMultiVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
-          const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut );
+          const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt = false );
     // Add functionality to update the protected stuff from elsewhere
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
     void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap );
@@ -48,6 +48,7 @@ namespace ana
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
+    bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void SaveTo( TDirectory* dir ) const;
@@ -58,6 +59,7 @@ namespace ana
     long long fNEntries;
     double fPOT;
     double fLivetime;
+    bool fSaveRunSubEvt;
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -65,6 +65,26 @@ namespace ana
     bool fSaveSliceNum;
   };
 
+  /// Allows to make covariance matrices using \ref Tree objects cleverly
+  class CovarianceMatrixTree : public Tree
+  {
+  public:
+    /// constructor with a vector \ref SpillMultiVar corresponding to the items to be used in binning decision and the weights
+    CovarianceMatrixTree( const std::string name, const std::vector<std::string>& labels, const std::string weightLabel,
+                          const std::vector< std::vector<std::pair<std::string,std::pair<double,double>>> >& binning,
+                          SpectrumLoaderBase& loader, const std::vector<SpillMultiVar>& vars, const unsigned int nUniverses,
+                          const SpillCut& spillcut );
+    /// Function to update protected members (the branches). DO NOT USE outside of the filling.
+    void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap ) override;
+    void SaveTo( TDirectory* dir ) const override;
+    void PrintBinning() const;
+  private:
+    std::map< unsigned int, std::vector< std::pair<std::string,std::pair<double,double>> >> fBinning;
+    std::vector<std::vector<double>> fWeights;
+    std::string fWeightLabel;
+    unsigned int fNUniverses;
+  };
+
   // Similar to Tree but for event weights e.g. to make splines...
   class WeightsTree
   {

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "sbnana/CAFAna/Core/Var.h"
+#include "sbnana/CAFAna/Core/MultiVar.h"
+#include "sbnana/CAFAna/Core/Cut.h"
+
+#include "sbnana/CAFAna/Core/SpectrumLoaderBase.h"
+#include "sbnana/CAFAna/Core/Utilities.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class TDirectory;
+class TTree;
+class TBranch;
+
+namespace ana
+{
+
+  class Tree
+  {
+  public:
+    /// constructor with a vector of \ref Var
+    Tree( const std::string name, const std::vector<std::string>& labels,
+          SpectrumLoaderBase& loader,
+          const std::vector<Var>& vars, const SpillCut& spillcut,
+          const Cut& cut, const SystShifts& shift = kNoShift );
+    /// constructor with a vector of \ref MultiVar
+    Tree( const std::string name, const std::vector<std::string>& labels,
+          SpectrumLoaderBase& loader,
+          const std::vector<MultiVar>& vars, const SpillCut& spillcut,
+          const Cut& cut, const SystShifts& shift = kNoShift );
+    /// constructor with a vector of \ref SpillVar
+    Tree( const std::string name, const std::vector<std::string>& labels,
+          SpectrumLoaderBase& loader,
+          const std::vector<SpillVar>& vars, const SpillCut& spillcut );
+    /// constructor with a vector of \ref SpillMultiVar
+    Tree( const std::string name, const std::vector<std::string>& labels,
+          SpectrumLoaderBase& loader,
+          const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut );
+    // Add functionality to update the protected stuff from elsewhere
+    void AddEntry( const std::string name, const double val ); // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    void UpdateNEntries( const long long val ) { fNEntries+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    void UpdatePOT( const double val ) { fPOT+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    void UpdateLivetime( const double val ) { fLivetime+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    // Utilities
+    double POT() const {return fPOT;} // as in Spectrum
+    double Livetime() const {return fLivetime;} // as in Spectrum
+    long long Entries() const {return fNEntries;}
+    void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    void SaveTo( TDirectory* dir ) const;
+  protected:
+    std::map< std::string, std::vector<double>> fBranchEntries;
+    std::string fTreeName;
+    std::vector<std::string> fOrderedBranchNames;
+    long long fNEntries;
+    double fPOT;
+    double fLivetime;
+  };
+
+}

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -25,12 +25,12 @@ namespace ana
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<Var>& vars, const SpillCut& spillcut,
-          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
+          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     /// constructor with a vector of \ref MultiVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<MultiVar>& vars, const SpillCut& spillcut,
-          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
+          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     /// constructor with a vector of \ref SpillVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
@@ -49,6 +49,7 @@ namespace ana
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
     bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
+    bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void SaveTo( TDirectory* dir ) const;
@@ -60,6 +61,7 @@ namespace ana
     double fPOT;
     double fLivetime;
     bool fSaveRunSubEvt;
+    bool fSaveSliceNum;
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -64,16 +64,12 @@ namespace ana
     bool fSaveSliceNum;
   };
 
-  // Similar to Tree but for a vector of ISyst to store weights and make splines...
-  class NSigmasTree
+  // Similar to Tree but for event weights e.g. to make splines...
+  class WeightsTree
   {
   public:
-    /// constructor with a vector of \ref ISyst
-    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
-                 SpectrumLoaderBase& loader,
-                 const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
-                 const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
-    // Add functionality to update the protected stuff from elsewhere
+    WeightsTree( const std::string name, const std::vector<std::string>& labels,
+                 const unsigned int nSigma, const bool saveRunSubEvt, const bool saveSliceNum, const unsigned int nWeightsExpected );
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
     void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap, const std::map<std::string, std::vector<double>> weightMap );
     /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
@@ -82,14 +78,13 @@ namespace ana
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
-    int NSigma() const {return fNSigma;}
+    int NSigma() const {return fNSigma;} // return as an int, then -NSigma to NSigma means something
     bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
-    void SaveToSplines( TDirectory* dir ) const;
-    void SaveTo( TDirectory* dir ) const {SaveToSplines(dir);} // TODO: update this to save a Tree of std::vector<double> instead of splines if desired...
-
+    virtual void SaveToSplines( TDirectory* dir ) const = 0;
+    virtual void SaveTo( TDirectory* dir ) const = 0;
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::map< std::string, std::vector<std::vector<double>>> fBranchWeightEntries;
@@ -102,6 +97,19 @@ namespace ana
     bool fSaveRunSubEvt;
     bool fSaveSliceNum;
     unsigned int fNSigma;
+    unsigned int fNWeightsExpected;
+  };
+
+  class NSigmasTree : public WeightsTree
+  {
+  public:
+    /// constructor with a vector of \ref ISyst
+    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                 SpectrumLoaderBase& loader,
+                 const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
+                 const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    void SaveToSplines( TDirectory* dir ) const override;
+    void SaveTo( TDirectory* dir ) const override {SaveToSplines(dir);} // TODO: update this to save a Tree of std::vector<double> instead of splines if desired...
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -64,4 +64,44 @@ namespace ana
     bool fSaveSliceNum;
   };
 
+  // Similar to Tree but for a vector of ISyst to store weights and make splines...
+  class NSigmasTree
+  {
+  public:
+    /// constructor with a vector of \ref ISyst
+    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                 SpectrumLoaderBase& loader,
+                 const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
+                 const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    // Add functionality to update the protected stuff from elsewhere
+    /// Function to update protected members (the branches). DO NOT USE outside of the filling.
+    void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap, const std::map<std::string, std::vector<double>> weightMap );
+    /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
+    void UpdateExposure ( const double pot, const double livetime );
+    // Utilities
+    double POT() const {return fPOT;} // as in Spectrum
+    double Livetime() const {return fLivetime;} // as in Spectrum
+    long long Entries() const {return fNEntries;}
+    int NSigma() const {return fNSigma;}
+    bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
+    bool SaveSliceNum() const {return fSaveSliceNum;}
+    void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    void SaveToSplines( TDirectory* dir ) const;
+    void SaveTo( TDirectory* dir ) const {SaveToSplines(dir);} // TODO: update this to save a Tree of std::vector<double> instead of splines if desired...
+
+  protected:
+    std::map< std::string, std::vector<double>> fBranchEntries;
+    std::map< std::string, std::vector<std::vector<double>>> fBranchWeightEntries;
+    std::string fTreeName;
+    std::vector<std::string> fOrderedBranchNames;
+    std::vector<std::string> fOrderedBranchWeightNames;
+    long long fNEntries;
+    double fPOT;
+    double fLivetime;
+    bool fSaveRunSubEvt;
+    bool fSaveSliceNum;
+    unsigned int fNSigma;
+  };
+
 }

--- a/sbnana/CAFAna/Core/Var.cxx
+++ b/sbnana/CAFAna/Core/Var.cxx
@@ -260,6 +260,13 @@ namespace ana
     }
   }
 
+  //----------------------------------------------------------------------
+  template<class T> bool
+  operator<(const _Var<T>& a, const _Var<T>& b)
+  {
+    return a.ID() < b.ID();
+  }
+
   // explicitly instantiate the templates for the types we know we have
   template class _Var<caf::SRSpillProxy>;
   template class _Var<caf::SRSliceProxy>;

--- a/sbnana/CAFAna/Core/Var.h
+++ b/sbnana/CAFAna/Core/Var.h
@@ -25,6 +25,7 @@ namespace ana
   template<class T> _Var<T> operator/(const _Var<T>& a, const _Var<T>& b);
   template<class T> _Var<T> operator+(const _Var<T>& a, const _Var<T>& b);
   template<class T> _Var<T> operator-(const _Var<T>& a, const _Var<T>& b);
+  template<class T> bool operator<(const _Var<T>& a, const _Var<T>& b); // for map-making
 
   /// Template for Var and SpillVar
   template<class T> class _Var

--- a/sbnana/CAFAna/Systs/SBNWeightSysts.cxx
+++ b/sbnana/CAFAna/Systs/SBNWeightSysts.cxx
@@ -173,14 +173,14 @@ namespace ana
   {
     // We can't ask the UniverseOracle about this, because it doesn't get
     // properly configured until it's seen its first CAF file.
-    return {"expskin",
-            "horncurrent",
-            "nucleoninexsec",
-            "nucleonqexsec",
-            "nucleontotxsec",
-            "pioninexsec",
-            "pionqexsec",
-            "piontotxsec"};
+    return {"expskin_Flux",
+            "horncurrent_Flux",
+            "nucleoninexsec_Flux",
+            "nucleonqexsec_Flux",
+            "nucleontotxsec_Flux",
+            "pioninexsec_Flux",
+            "pionqexsec_Flux",
+            "piontotxsec_Flux"};
   }
 
   // --------------------------------------------------------------------------

--- a/sbnana/CAFAna/Systs/UniverseOracle.cxx
+++ b/sbnana/CAFAna/Systs/UniverseOracle.cxx
@@ -89,9 +89,9 @@ namespace ana
       if(pset.map.size() != 1) continue;
 
       // Save which position in the vector this was
-      fSystIdxs[pset.map[0].param.name] = i;
+      fSystIdxs[pset.name] = i;
       // Save all the knob values
-      fShiftVals[pset.map[0].param.name] = pset.map[0].vals;
+      fShiftVals[pset.name] = pset.map[0].vals;
     }
   }
 


### PR DESCRIPTION
After recent updates to fix up the usage of the CovarianceMatrixTrees a bit, I am finally starting a PR to merge in the Trees paradigm to CAFAna/SBNAna. Many of the commits are from months ago, though I think they may appear as recent since I rebased based on develop and made a new branch, rather than commit directly from various releases/features where we have been using it. I believe this feature has been useful to some folks even outside of @jedori0228 and me directly, so will be nice when this can be merged even if there will be further updates :)

There is one commit here which I’ll note is a little bit unrelated to the Trees paradigm (e36cfbb426b688898033a8f33b030b8e97e5628f). This commit makes a change to UniverseOracle which enables one to use different sets of systematics.

The paradigm is as follows: most usage of CAFAna utilizes the `Spectrum` class or its derivatives. These are __sort-of__ histogram objects and very useful for the CAFAna fitting, and even offer EnsembleSpectrum for handling multiverse systematics together. However, in a number of cases, a more extensible format is better, e.g.:
- Having a pruned set of slices or spills, e.g., with a set of calculated Vars or even direct info from the CAFs that you want to explore for use in an un-binned format, or when you haven’t defined the binning yet. Relatedly, extensible plotting capabilities.
- Making correlations or combinations of multiple variables from such a pruned set
- Feeding info to external fitters/frameworks for analysis (e.g. for the use of GUNDAM for cross-section studies, or Profit for oscillation analysis)

Enter the various `Tree` classes being added in this PR. The user can define for example a common Cut but specify a vector of Vars to be evaluated with that cut and saved as individual entries saved into an output ROOT TTree for the user. The primary class being added is `Tree` which provides the basic functionality mentioned in the previous sentence. The user can use Vars, MultiVars, SpillVars, or SpillMultiVars, but they must only use one type at a time (this will change to be even more when a new variable type is added soon).

There is also a `CovarianceMatrixTree` class added which inherits from `Tree` and enables the user to produce a covariance matrix. The foreseen usage here (at least at the moment) is to make a set of SpillMultiVars, most of which are used to determine the binning for a given entry and one with N “universes” of weights for each such entry. (E.g. we have a spill with 4 objects - e.g. slices - passing criteria in my SpillMultiVar and I have 2 Vars used to determine the binning. So, 4 entries for each of these 2 Vars. Then, I have the Var I want to do the covariance for and say we have 100 universes. Then I’ll have 100 universes for slice 1, 100 for slice 2, etc.)

Then, there is the `WeightsTree` and its inheritors: `NSigmasTree` and `NUniversesTree`. These enable systematics to be considered, one for variables that can be treated as discrete sigma variations and one for variables treated in a “multiple universes” fashion. The `NSigmas` tree can currently be saved in the tree as entries which are a vector of the weights, as a `TSpline3`, as a `TGraph`, or as a `TClonesArray` (utilized in GUNDAM). For multiverse systematics, only a vector of the weights are able to be saved at present. One could then use these to build a covariance matrix, or one could also build SpillMultiVars so as to use the `CovarianceMatrixTree` (e.g. these 2 utilities have been under exploration by @jedori0228 and me for Geant4 systematics using geant4reweight). Additionally, the `MergeTree` function in `WeightsTree` enables one to join back the systematics with the rest of the considered variables from the entries, e.g. in the more standard `Tree`(s).

Many details are available in an old talk on doc-db (doc-32544) and I would be happy to discuss it again/with updates and further information at an upcoming SBN Analysis Frameworks meetings (tagging e.g. @PetrilloAtWork @JosiePaton). We had a preliminary discussion jointly with GUNDAM-focused analyzers and Profit developers/users a while back — though I should not that this has some things that were discussed but not everything for sure. For example, one now has the ability to use different sigma ranges for different dials (it’s controllable by a parameter in the constructor). However, this does not yet have the ability to make an n-dimensional spline.

As an example of a basic function:

```
… includes and other definitions of things like the loader, cuts, vars, etc.

Tree myTree ( “MyTree”,  {“kSliceCategory/i”,  “kIsSignal/i”,  “kRecoMomentum”,  “kTrueMomentum”},
               loader, {kSlcCategoryVar,  kIsSignalVar,  kRecoMomentumVar,  kTrueMomentumVar},
               kMySpillCut, kMySlcCut, kNoShift, true, true);

std::vector<std::string> systNames = { "GENIEReWeight_ICARUS_v2_multisigma_ZExpA1CCQE”};
std::vector<const ISyst*> systObjs;
systObjs.push_back( new SBNWeightSyst(systNames[0]) );
std::vector< std::pair<int,int> > systSigmas;
systSigmas.push_back( std::make_pair<int,int>(-3,3) );

NSigmasTree mySysts ( “MySigmaSysts”, systNames, loader, systObjs, systSigmas,
                      kMySpillCut, kMySlcCut, kNoShift, true, true );

loader.Go();

File *outFile = new TFile(“myFile.root”, ”recreate”);
mySysts.MergeTree( myTree );
mySysts.SaveTo( outFile->mkdir("Merged") );
```