### PR TITLE
Copy cafe to build directory so we don't have to run mrbslp

### DIFF
--- a/sbnana/SBNAna/CMakeLists.txt
+++ b/sbnana/SBNAna/CMakeLists.txt
@@ -23,7 +23,7 @@ add_definitions(-Wno-vla)
 # add_subdirectory(Analysis)
 # add_subdirectory(Systs)
 
-cet_script(cafe)
+cet_script(cafe ALWAYS_COPY)
 # same place as cafe script so we can find it
 cet_script(load_cafana_libs.C)
 #cet_script(rootlogon.C)


### PR DESCRIPTION
`cafe` script is not seen from the `build` directory, but only copied to `localProducts` during the `install` step. `mebsetenv` appends the `build` directory to `${PATH}`, so users have to run `mrbslp` to use `localProducts` instead.I found this simply fix copy the script to `build` directory and then copies it to `localProducts`.