### PR TITLE
Adding TruthVar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 
 find_package(cetmodules 3.20.00 REQUIRED )
-project(sbnana VERSION 10.01.00 LANGUAGES CXX)
+project(sbnana VERSION 10.01.01 LANGUAGES CXX)
 
 # cetbuildtools contains our cmake modules
 

--- a/sbnana/CAFAna/Core/Cut.cxx
+++ b/sbnana/CAFAna/Core/Cut.cxx
@@ -107,6 +107,7 @@ namespace ana
   // Make sure all versions get generated
   template bool operator< <caf::SRSliceProxy>(const Cut& a, const Cut& b);
   template bool operator< <caf::SRSpillProxy>(const SpillCut& a, const SpillCut& b);
+  template bool operator< <caf::SRTrueInteractionProxy>(const TruthCut& a, const TruthCut& b);
 
   //----------------------------------------------------------------------
   template<class T> _Cut<T> operator!(const _Cut<T>& a)

--- a/sbnana/CAFAna/Core/Cut.cxx
+++ b/sbnana/CAFAna/Core/Cut.cxx
@@ -97,6 +97,16 @@ namespace ana
   template SpillCut operator||<caf::SRSpillProxy>(const SpillCut& a, const SpillCut& b);
 
   //----------------------------------------------------------------------
+  template<class T> bool operator<(const _Cut<T>& a, const _Cut<T>& b)
+  {
+    return a.ID() < b.ID();
+  }
+
+  // Make sure all versions get generated
+  template bool operator< <caf::SRSliceProxy>(const Cut& a, const Cut& b);
+  template bool operator< <caf::SRSpillProxy>(const SpillCut& a, const SpillCut& b);
+
+  //----------------------------------------------------------------------
   template<class T> _Cut<T> operator!(const _Cut<T>& a)
   {
     static std::map<int, int> ids;

--- a/sbnana/CAFAna/Core/Cut.cxx
+++ b/sbnana/CAFAna/Core/Cut.cxx
@@ -71,6 +71,7 @@ namespace ana
   // Make sure all versions get generated
   template Cut operator&&<caf::SRSliceProxy>(const Cut& a, const Cut& b);
   template SpillCut operator&&<caf::SRSpillProxy>(const SpillCut& a, const SpillCut& b);
+  template TruthCut operator&&<caf::SRTrueInteractionProxy>(const TruthCut& a, const TruthCut& b);
 
   //----------------------------------------------------------------------
   template<class T> _Cut<T> operator||(const _Cut<T>& a, const _Cut<T>& b)
@@ -95,6 +96,7 @@ namespace ana
   // Make sure all versions get generated
   template Cut operator||<caf::SRSliceProxy>(const Cut& a, const Cut& b);
   template SpillCut operator||<caf::SRSpillProxy>(const SpillCut& a, const SpillCut& b);
+  template TruthCut operator||<caf::SRTrueInteractionProxy>(const TruthCut& a, const TruthCut& b);
 
   //----------------------------------------------------------------------
   template<class T> _Cut<T> operator!(const _Cut<T>& a)
@@ -114,6 +116,7 @@ namespace ana
   // Make sure all versions get generated
   template Cut operator!<caf::SRSliceProxy>(const Cut& a);
   template SpillCut operator!<caf::SRSpillProxy>(const SpillCut& a);
+  template TruthCut operator!<caf::SRTrueInteractionProxy>(const TruthCut& a);
 
 
   //----------------------------------------------------------------------
@@ -194,6 +197,7 @@ namespace ana
   // Make sure all three versions get generated
   template class _Cut<caf::SRSpillProxy>;
   template class _Cut<caf::SRSliceProxy>;
+  template class _Cut<caf::SRTrueInteractionProxy>;
 
   template<class T> int _Cut<T>::fgNextID = 0;
 
@@ -233,4 +237,21 @@ namespace ana
   template SpillCut operator<(double, const SpillVar&);
   template SpillCut operator>=(double, const SpillVar&);
   template SpillCut operator<=(double, const SpillVar&);
+
+  template TruthCut operator>(const TruthVar&, double);
+  template TruthCut operator<(const TruthVar&, double);
+  template TruthCut operator>=(const TruthVar&, double);
+  template TruthCut operator<=(const TruthVar&, double);
+  template TruthCut operator==(const TruthVar&, double);
+
+  template TruthCut operator>(const TruthVar&, const TruthVar&);
+  template TruthCut operator<(const TruthVar&, const TruthVar&);
+  template TruthCut operator>=(const TruthVar&, const TruthVar&);
+  template TruthCut operator<=(const TruthVar&, const TruthVar&);
+  template TruthCut operator==(const TruthVar&, const TruthVar&);
+
+  template TruthCut operator>(double, const TruthVar&);
+  template TruthCut operator<(double, const TruthVar&);
+  template TruthCut operator>=(double, const TruthVar&);
+  template TruthCut operator<=(double, const TruthVar&);
 }

--- a/sbnana/CAFAna/Core/Cut.h
+++ b/sbnana/CAFAna/Core/Cut.h
@@ -19,6 +19,9 @@ namespace ana
                                              const _Cut<T>& b);
   template<class T> _Cut<T> operator||(const _Cut<T>& a,
                                              const _Cut<T>& b);
+  template<class T> bool operator<(const _Cut<T>& a,
+                                         const _Cut<T>& b); // for map-making
+
   template<class T> _Cut<T> operator!(const _Cut<T>& a);
 
   typedef double (ExposureFunc_t)(const caf::SRSpill* spill);

--- a/sbnana/CAFAna/Core/Cut.h
+++ b/sbnana/CAFAna/Core/Cut.h
@@ -9,7 +9,7 @@
 
 #include "sbnana/CAFAna/Core/Var.h"
 
-namespace caf{class StandardRecord; class SRSpill; class SRSpillTruthBranch; class SRSlice;}
+namespace caf{class StandardRecord; class SRSpill; class SRTrueInteraction; class SRSlice;}
 
 namespace ana
 {
@@ -100,7 +100,7 @@ namespace ana
 
   /// \brief Cut designed to be used over the nuTree, ie all neutrinos, not
   /// just those that got slices.
-  typedef _Cut<caf::SRSpillTruthBranch> SpillTruthCut;
+  typedef _Cut<caf::SRTrueInteractionProxy> TruthCut;
 
   template<class T> _Cut<T> operator>(const _Var<T>& v, double c);
   template<class T> _Cut<T> operator<(const _Var<T>& v, double c);
@@ -127,4 +127,7 @@ namespace ana
 
   /// The simplest possible cut: pass everything, used as a default
   const SpillCut kNoSpillCut([](const caf::SRSpillProxy*){return true;});
+
+  /// The simplest possible cut: pass everything, used as a default
+  const TruthCut kNoTruthCut([](const caf::SRTrueInteractionProxy*){return true;});
 } // namespace

--- a/sbnana/CAFAna/Core/EnsembleSpectrum.cxx
+++ b/sbnana/CAFAna/Core/EnsembleSpectrum.cxx
@@ -41,6 +41,23 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  EnsembleSpectrum::EnsembleSpectrum(const std::string& label, const Binning& bins,
+                                     SpectrumLoaderBase& loader,
+                                     const TruthVar& var,
+                                     const TruthCut& truthcut,
+                                     const SpillCut& spillcut,
+                                     const std::vector<TruthVar>& univ_weis,
+                                     const TruthVar& cv_wei)
+
+    : fNom(label, bins, loader, var, truthcut, spillcut, kNoShift, cv_wei)
+  {
+    fUnivs.reserve(univ_weis.size());
+    for(const TruthVar& w: univ_weis){
+      fUnivs.emplace_back(label, bins, loader, var, truthcut, spillcut, kNoShift, cv_wei*w);
+    }
+  }
+
+  //----------------------------------------------------------------------
   TGraphAsymmErrors* EnsembleSpectrum::ErrorBand(double exposure,
                                                  EExposureType expotype,
                                                  EBinType bintype) const

--- a/sbnana/CAFAna/Core/EnsembleSpectrum.h
+++ b/sbnana/CAFAna/Core/EnsembleSpectrum.h
@@ -30,6 +30,15 @@ namespace ana
                      const std::vector<Var>& univ_weis,
                      const Var& cv_wei = kUnweighted);
 
+    // TruthVar; but ordering the arguments similar to Spectrum
+    EnsembleSpectrum(const std::string& label, const Binning& bins,
+                     SpectrumLoaderBase& loader,
+                     const TruthVar& var,
+                     const TruthCut& truthcut,
+                     const SpillCut& spillcut,
+                     const std::vector<TruthVar>& univ_weis,
+                     const TruthVar& cv_wei = kTruthUnweighted);
+
     Spectrum Nominal() const {return fNom;}
     unsigned int NUniverses() const {return fUnivs.size();}
     Spectrum Universe(unsigned int i) const

--- a/sbnana/CAFAna/Core/ISyst.h
+++ b/sbnana/CAFAna/Core/ISyst.h
@@ -50,6 +50,15 @@ namespace ana
                        caf::SRSliceProxy* sr,
                        double& weight) const = 0;
 
+    /// \brief Perform the systematic shift
+    ///
+    /// \param sigma   Number of sigma to shift record by
+    /// \param nu      SRTrueInteraction
+    /// \param weight  Scale this weight for reweighting systematics
+    virtual void Shift(double sigma,
+                       caf::SRTrueInteractionProxy* nu,
+                       double& weight) const = 0;
+
     /// PredictionInterp normally interpolates between spectra made at
     /// +/-1,2,3sigma. For some systematics that's overkill. Override this
     /// function to specify different behaviour for this systematic.

--- a/sbnana/CAFAna/Core/MultiVar.cxx
+++ b/sbnana/CAFAna/Core/MultiVar.cxx
@@ -75,10 +75,12 @@ namespace ana
   // explicitly instantiate the template for the types we know we have
   template MultiVar MultiVar2D(const MultiVar&, const Binning&, const MultiVar&, const Binning&);
   template SpillMultiVar MultiVar2D(const SpillMultiVar&, const Binning&, const SpillMultiVar&, const Binning&);
+  template TruthMultiVar MultiVar2D(const TruthMultiVar&, const Binning&, const TruthMultiVar&, const Binning&);
 
   // explicitly instantiate the templates for the types we know we have
   template class _MultiVar<caf::SRSpillProxy>;
   template class _MultiVar<caf::SRSliceProxy>;
+  template class _MultiVar<caf::SRTrueInteractionProxy>;
 
   // Stupid hack to avoid colliding with the IDs of actual Vars. Just count
   // down through negative numbers.

--- a/sbnana/CAFAna/Core/MultiVar.h
+++ b/sbnana/CAFAna/Core/MultiVar.h
@@ -47,6 +47,7 @@ namespace ana
 
   typedef _MultiVar<caf::SRSliceProxy> MultiVar;
   typedef _MultiVar<caf::SRSpillProxy> SpillMultiVar;
+  typedef _MultiVar<caf::SRTrueInteractionProxy> TruthMultiVar;
 
   template<class T> _MultiVar<T>
   MultiVar2D(const _MultiVar<T>& a, const Binning& binsa,

--- a/sbnana/CAFAna/Core/Spectrum.cxx
+++ b/sbnana/CAFAna/Core/Spectrum.cxx
@@ -69,10 +69,11 @@ namespace ana
                      const TruthVar& var,
                      const TruthCut& truthcut,
                      const SpillCut& spillcut,
+                     const SystShifts& shift,
                      const TruthVar& wei)
     : Spectrum(label, bins)
   {
-    loader.AddSpectrum(*this, var, truthcut, spillcut, wei);
+    loader.AddSpectrum(*this, var, truthcut, spillcut, shift, wei);
   }
   //----------------------------------------------------------------------
   Spectrum::Spectrum(const std::string& label, const Binning& bins,
@@ -80,10 +81,11 @@ namespace ana
                      const TruthMultiVar& var,
                      const TruthCut& truthcut,
                      const SpillCut& spillcut,
+                     const SystShifts& shift,
                      const TruthVar& wei)
     : Spectrum(label, bins)
   {
-    loader.AddSpectrum(*this, var, truthcut, spillcut, wei);
+    loader.AddSpectrum(*this, var, truthcut, spillcut, shift, wei);
   }
   //----------------------------------------------------------------------
   Spectrum::Spectrum(const std::string& label, const Binning& bins,
@@ -92,10 +94,11 @@ namespace ana
                      const TruthCut& truthcut,
                      const SpillCut& spillcut,
                      const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                     const SystShifts& shift,
                      const TruthVar& wei)
     : Spectrum(label, bins)
   {
-    loader.AddSpectrum(*this, var, truthcut, spillcut, cut, wei);
+    loader.AddSpectrum(*this, var, truthcut, spillcut, cut, shift, wei);
   }
   //----------------------------------------------------------------------
   Spectrum::Spectrum(const std::string& label, const Binning& bins,
@@ -104,10 +107,11 @@ namespace ana
                      const TruthCut& truthcut,
                      const SpillCut& spillcut,
                      const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                     const SystShifts& shift,
                      const TruthVar& wei)
     : Spectrum(label, bins)
   {
-    loader.AddSpectrum(*this, var, truthcut, spillcut, cut, wei);
+    loader.AddSpectrum(*this, var, truthcut, spillcut, cut, shift, wei);
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/Spectrum.cxx
+++ b/sbnana/CAFAna/Core/Spectrum.cxx
@@ -69,8 +69,41 @@ namespace ana
                      const TruthVar& var,
                      const TruthCut& truthcut,
                      const SpillCut& spillcut,
+                     const TruthVar& wei)
+    : Spectrum(label, bins)
+  {
+    loader.AddSpectrum(*this, var, truthcut, spillcut, wei);
+  }
+  //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& label, const Binning& bins,
+                     SpectrumLoaderBase& loader,
+                     const TruthMultiVar& var,
+                     const TruthCut& truthcut,
+                     const SpillCut& spillcut,
+                     const TruthVar& wei)
+    : Spectrum(label, bins)
+  {
+    loader.AddSpectrum(*this, var, truthcut, spillcut, wei);
+  }
+  //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& label, const Binning& bins,
+                     SpectrumLoaderBase& loader,
+                     const TruthVar& var,
+                     const TruthCut& truthcut,
+                     const SpillCut& spillcut,
                      const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
-                     const SystShifts& shift,
+                     const TruthVar& wei)
+    : Spectrum(label, bins)
+  {
+    loader.AddSpectrum(*this, var, truthcut, spillcut, cut, wei);
+  }
+  //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& label, const Binning& bins,
+                     SpectrumLoaderBase& loader,
+                     const TruthMultiVar& var,
+                     const TruthCut& truthcut,
+                     const SpillCut& spillcut,
+                     const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
                      const TruthVar& wei)
     : Spectrum(label, bins)
   {

--- a/sbnana/CAFAna/Core/Spectrum.cxx
+++ b/sbnana/CAFAna/Core/Spectrum.cxx
@@ -66,6 +66,20 @@ namespace ana
   //----------------------------------------------------------------------
   Spectrum::Spectrum(const std::string& label, const Binning& bins,
                      SpectrumLoaderBase& loader,
+                     const TruthVar& var,
+                     const TruthCut& truthcut,
+                     const SpillCut& spillcut,
+                     const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                     const SystShifts& shift,
+                     const TruthVar& wei)
+    : Spectrum(label, bins)
+  {
+    loader.AddSpectrum(*this, var, truthcut, spillcut, cut, wei);
+  }
+
+  //----------------------------------------------------------------------
+  Spectrum::Spectrum(const std::string& label, const Binning& bins,
+                     SpectrumLoaderBase& loader,
                      const MultiVar& var,
                      const SpillCut& spillcut,
                      const Cut& cut,

--- a/sbnana/CAFAna/Core/Spectrum.h
+++ b/sbnana/CAFAna/Core/Spectrum.h
@@ -60,6 +60,15 @@ namespace ana
              const SpillCut& cut,
              const SpillVar& wei = kSpillUnweighted);
 
+    Spectrum(const std::string& label, const Binning& bins,
+             SpectrumLoaderBase& loader,
+             const TruthVar& var,
+             const TruthCut& truthcut,
+             const SpillCut& spillcut,
+             const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+             const SystShifts& shift = kNoShift,
+             const TruthVar& wei = kTruthUnweighted);
+
     /// The only \ref MultiVar variant available
     Spectrum(const std::string& label, const Binning& bins,
              SpectrumLoaderBase& loader,

--- a/sbnana/CAFAna/Core/Spectrum.h
+++ b/sbnana/CAFAna/Core/Spectrum.h
@@ -65,12 +65,14 @@ namespace ana
              const TruthVar& var,
              const TruthCut& truthcut,
              const SpillCut& spillcut,
+             const SystShifts& shift = kNoShift,
              const TruthVar& wei = kTruthUnweighted);
     Spectrum(const std::string& label, const Binning& bins,
              SpectrumLoaderBase& loader,
              const TruthMultiVar& var,
              const TruthCut& truthcut,
              const SpillCut& spillcut,
+             const SystShifts& shift = kNoShift,
              const TruthVar& wei = kTruthUnweighted);
     Spectrum(const std::string& label, const Binning& bins,
              SpectrumLoaderBase& loader,
@@ -78,6 +80,7 @@ namespace ana
              const TruthCut& truthcut,
              const SpillCut& spillcut,
              const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+             const SystShifts& shift = kNoShift,
              const TruthVar& wei = kTruthUnweighted);
     Spectrum(const std::string& label, const Binning& bins,
              SpectrumLoaderBase& loader,
@@ -85,6 +88,7 @@ namespace ana
              const TruthCut& truthcut,
              const SpillCut& spillcut,
              const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+             const SystShifts& shift = kNoShift,
              const TruthVar& wei = kTruthUnweighted);
 
     /// The only \ref MultiVar variant available

--- a/sbnana/CAFAna/Core/Spectrum.h
+++ b/sbnana/CAFAna/Core/Spectrum.h
@@ -65,8 +65,26 @@ namespace ana
              const TruthVar& var,
              const TruthCut& truthcut,
              const SpillCut& spillcut,
+             const TruthVar& wei = kTruthUnweighted);
+    Spectrum(const std::string& label, const Binning& bins,
+             SpectrumLoaderBase& loader,
+             const TruthMultiVar& var,
+             const TruthCut& truthcut,
+             const SpillCut& spillcut,
+             const TruthVar& wei = kTruthUnweighted);
+    Spectrum(const std::string& label, const Binning& bins,
+             SpectrumLoaderBase& loader,
+             const TruthVar& var,
+             const TruthCut& truthcut,
+             const SpillCut& spillcut,
              const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
-             const SystShifts& shift = kNoShift,
+             const TruthVar& wei = kTruthUnweighted);
+    Spectrum(const std::string& label, const Binning& bins,
+             SpectrumLoaderBase& loader,
+             const TruthMultiVar& var,
+             const TruthCut& truthcut,
+             const SpillCut& spillcut,
+             const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
              const TruthVar& wei = kTruthUnweighted);
 
     /// The only \ref MultiVar variant available

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -115,6 +115,12 @@ namespace ana
     fSpillHistDefs.RemoveLoader(this);
     fSpillHistDefs.Clear();
 
+    fTruthHistDefs.RemoveLoader(this);
+    fTruthHistDefs.Clear();
+
+    fTruthHistWithCutDefs.RemoveLoader(this);
+    fTruthHistWithCutDefs.Clear();
+
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -464,6 +464,7 @@ namespace ana
     } // end for spillcut
 
     // Weights trees
+    // Sigma knobs
     for ( auto& [spillcut, shiftmap] : fNSigmasTreeDefs ) {
       const bool spillpass = spillcut(sr);
       // Cut failed, skip all the histograms that depend on it

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -757,8 +757,6 @@ namespace ana
     //unsigned int idxSpillCut = 0; // testing
     for ( auto& [spillcut, shiftmap] : fTruthTreeDefs ) {
       const bool spillpass = spillcut(sr);
-      // Cut failed, skip all the histograms that depend on it
-      if(!spillpass) continue;
 
       unsigned int idxSlice = 0; // in case we want to save the slice number to the tree
       for(caf::SRTrueInteractionProxy& nu: sr->mc.nu){
@@ -851,7 +849,12 @@ namespace ana
                 }
                 int tmp_CutType = HasMatchedSlicePassCut ? 1 : 0;
                 recordVals["CutType/i"].push_back( tmp_CutType );
+
+                int tmp_SpillCutType = spillpass ? 1 : 0;
+                recordVals["SpillCutType/i"].push_back( tmp_SpillCutType );
+
               }
+
 
 
               treemapIt->first->UpdateEntries(recordVals);

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -478,6 +478,8 @@ namespace ana
               else if ( slc.truth.index != nu.index ) continue;
               if( cut(&slc) ){
                 HasMatchedSlicePassCut = true;
+                // make sure to Rollback before break
+                caf::SRProxySystController::Rollback();
                 break;
               }
               caf::SRProxySystController::Rollback();

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -484,7 +484,7 @@ namespace ana
               std::map<std::string, std::vector<double>> headerVals;
               std::map<std::string, std::vector<double>> recordVals;
               for ( auto& [syst, systname] : treemapIt->second ) {
-                for ( int sigma=-treemapIt->first->NSigma(); sigma<=treemapIt->first->NSigma(); ++sigma ) {
+                for ( int sigma=treemapIt->first->NSigmaLo(systname); sigma<=treemapIt->first->NSigmaHi(systname); ++sigma ) {
 
                   // Need to provide a clean slate for each new set of systematic
                   // shifts to work from. Copying the whole StandardRecord is pretty

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -799,11 +799,10 @@ namespace ana
                 }
                 int tmp_CutType = HasMatchedSlicePassCut ? 1 : 0;
                 recordVals["CutType/i"].push_back( tmp_CutType );
-
-                int tmp_SpillCutType = spillpass ? 1 : 0;
-                recordVals["SpillCutType/i"].push_back( tmp_SpillCutType );
-
               }
+
+              int tmp_SpillCutType = spillpass ? 1 : 0;
+              recordVals["SpillCutType/i"].push_back( tmp_SpillCutType );
 
 
 

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -463,6 +463,68 @@ namespace ana
       } // end for tree
     } // end for spillcut
 
+    // Weights trees
+    for ( auto& [spillcut, shiftmap] : fNSigmasTreeDefs ) {
+      const bool spillpass = spillcut(sr);
+      // Cut failed, skip all the histograms that depend on it
+      if(!spillpass) continue;
+
+      unsigned int idxSlice = 0; // in case we want to save the slice number to the tree
+      // NB: We DON'T keep track of Nominal Cut/Var/etc. because we want to shift/reset shifts for the weight saving... We sacrifice potential speed here by choice.
+      for( caf::SRSliceProxy& slc: sr->slc ) {
+        for ( auto& [shift, cutmap] : shiftmap ) {
+          for ( auto& [cut, treemap] : cutmap ) {
+            const bool pass = cut(&slc);
+            // Cut failed, skip all the histograms that depended on it
+            if(!pass) continue;
+
+            for ( std::map<NSigmasTree*, std::map<const ISyst*, std::string>>::iterator treemapIt=treemap.begin(); treemapIt!=treemap.end(); ++treemapIt ) {
+
+              std::map<std::string, std::vector<double>> headerVals;
+              std::map<std::string, std::vector<double>> recordVals;
+              for ( auto& [syst, systname] : treemapIt->second ) {
+                for ( int sigma=-treemapIt->first->NSigma(); sigma<=treemapIt->first->NSigma(); ++sigma ) {
+
+                  // Need to provide a clean slate for each new set of systematic
+                  // shifts to work from. Copying the whole StandardRecord is pretty
+                  // expensive, so modify it in place and revert it afterwards.
+                  caf::SRProxySystController::BeginTransaction();
+
+                  double systWeight = 1;
+                  // Can special-case nominal to not pay cost of Shift()
+                  if(!shift.IsNominal()){
+                    shift.Shift(&slc, systWeight);
+                  }
+
+                  // Now shift for the weight we want to save
+                  const SystShifts& shiftSigma = SystShifts(syst,sigma);
+                  double systWeightSigma = 1;
+                  shiftSigma.Shift(&slc, systWeightSigma);
+
+                  recordVals[systname].push_back(systWeightSigma);
+
+                  // Reset shifts to get the next sigma
+                  caf::SRProxySystController::Rollback();
+                }
+              }
+              // If fSaveRunSubrunEvt then fill these entries...
+              if ( treemapIt->first->SaveRunSubEvent() ) {
+                headerVals["Run/i"].push_back( sr->hdr.run );
+                headerVals["Subrun/i"].push_back( sr->hdr.subrun );
+                headerVals["Evt/i"].push_back( sr->hdr.evt );
+              }
+              if ( treemapIt->first->SaveSliceNum() ) {
+                headerVals["Slice/i"].push_back( idxSlice );
+              }
+
+              treemapIt->first->UpdateEntries(headerVals,recordVals);
+            } // end for tree
+          } // end for cut
+        } // end for shift
+        idxSlice+=1;
+      } // end for slice
+    } // end for spillcut
+
   }
 
   //----------------------------------------------------------------------
@@ -521,6 +583,17 @@ namespace ana
     for ( auto& [spillcut, treemap] : fSpillTreeDefs ) {
       for ( std::map<Tree*, std::map<SpillVarOrMultiVar, std::string>>::iterator treemapIt=treemap.begin(); treemapIt!=treemap.end(); ++treemapIt ) {
         treemapIt->first->UpdateExposure(fPOT,fNReadouts);
+      }
+    }
+
+    // NSigmasTrees
+    for ( auto& [spillcut, shiftmap] : fNSigmasTreeDefs ) {
+      for ( auto& [shift, cutmap] : shiftmap ) {
+        for ( auto& [cut, treemap] : cutmap ) {
+          for ( std::map<NSigmasTree*, std::map<const ISyst*, std::string>>::iterator treemapIt=treemap.begin(); treemapIt!=treemap.end(); ++treemapIt ) {
+            treemapIt->first->UpdateExposure(fPOT,fNReadouts);
+          }
+        }
       }
     }
 

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -836,6 +836,24 @@ namespace ana
                   }
                 }
               }
+              // Adding CutType
+
+              if ( treemapIt->first->SaveTruthCutType() ){
+                // Loop over reco slices, and check if the truth-matched slice pass the (Slice)Cut
+                bool HasMatchedSlicePassCut = false;
+                for ( auto const& slc : sr->slc ) {
+                  if ( slc.truth.index < 0 ) continue;
+                  else if ( slc.truth.index != nu.index ) continue;
+                  if( treemapIt->first->GetSignalSelectionCut()(&slc) ){
+                    HasMatchedSlicePassCut = true;
+                    break;
+                  }
+                }
+                int tmp_CutType = HasMatchedSlicePassCut ? 1 : 0;
+                recordVals["CutType/i"].push_back( tmp_CutType );
+              }
+
+
               treemapIt->first->UpdateEntries(recordVals);
               //idxTree+=1;
             } // end for tree

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -658,7 +658,7 @@ namespace ana
           } // end for cut
 
           // Return StandardRecord to its unshifted form ready for the next
-          // histogram.
+          // Tree.
           caf::SRProxySystController::Rollback();
 
           //idxShift+=1;
@@ -813,7 +813,7 @@ namespace ana
           } // end for cut
 
           // Return StandardRecord to its unshifted form ready for the next
-          // histogram.
+          // Tree.
           caf::SRProxySystController::Rollback();
 
           //idxShift+=1;
@@ -1019,7 +1019,7 @@ namespace ana
           } // end for cut
 
           // Return StandardRecord to its unshifted form ready for the next
-          // histogram.
+          // Tree.
           caf::SRProxySystController::Rollback();
         } // end for shift
         idxSlice+=1;
@@ -1079,7 +1079,7 @@ namespace ana
           } // end for truthcut
 
           // Return StandardRecord to its unshifted form ready for the next
-          // histogram.
+          // Tree.
           caf::SRProxySystController::Rollback();
         } // end for shift
 

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -351,7 +351,7 @@ namespace ana
 
               // if TruthMultiVar
               if(truthvardef.first.IsMulti()){
-                for(double truthval: truthvardef.first.GetMultiVar()(&slc)){
+                for(double truthval: truthvardef.first.GetMultiVar()(&nu)){
                   for(Spectrum* s: truthvardef.second.spects)
                     s->Fill(truthval, truthwei);
                 }
@@ -386,6 +386,91 @@ namespace ana
       } // end for nu loop
 
     } // end for spillcutdef
+
+
+    // TruthVar with (Slice)Cut by truth-matching
+
+    for(auto& spillcutdef: fTruthHistWithCutDefs){
+      const SpillCut& spillcut = spillcutdef.first;
+
+      const bool spillpass = spillcut(sr); // nomSpillCutCache.Get(spillcut, sr);
+      // Cut failed, skip all the histograms that depended on it
+      if(!spillpass) continue;
+
+      for(auto& cutdef: spillcutdef.second){
+
+        const Cut& cut = cutdef.first;
+
+        // now start the nu loop
+        for(caf::SRTrueInteractionProxy& nu: sr->mc.nu){
+
+          // Loop over reco slices, and check if the truth-matched slice pass the (Slice)Cut
+          bool HasMatchedSlicePassCut = false;
+          for ( auto const& slc : sr->slc ) {
+            if ( slc.truth.index < 0 ) continue;
+            else if ( slc.truth.index != nu.index ) continue;
+            if( cut(&slc) ){
+              HasMatchedSlicePassCut = true;
+              break;
+            }
+          }
+
+          if(!HasMatchedSlicePassCut) continue;
+
+          for(auto& truthcutdef: cutdef.second){
+
+            const TruthCut& truthcut = truthcutdef.first;
+
+            const bool truthpass = truthcut(&nu);
+            // TruthCut failed, skip all the histograms that depended on it
+            if(!truthpass) continue;
+
+            for(auto& truthweidef: truthcutdef.second){
+
+              const TruthVar& truthweivar = truthweidef.first;
+              double truthwei = truthweivar(&nu);
+
+              for(auto& truthvardef: truthweidef.second){
+
+                // if TruthMultiVar
+                if(truthvardef.first.IsMulti()){
+                  for(double truthval: truthvardef.first.GetMultiVar()(&nu)){
+                    for(Spectrum* s: truthvardef.second.spects)
+                      s->Fill(truthval, truthwei);
+                  }
+                }
+                // if TruthVar
+                else{
+
+                  const TruthVar& truthvar = truthvardef.first.GetVar();
+                  const double truthval = truthvar(&nu);
+
+                  if(std::isnan(truthval) || std::isinf(truthval)){
+                    std::cerr << "Warning: Bad value: " << truthval
+                              << " returned from a TruthVar. The input variable(s) could "
+                              << "be NaN in the CAF, or perhaps your "
+                              << "Var code computed 0/0?";
+                    std::cout << " Not filling into this histogram for this slice." << std::endl;
+                    continue;
+                  }
+
+                  for(Spectrum* s: truthvardef.second.spects) s->Fill(truthval, truthwei);
+
+                }
+
+              } // end for truthvardef
+
+            } // end for truthweidef
+
+          } // end for truthcutdef
+
+        } // end for nu loop
+
+      } // end for cutdef
+
+    } // end for spillcutdef
+
+
 
     // Trees
     //unsigned int idxSpillCut = 0; // testing
@@ -695,6 +780,34 @@ namespace ana
           for(Spectrum* s: spillvardef.second.spects){
             s->fPOT += fPOT;
             s->fLivetime += fNReadouts;
+          }
+        }
+      }
+    }
+
+    for(auto& spillcutdef: fTruthHistDefs){
+      for(auto& truthcutdef: spillcutdef.second){
+        for(auto& truthweidef: truthcutdef.second){
+          for(auto& truthvardef: truthweidef.second){
+            for(Spectrum* s: truthvardef.second.spects){
+              s->fPOT += fPOT;
+              s->fLivetime += fNReadouts;
+            }
+          }
+        }
+      }
+    }
+
+    for(auto& spillcutdef: fTruthHistWithCutDefs){
+      for(auto& cutdef: spillcutdef.second){
+        for(auto& truthcutdef: cutdef.second){
+          for(auto& truthweidef: truthcutdef.second){
+            for(auto& truthvardef: truthweidef.second){
+              for(Spectrum* s: truthvardef.second.spects){
+                s->fPOT += fPOT;
+                s->fLivetime += fNReadouts;
+              }
+            }
           }
         }
       }

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -320,6 +320,89 @@ namespace ana
         } // end for shiftdef
       } // end for slc
     } // end for spillcutdef
+
+
+    for(auto& spillcutdef: fTruthHistDefs){
+      const SpillCut& spillcut = spillcutdef.first;
+
+      const bool spillpass = spillcut(sr); // nomSpillCutCache.Get(spillcut, sr);
+      // Cut failed, skip all the histograms that depended on it
+      if(!spillpass) continue;
+
+      // now start the nu loop
+      for(caf::SRTrueInteractionProxy& nu: sr->mc.nu){
+
+        for(auto& cutdef: spillcutdef.second){
+          const Cut& cut = cutdef.first;
+          // loop over reco slices that are truth-matched to this given nu
+          // return "true" if any of those slices pass this cut
+          bool HasMatchedSlicePassCut = false;
+          for(caf::SRSliceProxy& slc: sr->slc){
+            if( slc.truth.index < 0 ) continue; // only neutrino slice
+            else if ( slc.truth.index != nu.index ) continue; // matched
+
+            if( cut(&slc) ){
+              HasMatchedSlicePassCut = true;
+              break;
+            }
+
+          } // end loop over reco slices
+
+          if(!HasMatchedSlicePassCut) continue;
+
+          for(auto& truthcutdef: cutdef.second){
+
+            const TruthCut& truthcut = truthcutdef.first;
+
+            const bool truthpass = truthcut(&nu);
+            // TruthCut failed, skip all the histograms that depended on it
+            if(!truthpass) continue;
+
+            for(auto& truthweidef: truthcutdef.second){
+
+              const TruthVar& truthweivar = truthweidef.first;
+              double truthwei = truthweivar(&nu);
+
+              for(auto& truthvardef: truthweidef.second){
+                /*
+                //TODO do multi later
+                if(vardef.first.IsMulti()){
+                  for(double val: vardef.first.GetMultiVar()(&slc)){
+                    for(Spectrum* s: vardef.second.spects)
+                      s->Fill(val, wei);
+                  }
+                  continue;
+                }
+                */
+                const TruthVar& truthvar = truthvardef.first.GetVar();
+
+                const double val = truthvar(&nu);
+
+                if(std::isnan(val) || std::isinf(val)){
+                  std::cerr << "Warning: Bad value: " << val
+                            << " returned from a TruthVar. The input variable(s) could "
+                            << "be NaN in the CAF, or perhaps your "
+                            << "Var code computed 0/0?";
+                  std::cout << " Not filling into this histogram for this slice." << std::endl;
+                  continue;
+                }
+
+                for(Spectrum* s: truthvardef.second.spects) s->Fill(val, truthwei);
+
+              } // end for truthvardef
+
+
+
+            } // end for truthweidef
+
+          } // end for truthcutdef
+
+        } // end for cutdef
+
+      } // end for nu loop
+
+    } // end for spillcutdef
+
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -840,7 +840,8 @@ namespace ana
               std::map<std::string, std::vector<double>> headerVals;
               std::map<std::string, std::vector<double>> recordVals;
               for ( auto& [syst, systname] : treemapIt->second ) {
-                for ( int sigma=treemapIt->first->NSigmaLo(systname); sigma<=treemapIt->first->NSigmaHi(systname); ++sigma ) {
+                for ( unsigned int i_sigma=0; i_sigma<treemapIt->first->NWeights(systname); ++i_sigma){
+                  double sigma = treemapIt->first->GetSigma(systname, i_sigma);
 
                   // Need to provide a clean slate for each new set of systematic
                   // shifts to work from. Copying the whole StandardRecord is pretty
@@ -896,7 +897,8 @@ namespace ana
             std::map<std::string, std::vector<double>> headerVals;
             std::map<std::string, std::vector<double>> recordVals;
             for ( auto& [syst, systname] : treemapIt->second ) {
-              for ( int sigma=treemapIt->first->NSigmaLo(systname); sigma<=treemapIt->first->NSigmaHi(systname); ++sigma ) {
+              for ( unsigned int i_sigma=0; i_sigma<treemapIt->first->NWeights(systname); ++i_sigma){
+                double sigma = treemapIt->first->GetSigma(systname, i_sigma);
 
                 // Need to provide a clean slate for each new set of systematic
                 // shifts to work from. Copying the whole StandardRecord is pretty

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -425,6 +425,10 @@ namespace ana
 
           } // end for truthcutdef
 
+          // Return StandardRecord to its unshifted form ready for the next
+          // histogram.
+          caf::SRProxySystController::Rollback();
+
         } // end for shiftdef
 
       } // end for nu loop

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -329,7 +329,7 @@ namespace ana
       // Cut failed, skip all the histograms that depend on it
       if(!spillpass) continue;
 
-      //unsigned int idxSlice = 0; // testing
+      unsigned int idxSlice = 0; // in case we want to save the slice number to the tree
       for( caf::SRSliceProxy& slc: sr->slc ) {
         // Some shifts only adjust the weight, so they're effectively nominal,
         // but aren't grouped with the other nominal histograms. Keep track of
@@ -393,11 +393,16 @@ namespace ana
                 //idxVar+=1;
               } // end for var/varname
               // If fSaveRunSubrunEvt then fill these entries...
-              if ( treemapIt->first->SaveRunSubEvent() ) {
+              if ( treemapIt->first->SaveRunSubEvent() || treemapIt->first->SaveSliceNum() ) {
                 for ( unsigned int idxRun=0; idxRun<numEntries; ++idxRun ) {
-                  recordVals["Run/i"].push_back( sr->hdr.run );
-                  recordVals["Subrun/i"].push_back( sr->hdr.subrun );
-                  recordVals["Evt/i"].push_back( sr->hdr.evt );
+                  if ( treemapIt->first->SaveRunSubEvent() ) {
+                    recordVals["Run/i"].push_back( sr->hdr.run );
+                    recordVals["Subrun/i"].push_back( sr->hdr.subrun );
+                    recordVals["Evt/i"].push_back( sr->hdr.evt );
+                  }
+                  if ( treemapIt->first->SaveSliceNum() ) {
+                    recordVals["Slice/i"].push_back( idxSlice );
+                  }
                 }
               }
               treemapIt->first->UpdateEntries(recordVals);
@@ -412,7 +417,7 @@ namespace ana
 
           //idxShift+=1;
         } // end for shift
-        //idxSlice+=1;
+        idxSlice+=1;
       } // end for slice
       //idxSpillCut+=1;
     } // end for spillcut

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -411,7 +411,7 @@ namespace ana
                               << " returned from a TruthVar. The input variable(s) could "
                               << "be NaN in the CAF, or perhaps your "
                               << "Var code computed 0/0?";
-                    std::cout << " Not filling into this histogram for this slice." << std::endl;
+                    std::cout << " Not filling into this histogram for this True Interaction." << std::endl;
                     continue;
                   }
 

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -452,19 +452,6 @@ namespace ana
         // now start the nu loop
         for(caf::SRTrueInteractionProxy& nu: sr->mc.nu){
 
-          // Loop over reco slices, and check if the truth-matched slice pass the (Slice)Cut
-          bool HasMatchedSlicePassCut = false;
-          for ( auto const& slc : sr->slc ) {
-            if ( slc.truth.index < 0 ) continue;
-            else if ( slc.truth.index != nu.index ) continue;
-            if( cut(&slc) ){
-              HasMatchedSlicePassCut = true;
-              break;
-            }
-          }
-
-          if(!HasMatchedSlicePassCut) continue;
-
           // Some shifts only adjust the weight, so they're effectively nominal,
           // but aren't grouped with the other nominal histograms. Keep track of
           // the results for nominals in these caches to speed those systs up.
@@ -475,6 +462,27 @@ namespace ana
           for(auto& shiftdef: cutdef.second){
             const SystShifts& shift = shiftdef.first;
 
+            // Loop over reco slices, and check if the truth-matched slice pass the (Slice)Cut
+            // We have to shift Slice, and rollback for the actual neutrino shifts
+            // NB) Here, the "reweighting" shifts is not considered but only the lateral shifts on reco selection
+            bool HasMatchedSlicePassCut = false;
+            for(caf::SRSliceProxy& slc: sr->slc){
+              caf::SRProxySystController::BeginTransaction();
+              double dummy_systWeight = 1;
+              if(!shift.IsNominal()){
+                shift.Shift(&slc, dummy_systWeight);
+              }
+              if ( slc.truth.index < 0 ) continue;
+              else if ( slc.truth.index != nu.index ) continue;
+              if( cut(&slc) ){
+                HasMatchedSlicePassCut = true;
+                break;
+              }
+              caf::SRProxySystController::Rollback();
+            }
+            if(!HasMatchedSlicePassCut) continue;
+
+
             // Need to provide a clean slate for each new set of systematic
             // shifts to work from. Copying the whole StandardRecord is pretty
             // expensive, so modify it in place and revert it afterwards.
@@ -482,7 +490,6 @@ namespace ana
             caf::SRProxySystController::BeginTransaction();
 
             bool shifted = false;
-
             double systWeight = 1;
             // Can special-case nominal to not pay cost of Shift()
             if(!shift.IsNominal()){
@@ -542,6 +549,10 @@ namespace ana
               } // end for truthweidef
 
             } // end for truthcutdef
+
+            // Return StandardRecord to its unshifted form ready for the next
+            // histogram.
+            caf::SRProxySystController::Rollback();
 
           } // end for shiftdef 
 

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -555,6 +555,30 @@ namespace ana
     //spect.AddLoader(this); // Remember we have a Go() pending
   }
 
+
+  //----------------------------------------------------------------------
+
+  void SpectrumLoaderBase::AddNUniversesTree(NUniversesTree& tree,
+                                             const std::vector<std::string>& labels,
+                                             const std::vector<std::vector<TruthVar>>& univKnobs,
+                                             const TruthCut& truthcut,
+                                             const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add NUniversesTree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      std::vector<TruthVarOrMultiVar> vecTruthVarOrMultiVar;
+      for ( unsigned int idxUniv=0; idxUniv<univKnobs.at(idx).size(); ++idxUniv ) vecTruthVarOrMultiVar.push_back( univKnobs.at(idx).at(idxUniv) );
+      fTruthNUniversesTreeDefs[shift][truthcut][&tree][ vecTruthVarOrMultiVar ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
   //----------------------------------------------------------------------
   void SpectrumLoaderBase::
   RemoveReweightableSpectrum(ReweightableSpectrum* spect)

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -513,6 +513,26 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddNSigmasTree(NSigmasTree& tree,
+                                          const std::vector<std::string>& labels,
+                                          const std::vector<const ISyst*>& systsToStore,
+                                          const TruthCut& truthcut,
+                                          const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add NSigmasTree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fTruthNSigmasTreeDefs[shift][truthcut][&tree][ systsToStore.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
   void SpectrumLoaderBase::AddNUniversesTree(NUniversesTree& tree,
                                              const std::vector<std::string>& labels,
                                              const std::vector<std::vector<Var>>& univKnobs,

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -471,6 +471,27 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddTree(Tree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<TruthVar>& vars,
+                                   const SpillCut& spillcut,
+                                   const TruthCut& truthcut,
+                                   const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Tree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fTruthTreeDefs[spillcut][shift][truthcut][&tree][ vars.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
   void SpectrumLoaderBase::AddNSigmasTree(NSigmasTree& tree,
                                           const std::vector<std::string>& labels,
                                           const std::vector<const ISyst*>& systsToStore,

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -349,6 +349,44 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddTree(Tree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<SpillVar>& vars,
+                                   const SpillCut& spillcut)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Tree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fSpillTreeDefs[spillcut][&tree][ vars.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddTree(Tree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<SpillMultiVar>& vars,
+                                   const SpillCut& spillcut)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Tree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fSpillTreeDefs[spillcut][&tree][ vars.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
   void SpectrumLoaderBase::
   RemoveReweightableSpectrum(ReweightableSpectrum* spect)
   {

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -265,6 +265,44 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddSpectrum(Spectrum& spect,
+                                       const TruthVar& var,
+                                       const TruthCut truthcut,
+                                       const SpillCut& spillcut,
+                                       const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                                       const TruthVar& wei)
+  { 
+    if(fGone){
+      std::cerr << "Error: can't add Spectra after the call to Go()" << std::endl;
+      abort();
+    }
+
+    fTruthHistDefs[spillcut][cut][truthcut][wei][var].spects.push_back(&spect);
+
+    spect.AddLoader(this); // Remember we have a Go() pending
+    
+  }
+
+  //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddSpectrum(Spectrum& spect,
+                                       const TruthMultiVar& var,
+                                       const TruthCut truthcut,
+                                       const SpillCut& spillcut,
+                                       const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                                       const TruthVar& wei)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Spectra after the call to Go()" << std::endl;
+      abort();
+    }
+
+    fTruthHistDefs[spillcut][cut][truthcut][wei][var].spects.push_back(&spect);
+
+    spect.AddLoader(this); // Remember we have a Go() pending
+
+  }
+
+  //----------------------------------------------------------------------
   void SpectrumLoaderBase::RemoveSpectrum(Spectrum* spect)
   {
     fHistDefs.Erase(spect);

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -387,6 +387,27 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddNSigmasTree(NSigmasTree& tree,
+                                          const std::vector<std::string>& labels,
+                                          const std::vector<const ISyst*>& systsToStore,
+                                          const SpillCut& spillcut,
+                                          const Cut& cut,
+                                          const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add WeightsTree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fNSigmasTreeDefs[spillcut][shift][cut][&tree][ systsToStore.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
   void SpectrumLoaderBase::
   RemoveReweightableSpectrum(ReweightableSpectrum* spect)
   {

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -395,7 +395,7 @@ namespace ana
                                           const SystShifts& shift)
   {
     if(fGone){
-      std::cerr << "Error: can't add WeightsTree after the call to Go()" << std::endl;
+      std::cerr << "Error: can't add NSigmasTree after the call to Go()" << std::endl;
       abort();
     }
 

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -273,6 +273,7 @@ namespace ana
                                        const TruthVar& var,
                                        const TruthCut truthcut,
                                        const SpillCut& spillcut,
+                                       const SystShifts& shift,
                                        const TruthVar& wei)
   {
     if(fGone){
@@ -280,7 +281,7 @@ namespace ana
       abort();
     }
 
-    fTruthHistDefs[spillcut][truthcut][wei][var].spects.push_back(&spect);
+    fTruthHistDefs[spillcut][shift][truthcut][wei][var].spects.push_back(&spect);
 
     spect.AddLoader(this); // Remember we have a Go() pending
 
@@ -291,6 +292,7 @@ namespace ana
                                        const TruthMultiVar& var,
                                        const TruthCut truthcut,
                                        const SpillCut& spillcut,
+                                       const SystShifts& shift,
                                        const TruthVar& wei)
   {
     if(fGone){
@@ -298,7 +300,7 @@ namespace ana
       abort();
     }
 
-    fTruthHistDefs[spillcut][truthcut][wei][var].spects.push_back(&spect);
+    fTruthHistDefs[spillcut][shift][truthcut][wei][var].spects.push_back(&spect);
 
     spect.AddLoader(this); // Remember we have a Go() pending
 
@@ -310,6 +312,7 @@ namespace ana
                                        const TruthCut truthcut,
                                        const SpillCut& spillcut,
                                        const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                                       const SystShifts& shift,
                                        const TruthVar& wei)
   { 
     if(fGone){
@@ -317,7 +320,7 @@ namespace ana
       abort();
     }
 
-    fTruthHistWithCutDefs[spillcut][cut][truthcut][wei][var].spects.push_back(&spect);
+    fTruthHistWithCutDefs[spillcut][cut][shift][truthcut][wei][var].spects.push_back(&spect);
 
     spect.AddLoader(this); // Remember we have a Go() pending
     
@@ -329,6 +332,7 @@ namespace ana
                                        const TruthCut truthcut,
                                        const SpillCut& spillcut,
                                        const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                                       const SystShifts& shift,
                                        const TruthVar& wei)
   {
     if(fGone){
@@ -336,7 +340,7 @@ namespace ana
       abort();
     }
 
-    fTruthHistWithCutDefs[spillcut][cut][truthcut][wei][var].spects.push_back(&spect);
+    fTruthHistWithCutDefs[spillcut][cut][shift][truthcut][wei][var].spects.push_back(&spect);
 
     spect.AddLoader(this); // Remember we have a Go() pending
 
@@ -555,7 +559,7 @@ namespace ana
 
   template struct SpectrumLoaderBase::IDMap<SpillCut, SpectrumLoaderBase::IDMap<SpillVar, SpectrumLoaderBase::IDMap<SpectrumLoaderBase::SpillVarOrMultiVar, SpectrumLoaderBase::SpectList>>>;
 
-  template struct SpectrumLoaderBase::IDMap<SpillCut, SpectrumLoaderBase::IDMap<TruthCut, SpectrumLoaderBase::IDMap<TruthVar, SpectrumLoaderBase::IDMap<SpectrumLoaderBase::TruthVarOrMultiVar, SpectrumLoaderBase::SpectList>>>>;
-  template struct SpectrumLoaderBase::IDMap<SpillCut, SpectrumLoaderBase::IDMap<Cut, SpectrumLoaderBase::IDMap<TruthCut, SpectrumLoaderBase::IDMap<TruthVar, SpectrumLoaderBase::IDMap<SpectrumLoaderBase::TruthVarOrMultiVar, SpectrumLoaderBase::SpectList>>>>>;
+  template struct SpectrumLoaderBase::IDMap<SpillCut, SpectrumLoaderBase::IDMap<SystShifts, SpectrumLoaderBase::IDMap<TruthCut, SpectrumLoaderBase::IDMap<TruthVar, SpectrumLoaderBase::IDMap<SpectrumLoaderBase::TruthVarOrMultiVar, SpectrumLoaderBase::SpectList>>>>>;
+  template struct SpectrumLoaderBase::IDMap<SpillCut, SpectrumLoaderBase::IDMap<Cut, SpectrumLoaderBase::IDMap<SystShifts, SpectrumLoaderBase::IDMap<TruthCut, SpectrumLoaderBase::IDMap<TruthVar, SpectrumLoaderBase::IDMap<SpectrumLoaderBase::TruthVarOrMultiVar, SpectrumLoaderBase::SpectList>>>>>>;
 
 } // namespace

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -270,6 +270,42 @@ namespace ana
                                        const TruthVar& var,
                                        const TruthCut truthcut,
                                        const SpillCut& spillcut,
+                                       const TruthVar& wei)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Spectra after the call to Go()" << std::endl;
+      abort();
+    }
+
+    fTruthHistDefs[spillcut][truthcut][wei][var].spects.push_back(&spect);
+
+    spect.AddLoader(this); // Remember we have a Go() pending
+
+  }
+
+  //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddSpectrum(Spectrum& spect,
+                                       const TruthMultiVar& var,
+                                       const TruthCut truthcut,
+                                       const SpillCut& spillcut,
+                                       const TruthVar& wei)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Spectra after the call to Go()" << std::endl;
+      abort();
+    }
+
+    fTruthHistDefs[spillcut][truthcut][wei][var].spects.push_back(&spect);
+
+    spect.AddLoader(this); // Remember we have a Go() pending
+
+  }
+
+  //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddSpectrum(Spectrum& spect,
+                                       const TruthVar& var,
+                                       const TruthCut truthcut,
+                                       const SpillCut& spillcut,
                                        const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
                                        const TruthVar& wei)
   { 
@@ -278,7 +314,7 @@ namespace ana
       abort();
     }
 
-    fTruthHistDefs[spillcut][cut][truthcut][wei][var].spects.push_back(&spect);
+    fTruthHistWithCutDefs[spillcut][cut][truthcut][wei][var].spects.push_back(&spect);
 
     spect.AddLoader(this); // Remember we have a Go() pending
     
@@ -297,7 +333,7 @@ namespace ana
       abort();
     }
 
-    fTruthHistDefs[spillcut][cut][truthcut][wei][var].spects.push_back(&spect);
+    fTruthHistWithCutDefs[spillcut][cut][truthcut][wei][var].spects.push_back(&spect);
 
     spect.AddLoader(this); // Remember we have a Go() pending
 

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -408,6 +408,29 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddNUniversesTree(NUniversesTree& tree,
+                                             const std::vector<std::string>& labels,
+                                             const std::vector<std::vector<Var>>& univKnobs,
+                                             const SpillCut& spillcut,
+                                             const Cut& cut,
+                                             const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add NUniversesTree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      std::vector<VarOrMultiVar> vecVarOrMultiVar;
+      for ( unsigned int idxUniv=0; idxUniv<univKnobs.at(idx).size(); ++idxUniv ) vecVarOrMultiVar.push_back( univKnobs.at(idx).at(idxUniv) );
+      fNUniversesTreeDefs[spillcut][shift][cut][&tree][ vecVarOrMultiVar ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
   void SpectrumLoaderBase::
   RemoveReweightableSpectrum(ReweightableSpectrum* spect)
   {

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -545,4 +545,8 @@ namespace ana
   template struct SpectrumLoaderBase::IDMap<SpillCut, SpectrumLoaderBase::IDMap<SystShifts, SpectrumLoaderBase::IDMap<Cut, SpectrumLoaderBase::IDMap<Var, SpectrumLoaderBase::IDMap<SpectrumLoaderBase::VarOrMultiVar, SpectrumLoaderBase::SpectList>>>>>;
 
   template struct SpectrumLoaderBase::IDMap<SpillCut, SpectrumLoaderBase::IDMap<SpillVar, SpectrumLoaderBase::IDMap<SpectrumLoaderBase::SpillVarOrMultiVar, SpectrumLoaderBase::SpectList>>>;
+
+  template struct SpectrumLoaderBase::IDMap<SpillCut, SpectrumLoaderBase::IDMap<TruthCut, SpectrumLoaderBase::IDMap<TruthVar, SpectrumLoaderBase::IDMap<SpectrumLoaderBase::TruthVarOrMultiVar, SpectrumLoaderBase::SpectList>>>>;
+  template struct SpectrumLoaderBase::IDMap<SpillCut, SpectrumLoaderBase::IDMap<Cut, SpectrumLoaderBase::IDMap<TruthCut, SpectrumLoaderBase::IDMap<TruthVar, SpectrumLoaderBase::IDMap<SpectrumLoaderBase::TruthVarOrMultiVar, SpectrumLoaderBase::SpectList>>>>>;
+
 } // namespace

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -7,6 +7,7 @@
 #include "sbnana/CAFAna/Core/Spectrum.h"
 #include "sbnana/CAFAna/Core/Utilities.h"
 #include "sbnana/CAFAna/Core/WildcardSource.h"
+#include "sbnana/CAFAna/Core/Tree.h"
 
 #include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
 
@@ -303,6 +304,48 @@ namespace ana
     fHistDefs[spillcut][shift][slicecut][wei][var].rwSpects.push_back(&spect);
 
     spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddTree(Tree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<Var>& vars,
+                                   const SpillCut& spillcut,
+                                   const Cut& cut,
+                                   const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Tree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fTreeDefs[spillcut][shift][cut][&tree][ vars.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
+  }
+
+  //----------------------------------------------------------------------
+  void SpectrumLoaderBase::AddTree(Tree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<MultiVar>& vars,
+                                   const SpillCut& spillcut,
+                                   const Cut& cut,
+                                   const SystShifts& shift)
+  {
+    if(fGone){
+      std::cerr << "Error: can't add Tree after the call to Go()" << std::endl;
+      abort();
+    }
+
+    for ( unsigned int idx=0; idx<labels.size(); ++idx ) {
+      fTreeDefs[spillcut][shift][cut][&tree][ vars.at(idx) ] = labels.at(idx);
+    }
+
+    // TODO do we need to add/remove loaders?
+    //spect.AddLoader(this); // Remember we have a Go() pending
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.cxx
@@ -151,6 +151,8 @@ namespace ana
   {
     fHistDefs.RemoveLoader(this);
     fSpillHistDefs.RemoveLoader(this);
+    fTruthHistDefs.RemoveLoader(this);
+    fTruthHistWithCutDefs.RemoveLoader(this);
   }
 
   //----------------------------------------------------------------------
@@ -345,6 +347,8 @@ namespace ana
   {
     fHistDefs.Erase(spect);
     fSpillHistDefs.Erase(spect);
+    fTruthHistDefs.Erase(spect);
+    fTruthHistWithCutDefs.Erase(spect);
   }
 
   //----------------------------------------------------------------------
@@ -512,6 +516,8 @@ namespace ana
   {
     fHistDefs.Erase(spect);
     fSpillHistDefs.Erase(spect);
+    fTruthHistDefs.Erase(spect);
+    fTruthHistWithCutDefs.Erase(spect);
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -182,6 +182,14 @@ namespace ana
                                    const Cut& cut,
                                    const SystShifts& shift);
 
+
+    /// For use by the constructors of \ref NUniversesTree class but for TrueTree
+    virtual void AddNUniversesTree(NUniversesTree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<std::vector<TruthVar>>& univKnobs,
+                                   const TruthCut& truthcut,
+                                   const SystShifts& shift);
+
     /// Load all the registered spectra
     virtual void Go() = 0;
 
@@ -331,6 +339,7 @@ namespace ana
     std::map<SystShifts, std::map<TruthCut, std::map<NSigmasTree*, std::map<const ISyst*, std::string>>>> fTruthNSigmasTreeDefs;
     // And a version that saves up universe-based systematic weights to make event-by-event weight lists
     std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NUniversesTree*, std::map<std::vector<VarOrMultiVar>, std::string>>>>> fNUniversesTreeDefs;
+    std::map<SystShifts, std::map<TruthCut, std::map<NUniversesTree*, std::map<std::vector<TruthVarOrMultiVar>, std::string>>>> fTruthNUniversesTreeDefs;
 
   };
 
@@ -465,6 +474,13 @@ namespace ana
                            const SpillCut& spillcut,
                            const Cut& cut,
                            const SystShifts& shift) override {}
+
+    void AddNUniversesTree(NUniversesTree& tree,
+                           const std::vector<std::string>& labels,
+                           const std::vector<std::vector<TruthVar>>& univKnobs,
+                           const TruthCut& truthcut,
+                           const SystShifts& shift) override {}
+
   };
   /// \brief Dummy loader that doesn't load any files
   ///

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -353,6 +353,18 @@ namespace ana
                      const TruthVar& var,
                      const TruthCut truthcut,
                      const SpillCut& spillcut,
+                     const TruthVar& wei = kTruthUnweighted) override {}
+
+    void AddSpectrum(Spectrum& spect,
+                     const TruthMultiVar& var,
+                     const TruthCut truthcut,
+                     const SpillCut& spillcut,
+                     const TruthVar& wei = kTruthUnweighted) override {}
+
+    void AddSpectrum(Spectrum& spect,
+                     const TruthVar& var,
+                     const TruthCut truthcut,
+                     const SpillCut& spillcut,
                      const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
                      const TruthVar& wei = kTruthUnweighted) override {}
 

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -167,6 +167,13 @@ namespace ana
                                 const Cut& cut,
                                 const SystShifts& shift);
 
+    /// For use by the constructors of \ref NSigmasTree class but for TrueTree
+    virtual void AddNSigmasTree(NSigmasTree& tree,
+                                const std::vector<std::string>& labels,
+                                const std::vector<const ISyst*>& systsToStore,
+                                const TruthCut& truthcut,
+                                const SystShifts& shift);
+
     /// For use by the constructors of \ref NUniversesTree class
     virtual void AddNUniversesTree(NUniversesTree& tree,
                                    const std::vector<std::string>& labels,
@@ -321,6 +328,7 @@ namespace ana
     std::map<SpillCut, std::map<SystShifts, std::map<TruthCut, std::map<Tree*, std::map<TruthVarOrMultiVar, std::string>>>>> fTruthTreeDefs;
     // And a version that saves up the syst weights used to make event-by-event splines
     std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NSigmasTree*, std::map<const ISyst*, std::string>>>>> fNSigmasTreeDefs;
+    std::map<SystShifts, std::map<TruthCut, std::map<NSigmasTree*, std::map<const ISyst*, std::string>>>> fTruthNSigmasTreeDefs;
     // And a version that saves up universe-based systematic weights to make event-by-event weight lists
     std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NUniversesTree*, std::map<std::vector<VarOrMultiVar>, std::string>>>>> fNUniversesTreeDefs;
 
@@ -443,6 +451,12 @@ namespace ana
                         const std::vector<const ISyst*>& systsToStore,
                         const SpillCut& spillcut,
                         const Cut& cut,
+                        const SystShifts& shift) override {}
+
+    void AddNSigmasTree(NSigmasTree& tree,
+                        const std::vector<std::string>& labels,
+                        const std::vector<const ISyst*>& systsToStore,
+                        const TruthCut& truthcut,
                         const SystShifts& shift) override {}
 
     void AddNUniversesTree(NUniversesTree& tree,

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -27,6 +27,7 @@ namespace ana
   class Tree;
   class WeightsTree;
   class NSigmasTree;
+  class NUniversesTree;
 
   /// Is this data-file representing beam spills or cosmic spills?
   enum DataSource{
@@ -126,6 +127,14 @@ namespace ana
                                 const SpillCut& spillcut,
                                 const Cut& cut,
                                 const SystShifts& shift);
+
+    /// For use by the constructors of \ref NUniversesTree class
+    virtual void AddNUniversesTree(NUniversesTree& tree,
+                                   const std::vector<std::string>& labels,
+                                   const std::vector<std::vector<Var>>& univKnobs,
+                                   const SpillCut& spillcut,
+                                   const Cut& cut,
+                                   const SystShifts& shift);
 
     /// Load all the registered spectra
     virtual void Go() = 0;
@@ -266,6 +275,8 @@ namespace ana
     std::map<SpillCut, std::map<Tree*, std::map<SpillVarOrMultiVar, std::string>>> fSpillTreeDefs;
     // And a version that saves up the syst weights used to make event-by-event splines
     std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NSigmasTree*, std::map<const ISyst*, std::string>>>>> fNSigmasTreeDefs;
+    // And a version that saves up universe-based systematic weights to make event-by-event weight lists
+    std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NUniversesTree*, std::map<std::vector<VarOrMultiVar>, std::string>>>>> fNUniversesTreeDefs;
   };
 
   // For map-making
@@ -347,6 +358,13 @@ namespace ana
                         const SpillCut& spillcut,
                         const Cut& cut,
                         const SystShifts& shift) override {}
+
+    void AddNUniversesTree(NUniversesTree& tree,
+                           const std::vector<std::string>& labels,
+                           const std::vector<std::vector<Var>>& univKnobs,
+                           const SpillCut& spillcut,
+                           const Cut& cut,
+                           const SystShifts& shift) override {}
   };
   /// \brief Dummy loader that doesn't load any files
   ///

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -82,9 +82,20 @@ namespace ana
                              const TruthVar& var,
                              const TruthCut truthcut,
                              const SpillCut& spillcut,
+                             const TruthVar& wei = kTruthUnweighted);
+    /// For use by the \ref Spectrum constructor
+    virtual void AddSpectrum(Spectrum& spect,
+                             const TruthMultiVar& var,
+                             const TruthCut truthcut,
+                             const SpillCut& spillcut,
+                             const TruthVar& wei = kTruthUnweighted);
+    /// For use by the \ref Spectrum constructor
+    virtual void AddSpectrum(Spectrum& spect,
+                             const TruthVar& var,
+                             const TruthCut truthcut,
+                             const SpillCut& spillcut,
                              const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
                              const TruthVar& wei = kTruthUnweighted);
-
     /// For use by the \ref Spectrum constructor
     virtual void AddSpectrum(Spectrum& spect,
                              const TruthMultiVar& var,
@@ -284,8 +295,11 @@ namespace ana
     IDMap<SpillCut, IDMap<SystShifts, IDMap<Cut, IDMap<Var, IDMap<VarOrMultiVar, SpectList>>>>> fHistDefs;
     /// [spillcut][spillwei][spillvar]
     IDMap<SpillCut, IDMap<SpillVar, IDMap<SpillVarOrMultiVar, SpectList>>> fSpillHistDefs;
+
+    /// [spillcut][truthcut][truthweight][truthvar]
+    IDMap<SpillCut, IDMap<TruthCut, IDMap<TruthVar, IDMap<TruthVarOrMultiVar, SpectList>>>> fTruthHistDefs;
     /// [spillcut][cut][truthcut][truthweight][truthvar]
-    IDMap<SpillCut, IDMap<Cut, IDMap<TruthCut, IDMap<TruthVar, IDMap<TruthVarOrMultiVar, SpectList>>>>> fTruthHistDefs;
+    IDMap<SpillCut, IDMap<Cut, IDMap<TruthCut, IDMap<TruthVar, IDMap<TruthVarOrMultiVar, SpectList>>>>> fTruthHistWithCutDefs;
 
     // TODO: Probably someone can make a more efficient version of SpectList
     //       that works with Tree objects... In the meantime, let's use a standard

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -25,6 +25,7 @@ namespace ana
   class Spectrum;
   class ReweightableSpectrum;
   class Tree;
+  class WeightsTree;
   class NSigmasTree;
 
   /// Is this data-file representing beam spills or cosmic spills?

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -72,6 +72,22 @@ namespace ana
                              const SpillCut& cut,
                              const SpillVar& wei = kSpillUnweighted);
 
+    /// For use by the \ref Spectrum constructor
+    virtual void AddSpectrum(Spectrum& spect,
+                             const TruthVar& var,
+                             const TruthCut truthcut,
+                             const SpillCut& spillcut,
+                             const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                             const TruthVar& wei = kTruthUnweighted);
+
+    /// For use by the \ref Spectrum constructor
+    virtual void AddSpectrum(Spectrum& spect,
+                             const TruthMultiVar& var,
+                             const TruthCut truthcut,
+                             const SpillCut& spillcut,
+                             const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                             const TruthVar& wei = kTruthUnweighted);
+
     /// For use by the constructors of \ref ReweightableSpectrum subclasses
     virtual void AddReweightableSpectrum(ReweightableSpectrum& spect,
                                          const Var& var,
@@ -208,6 +224,7 @@ namespace ana
 
     typedef _VarOrMultiVar<caf::SRSliceProxy> VarOrMultiVar;
     typedef _VarOrMultiVar<caf::SRSpillProxy> SpillVarOrMultiVar;
+    typedef _VarOrMultiVar<caf::SRTrueInteractionProxy> TruthVarOrMultiVar;
 
     /// \brief All the spectra that need to be filled
     ///
@@ -215,6 +232,9 @@ namespace ana
     IDMap<SpillCut, IDMap<SystShifts, IDMap<Cut, IDMap<Var, IDMap<VarOrMultiVar, SpectList>>>>> fHistDefs;
     /// [spillcut][spillwei][spillvar]
     IDMap<SpillCut, IDMap<SpillVar, IDMap<SpillVarOrMultiVar, SpectList>>> fSpillHistDefs;
+    /// [spillcut][cut][truthcut][truthweight][truthvar]
+    IDMap<SpillCut, IDMap<Cut, IDMap<TruthCut, IDMap<TruthVar, IDMap<TruthVarOrMultiVar, SpectList>>>>> fTruthHistDefs;
+
   };
 
   /// \brief Dummy loader that doesn't load any files
@@ -249,6 +269,22 @@ namespace ana
                      const SpillMultiVar& var,
                      const SpillCut& cut,
                      const SpillVar& wei = kSpillUnweighted) override {}
+
+    void AddSpectrum(Spectrum& spect,
+                     const TruthVar& var,
+                     const TruthCut truthcut,
+                     const SpillCut& spillcut,
+                     const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                     const TruthVar& wei = kTruthUnweighted) override {}
+
+    void AddSpectrum(Spectrum& spect,
+                     const TruthMultiVar& var,
+                     const TruthCut truthcut,
+                     const SpillCut& spillcut,
+                     const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                     const TruthVar& wei = kTruthUnweighted) override {}
+
+
 
     void AddReweightableSpectrum(ReweightableSpectrum& spect,
                                  const Var& var,

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -151,6 +151,14 @@ namespace ana
                          const std::vector<SpillMultiVar>& vars,
                          const SpillCut& spillcut);
 
+    /// For use by the constructors of \ref Tree class
+    virtual void AddTree(Tree& tree,
+                         const std::vector<std::string>& labels,
+                         const std::vector<TruthVar>& vars,
+                         const SpillCut& spillcut,
+                         const TruthCut& truthcut,
+                         const SystShifts& shift);
+
     /// For use by the constructors of \ref NSigmasTree class
     virtual void AddNSigmasTree(NSigmasTree& tree,
                                 const std::vector<std::string>& labels,
@@ -310,6 +318,7 @@ namespace ana
     //       map. But otherwise, let's keep it the same way...
     std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<Tree*, std::map<VarOrMultiVar, std::string>>>>> fTreeDefs;
     std::map<SpillCut, std::map<Tree*, std::map<SpillVarOrMultiVar, std::string>>> fSpillTreeDefs;
+    std::map<SpillCut, std::map<SystShifts, std::map<TruthCut, std::map<Tree*, std::map<TruthVarOrMultiVar, std::string>>>>> fTruthTreeDefs;
     // And a version that saves up the syst weights used to make event-by-event splines
     std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NSigmasTree*, std::map<const ISyst*, std::string>>>>> fNSigmasTreeDefs;
     // And a version that saves up universe-based systematic weights to make event-by-event weight lists
@@ -421,6 +430,13 @@ namespace ana
                  const std::vector<std::string>& labels,
                  const std::vector<SpillMultiVar>& vars,
                  const SpillCut& spillcut) override {}
+
+    void AddTree(Tree& tree,
+                 const std::vector<std::string>& labels,
+                 const std::vector<TruthVar>& vars,
+                 const SpillCut& spillcut,
+                 const TruthCut& truthcut,
+                 const SystShifts& shift) override {}
 
     void AddNSigmasTree(NSigmasTree& tree,
                         const std::vector<std::string>& labels,

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -316,9 +316,6 @@ namespace ana
     template<class T>
     friend bool operator<(const _VarOrMultiVar<T>& a, const _VarOrMultiVar<T>& b) noexcept;
 
-    template<class T>
-    friend bool operator<(const _VarOrMultiVar<T>& a, const _VarOrMultiVar<T>& b) noexcept;
-
     /// \brief All the spectra that need to be filled
     ///
     /// [spillcut][shift][cut][wei][var]

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -25,6 +25,7 @@ namespace ana
   class Spectrum;
   class ReweightableSpectrum;
   class Tree;
+  class NSigmasTree;
 
   /// Is this data-file representing beam spills or cosmic spills?
   enum DataSource{
@@ -116,6 +117,14 @@ namespace ana
                          const std::vector<std::string>& labels,
                          const std::vector<SpillMultiVar>& vars,
                          const SpillCut& spillcut);
+
+    /// For use by the constructors of \ref NSigmasTree class
+    virtual void AddNSigmasTree(NSigmasTree& tree,
+                                const std::vector<std::string>& labels,
+                                const std::vector<const ISyst*>& systsToStore,
+                                const SpillCut& spillcut,
+                                const Cut& cut,
+                                const SystShifts& shift);
 
     /// Load all the registered spectra
     virtual void Go() = 0;
@@ -254,6 +263,8 @@ namespace ana
     //       map. But otherwise, let's keep it the same way...
     std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<Tree*, std::map<VarOrMultiVar, std::string>>>>> fTreeDefs;
     std::map<SpillCut, std::map<Tree*, std::map<SpillVarOrMultiVar, std::string>>> fSpillTreeDefs;
+    // And a version that saves up the syst weights used to make event-by-event splines
+    std::map<SpillCut, std::map<SystShifts, std::map<Cut, std::map<NSigmasTree*, std::map<const ISyst*, std::string>>>>> fNSigmasTreeDefs;
   };
 
   // For map-making
@@ -328,6 +339,13 @@ namespace ana
                  const std::vector<std::string>& labels,
                  const std::vector<SpillMultiVar>& vars,
                  const SpillCut& spillcut) override {}
+
+    void AddNSigmasTree(NSigmasTree& tree,
+                        const std::vector<std::string>& labels,
+                        const std::vector<const ISyst*>& systsToStore,
+                        const SpillCut& spillcut,
+                        const Cut& cut,
+                        const SystShifts& shift) override {}
   };
   /// \brief Dummy loader that doesn't load any files
   ///

--- a/sbnana/CAFAna/Core/SpectrumLoaderBase.h
+++ b/sbnana/CAFAna/Core/SpectrumLoaderBase.h
@@ -82,12 +82,14 @@ namespace ana
                              const TruthVar& var,
                              const TruthCut truthcut,
                              const SpillCut& spillcut,
+                             const SystShifts& shift,
                              const TruthVar& wei = kTruthUnweighted);
     /// For use by the \ref Spectrum constructor
     virtual void AddSpectrum(Spectrum& spect,
                              const TruthMultiVar& var,
                              const TruthCut truthcut,
                              const SpillCut& spillcut,
+                             const SystShifts& shift,
                              const TruthVar& wei = kTruthUnweighted);
     /// For use by the \ref Spectrum constructor
     virtual void AddSpectrum(Spectrum& spect,
@@ -95,6 +97,7 @@ namespace ana
                              const TruthCut truthcut,
                              const SpillCut& spillcut,
                              const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                             const SystShifts& shift,
                              const TruthVar& wei = kTruthUnweighted);
     /// For use by the \ref Spectrum constructor
     virtual void AddSpectrum(Spectrum& spect,
@@ -102,6 +105,7 @@ namespace ana
                              const TruthCut truthcut,
                              const SpillCut& spillcut,
                              const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                             const SystShifts& shift,
                              const TruthVar& wei = kTruthUnweighted);
 
     /// For use by the constructors of \ref ReweightableSpectrum subclasses
@@ -296,10 +300,10 @@ namespace ana
     /// [spillcut][spillwei][spillvar]
     IDMap<SpillCut, IDMap<SpillVar, IDMap<SpillVarOrMultiVar, SpectList>>> fSpillHistDefs;
 
-    /// [spillcut][truthcut][truthweight][truthvar]
-    IDMap<SpillCut, IDMap<TruthCut, IDMap<TruthVar, IDMap<TruthVarOrMultiVar, SpectList>>>> fTruthHistDefs;
-    /// [spillcut][cut][truthcut][truthweight][truthvar]
-    IDMap<SpillCut, IDMap<Cut, IDMap<TruthCut, IDMap<TruthVar, IDMap<TruthVarOrMultiVar, SpectList>>>>> fTruthHistWithCutDefs;
+    /// [spillcut][shift][truthcut][truthweight][truthvar]
+    IDMap<SpillCut, IDMap<SystShifts, IDMap<TruthCut, IDMap<TruthVar, IDMap<TruthVarOrMultiVar, SpectList>>>>> fTruthHistDefs;
+    /// [spillcut][cut][shift][truthcut][truthweight][truthvar]
+    IDMap<SpillCut, IDMap<Cut, IDMap<SystShifts, IDMap<TruthCut, IDMap<TruthVar, IDMap<TruthVarOrMultiVar, SpectList>>>>>> fTruthHistWithCutDefs;
 
     // TODO: Probably someone can make a more efficient version of SpectList
     //       that works with Tree objects... In the meantime, let's use a standard
@@ -353,12 +357,14 @@ namespace ana
                      const TruthVar& var,
                      const TruthCut truthcut,
                      const SpillCut& spillcut,
+                     const SystShifts& shift,
                      const TruthVar& wei = kTruthUnweighted) override {}
 
     void AddSpectrum(Spectrum& spect,
                      const TruthMultiVar& var,
                      const TruthCut truthcut,
                      const SpillCut& spillcut,
+                     const SystShifts& shift,
                      const TruthVar& wei = kTruthUnweighted) override {}
 
     void AddSpectrum(Spectrum& spect,
@@ -366,6 +372,7 @@ namespace ana
                      const TruthCut truthcut,
                      const SpillCut& spillcut,
                      const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                     const SystShifts& shift,
                      const TruthVar& wei = kTruthUnweighted) override {}
 
     void AddSpectrum(Spectrum& spect,
@@ -373,6 +380,7 @@ namespace ana
                      const TruthCut truthcut,
                      const SpillCut& spillcut,
                      const Cut& cut, // loop over reco slices and see if any matched to this truth and pass "cut"
+                     const SystShifts& shift,
                      const TruthVar& wei = kTruthUnweighted) override {}
 
 

--- a/sbnana/CAFAna/Core/SystShifts.cxx
+++ b/sbnana/CAFAna/Core/SystShifts.cxx
@@ -166,4 +166,11 @@ namespace ana
 
     return ret;
   }
+
+  //----------------------------------------------------------------------
+  bool operator<(const SystShifts& a, const SystShifts& b)
+  {
+    return a.ID() < b.ID();
+  }
+
 }

--- a/sbnana/CAFAna/Core/SystShifts.cxx
+++ b/sbnana/CAFAna/Core/SystShifts.cxx
@@ -89,6 +89,12 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void SystShifts::Shift(caf::SRTrueInteractionProxy* nu, double& weight) const
+  {
+    for(auto it: fSysts) it.first->Shift(it.second, nu, weight);
+  }
+
+  //----------------------------------------------------------------------
   std::string SystShifts::ShortName() const
   {
     if(fSysts.empty()) return "nominal";

--- a/sbnana/CAFAna/Core/SystShifts.h
+++ b/sbnana/CAFAna/Core/SystShifts.h
@@ -58,5 +58,7 @@ namespace ana
     static int fgNextID;
   };
 
+  bool operator< (const SystShifts& a, const SystShifts& b);
+
   const SystShifts kNoShift = SystShifts::Nominal();
 }

--- a/sbnana/CAFAna/Core/SystShifts.h
+++ b/sbnana/CAFAna/Core/SystShifts.h
@@ -34,6 +34,7 @@ namespace ana
     double Penalty() const;
 
     void Shift(caf::SRSliceProxy* slc, double& weight) const;
+    void Shift(caf::SRTrueInteractionProxy* nu, double& weight) const;
 
     /// Brief description of component shifts, for printing to screen
     std::string ShortName() const;

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -6,6 +6,7 @@
 #include "TH1D.h"
 #include "TGraph.h"
 #include "TSpline.h"
+#include "TClonesArray.h"
 
 #include <cassert>
 #include <cmath>
@@ -644,6 +645,135 @@ namespace ana
     theTree.Write();
 
     tmp->cd();
+  }
+
+  //----------------------------------------------------------------------
+  void NSigmasTree::SaveToTClonesArrays( TDirectory* dir ) const
+  {
+
+    std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;
+    std::cout << "  " << fNEntries << " Entries" << std::endl;
+    std::cout << "  For " << fPOT << " POT and " << fLivetime << " Livetime" << std::endl;
+    std::cout << "  Containing " << fOrderedBranchWeightNames.size() << " TClonesArray per entry..." << std::endl;
+
+    // Check (and assert) that the branches all have fNEntries
+    for ( auto const& [branch, values] : fBranchEntries ){
+      assert( (long long)values.size() == fNEntries );
+    }
+    for ( auto const& [branch, weightVecs] : fBranchWeightEntries ){
+      assert( (long long)weightVecs.size() == fNEntries );
+    }
+
+    TDirectory *tmp = gDirectory;
+    dir->cd();
+
+    TH1D thePOT("POT","POT",1,0,1);
+    thePOT.SetBinContent(1,fPOT);
+    thePOT.Write();
+
+    TH1D theLivetime("Livetime","Livetime",1,0,1);
+    theLivetime.SetBinContent(1,fLivetime);
+    theLivetime.Write();
+
+    TTree theTree( fTreeName.c_str(), fTreeName.c_str() );
+
+    const int NBranches = fOrderedBranchNames.size();
+
+    bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
+    double entryValsDouble[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
+
+    for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
+      if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
+                        &entryValsInt[idxBranch] );
+        treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
+                        &entryValsInt[idxBranch] );
+        treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
+        std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
+      }
+      else {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
+      }
+    }
+
+    const int NBranchesWeights = fOrderedBranchWeightNames.size();
+
+    TClonesArray *arraysArr[NBranchesWeights];
+    for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+      arraysArr[idxBranchWeight] = new TClonesArray("TGraph", 1);
+      theTree.Branch( fOrderedBranchWeightNames.at(idxBranchWeight).c_str(), &arraysArr[idxBranchWeight], 32000, -1);
+    }
+
+    // Loop over entries
+    for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
+      // Fill up the vals for the standard value branches
+      for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
+      }
+      // Make the graphs
+      for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+        const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
+        double sigmasArr[NSigmas];
+        for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
+          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + int(idxSigma));
+        }
+
+        double weightsArr[NSigmas];
+        unsigned int idxVal = 0;
+        for ( auto const& val : fBranchWeightEntries.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at( idxEntry ) ) {
+          weightsArr[ idxVal ] = val;
+          idxVal+=1;
+        }
+
+        new( (*arraysArr[idxBranchWeight])[0]) TGraph(NSigmas,sigmasArr,weightsArr);
+
+      }
+
+      theTree.Fill();
+
+      for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+        arraysArr[idxBranchWeight]->Clear();
+      }
+
+    }
+
+    theTree.Write();
+
+    tmp->cd();
+
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -145,6 +145,7 @@ namespace ana
     assert( labels.size() == vars.size() );
 
     fOrderedBranchNames.push_back( "CutType/i" ); fBranchEntries["CutType/i"] = {};
+    fOrderedBranchNames.push_back( "SpillCutType/i" ); fBranchEntries["SpillCutType/i"] = {};
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -1,0 +1,118 @@
+#include "sbnana/CAFAna/Core/Tree.h"
+
+#include "TDirectory.h"
+#include "TBranch.h"
+#include "TTree.h"
+
+#include <cassert>
+
+namespace ana
+{
+
+  //----------------------------------------------------------------------
+  // Constructor for a set of Vars, typical usage for a Selected Tree
+  Tree::Tree( const std::string name, const std::vector<std::string>& labels,
+              SpectrumLoaderBase& loader,
+              const std::vector<Var>& vars, const SpillCut& spillcut,
+              const Cut& cut, const SystShifts& shift )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+  {
+    assert( labels.size() == vars.size() );
+
+    for ( unsigned int i=0; i<labels.size(); ++i ) {
+      fOrderedBranchNames.push_back( labels.at(i) );
+      fBranchEntries[labels.at(i)] = {};
+    }
+
+    loader.AddTree( *this, labels, vars, spillcut, cut, shift );
+  }
+
+  //----------------------------------------------------------------------
+  // Constructor for a set of MultiVars
+  Tree::Tree( const std::string name, const std::vector<std::string>& labels,
+              SpectrumLoaderBase& loader,
+              const std::vector<MultiVar>& vars, const SpillCut& spillcut,
+              const Cut& cut, const SystShifts& shift )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+  {
+    assert( labels.size() == vars.size() );
+
+    for ( unsigned int i=0; i<labels.size(); ++i ) {
+      fOrderedBranchNames.push_back( labels.at(i) );
+      fBranchEntries[labels.at(i)] = {};
+    }
+
+    loader.AddTree( *this, labels, vars, spillcut, cut, shift );
+  }
+
+  //----------------------------------------------------------------------
+  // Constructor for a set of SpillVars
+  Tree::Tree( const std::string name, const std::vector<std::string>& labels,
+              SpectrumLoaderBase& loader,
+              const std::vector<Var>& vars, const SpillCut& spillcut)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+  {
+    assert( labels.size() == vars.size() );
+
+    for ( unsigned int i=0; i<labels.size(); ++i ) {
+      fOrderedBranchNames.push_back( labels.at(i) );
+      fBranchEntries[labels.at(i)] = {};
+    }
+
+    loader.AddTree( *this, labels, vars, spillcut, cut, shift );
+  }
+
+  //----------------------------------------------------------------------
+  // Add an entry to a branch
+  void Tree::AddEntry( const std::string name, const double val )
+  {
+    assert ( fBranchEntries.find(name) != fBranchEntries.end() );
+  
+    fBranchEntries.at(name).push_back(val);
+  }
+
+  //----------------------------------------------------------------------
+  // Save to a ROOT file directory as a TTree -- similar to Spectrum::SaveTo()
+  void Tree::SaveTo( TDirectory* dir ) const
+  {
+    std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;
+    std::cout << "  " << fNEntries << " Entries" << std::endl;
+    std::cout << "  For " << fPOT << " POT and " << fLivetime << " Livetime" << std::endl;
+    if ( fNEntries>=1 ) {
+      std::cout << "  Sample:" << std::endl;
+      for ( auto const& [key, value] : fBranchEntries ) {
+        std::cout << "    " << key << " has first value " << value.at(0) << std::endl;
+      }
+    }
+    else {
+      std::cout << "    Double checking --> " << fOrderedBranchNames.at(0)
+                << " has size " <<  fBranchEntries.at( fOrderedBranchNames.at(0) ).size() << std::endl;
+    }
+
+    TDirectory *tmp = gDirectory;
+    dir->cd();
+
+    TTree theTree( fTreeName.c_str(), fTreeName.c_str() );
+
+    const int NBranches = fOrderedBranchNames.size();
+    double entryVals[ NBranches ];
+
+    for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
+      theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryVals[idxBranch] );
+    }
+
+    // Loop over entries
+    for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
+      // Fill up the vals
+      for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
+        entryVals[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+      }
+      theTree.Fill();
+    }
+
+    theTree.Write();
+
+    tmp->cd();
+  }
+
+}

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -909,6 +909,18 @@ namespace ana
 
     loader.AddNSigmasTree( *this, labels, systsToStore, truthcut, shift );
   }
+  //----------------------------------------------------------------------
+  NSigmasTree::NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                            SpectrumLoaderBase& loader,
+                            const std::vector<const ISyst*>& systsToStore, const std::vector<std::vector<double>>& nSigma,
+                            const TruthCut& truthcut, const SystShifts& shift, const bool saveRunSubEvt)
+  : WeightsTree(name,labels,nSigma,saveRunSubEvt,false)
+  {
+    assert( labels.size() == systsToStore.size() );
+    assert( nSigma.size() == labels.size() );
+
+    loader.AddNSigmasTree( *this, labels, systsToStore, truthcut, shift );
+  }
 
   //----------------------------------------------------------------------
   void NSigmasTree::SaveToSplines( TDirectory* dir ) const

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -360,7 +360,15 @@ namespace ana
   //----------------------------------------------------------------------
   void WeightsTree::MergeTree( const Tree& inTree )
   {
-    assert( this->fSaveRunSubEvt && this->fSaveSliceNum && inTree.fSaveRunSubEvt && inTree.fSaveSliceNum );
+    // RunSubEvt must be saved
+    assert( this->fSaveRunSubEvt && inTree.fSaveRunSubEvt );
+    // Tree with SpilVar or TruthVar does not require SliceNum to be saved.
+    // But if either of "This" or "inTree" does save SliceNum, then both should have it saved
+    bool SliceNumIsSaved = false;
+    if( this->fSaveSliceNum || inTree.fSaveSliceNum ){
+      assert( this->fSaveSliceNum && inTree.fSaveSliceNum );
+      SliceNumIsSaved = true;
+    }
 
     // This requires the branches to agree and be in the same order...
     // Someone could write a more complicated version but right now this is the foreseen use.
@@ -369,8 +377,10 @@ namespace ana
       // Entries must be the same
       assert( this->fBranchEntries.at("Run/i").at(idx) == inTree.fBranchEntries.at("Run/i").at(idx) &&
               this->fBranchEntries.at("Subrun/i").at(idx) == inTree.fBranchEntries.at("Subrun/i").at(idx) &&
-              this->fBranchEntries.at("Evt/i").at(idx) == inTree.fBranchEntries.at("Evt/i").at(idx) &&
-              this->fBranchEntries.at("Slice/i").at(idx) == inTree.fBranchEntries.at("Slice/i").at(idx) );
+              this->fBranchEntries.at("Evt/i").at(idx) == inTree.fBranchEntries.at("Evt/i").at(idx) );
+      if(SliceNumIsSaved){
+        assert( this->fBranchEntries.at("Slice/i").at(idx) == inTree.fBranchEntries.at("Slice/i").at(idx) );
+      }
     }
 
     std::vector<std::string> branchesToFill;

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -439,6 +439,19 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  NSigmasTree::NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                            SpectrumLoaderBase& loader,
+                            const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
+                            const TruthCut& truthcut, const SystShifts& shift, const bool saveRunSubEvt)
+  : WeightsTree(name,labels,nSigma,saveRunSubEvt,false)
+  {
+    assert( labels.size() == systsToStore.size() );
+    assert( nSigma.size() == labels.size() );
+
+    loader.AddNSigmasTree( *this, labels, systsToStore, truthcut, shift );
+  }
+
+  //----------------------------------------------------------------------
   void NSigmasTree::SaveToSplines( TDirectory* dir ) const
   {
     std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -735,7 +735,7 @@ namespace ana
       fNWeightsExpected[labels.at(i)] = (unsigned int)((nSigma.at(i).second-nSigma.at(i).first) + 1);
       fNSigmas[labels.at(i)] = {};
       for( unsigned int i_sigma=0; i_sigma<fNWeightsExpected[labels.at(i)]; ++i_sigma){
-        fNSigmas[labels.at(i)].push_back( nSigma.at(i).first + i_sigma );
+        fNSigmas[labels.at(i)].push_back( (float)nSigma.at(i).first + (float)i_sigma );
       }
 
     }

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -830,6 +830,24 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  NUniversesTree::NUniversesTree( const std::string name, const std::vector<std::string>& labels,
+                                  SpectrumLoaderBase& loader,
+                                  const std::vector<std::vector<TruthVar>>& univsKnobs,
+                                  const std::vector<unsigned int>& nUniverses,
+                                  const TruthCut& truthcut,
+                                  const SystShifts& shift, const bool saveRunSubEvt)
+  : WeightsTree(name,labels,nUniverses,saveRunSubEvt,false)
+  {
+    assert( labels.size() == univsKnobs.size() );
+
+    for ( unsigned int i=0; i<labels.size(); ++i ) {
+      assert( univsKnobs.at(i).size() == nUniverses.at(i) );
+    }
+
+    loader.AddNUniversesTree( *this, labels, univsKnobs, truthcut, shift );
+  }
+
+  //----------------------------------------------------------------------
   void NUniversesTree::SaveTo( TDirectory* dir ) const
   {
     std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -132,6 +132,34 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  // Constructor for a set of TruthVars
+  Tree::Tree( const std::string name, const std::vector<std::string>& labels,
+              SpectrumLoaderBase& loader,
+              const std::vector<TruthVar>& vars, const SpillCut& spillcut,
+              const TruthCut& truthcut, const SystShifts& shift, const bool saveRunSubEvt )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false)
+  {
+    assert( labels.size() == vars.size() );
+
+    for ( unsigned int i=0; i<labels.size(); ++i ) {
+      fOrderedBranchNames.push_back( labels.at(i) );
+      fBranchEntries[labels.at(i)] = {};
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
+    }
+
+    loader.AddTree( *this, labels, vars, spillcut, truthcut, shift );
+  }
+
+  //----------------------------------------------------------------------
   // Add an entry to a branch
   void Tree::UpdateEntries( const std::map<std::string, std::vector<double>> valsMap )
   {

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -21,7 +21,7 @@ namespace ana
               SpectrumLoaderBase& loader,
               const std::vector<Var>& vars, const SpillCut& spillcut,
               const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt, const bool saveSliceNum )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum), fSaveTruthCutType(false), SignalSelection(kNoCut)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum), SignalSelection(kNoCut)
   {
     assert( labels.size() == vars.size() );
 
@@ -53,7 +53,7 @@ namespace ana
               SpectrumLoaderBase& loader,
               const std::vector<MultiVar>& vars, const SpillCut& spillcut,
               const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt, const bool saveSliceNum )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum), fSaveTruthCutType(false), SignalSelection(kNoCut)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum), SignalSelection(kNoCut)
   {
     assert( labels.size() == vars.size() );
 
@@ -84,7 +84,7 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<SpillVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false), fSaveTruthCutType(false), SignalSelection(kNoCut)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false), SignalSelection(kNoCut)
   {
     assert( labels.size() == vars.size() );
 
@@ -111,7 +111,7 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false), fSaveTruthCutType(false), SignalSelection(kNoCut)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false), SignalSelection(kNoCut)
   {
     assert( labels.size() == vars.size() );
 
@@ -141,12 +141,16 @@ namespace ana
               const TruthCut& truthcut,
               const Cut& SignalSelection,
               const SystShifts& shift,
-              const bool saveRunSubEvt)
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false), fSaveTruthCutType(true), SignalSelection(SignalSelection)
+              const bool saveRunSubEvt,
+              const bool saveTruthCutType)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false), SignalSelection(SignalSelection)
   {
     assert( labels.size() == vars.size() );
 
-    fOrderedBranchNames.push_back( "CutType/i" ); fBranchEntries["CutType/i"] = {};
+    SetSaveTruthCutType(saveTruthCutType);
+    if( SaveTruthCutType() ) {
+      fOrderedBranchNames.push_back( "CutType/i" ); fBranchEntries["CutType/i"] = {};
+    }
     fOrderedBranchNames.push_back( "SpillCutType/i" ); fBranchEntries["SpillCutType/i"] = {};
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
@@ -165,6 +169,7 @@ namespace ana
     }
 
     loader.AddTree( *this, labels, vars, spillcut, truthcut, shift );
+
   }
 
   //----------------------------------------------------------------------

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -452,6 +452,126 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  void NSigmasTree::SaveToGraphs( TDirectory* dir ) const
+  {
+    std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;
+    std::cout << "  " << fNEntries << " Entries" << std::endl;
+    std::cout << "  For " << fPOT << " POT and " << fLivetime << " Livetime" << std::endl;
+    std::cout << "  Containing " << fOrderedBranchWeightNames.size() << " graphs per entry..." << std::endl;
+
+    // Check (and assert) that the branches all have fNEntries
+    for ( auto const& [branch, values] : fBranchEntries ){
+      assert( (long long)values.size() == fNEntries );
+    }
+    for ( auto const& [branch, weightVecs] : fBranchWeightEntries ){
+      assert( (long long)weightVecs.size() == fNEntries );
+    }
+
+    TDirectory *tmp = gDirectory;
+    dir->cd();
+
+    TH1D thePOT("POT","POT",1,0,1);
+    thePOT.SetBinContent(1,fPOT);
+    thePOT.Write();
+
+    TH1D theLivetime("Livetime","Livetime",1,0,1);
+    theLivetime.SetBinContent(1,fLivetime);
+    theLivetime.Write();
+
+    TTree theTree( fTreeName.c_str(), fTreeName.c_str() );
+
+    const int NBranches = fOrderedBranchNames.size();
+
+    bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
+    double entryValsDouble[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
+
+    for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
+      if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
+                        &entryValsInt[idxBranch] );
+        treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
+                        &entryValsInt[idxBranch] );
+        treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
+        std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
+      }
+      else {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
+      }
+    }
+
+    const int NBranchesWeights = fOrderedBranchWeightNames.size();
+    const int NSigmas = 2*fNSigma+1;
+
+    double sigmasArr[NSigmas];
+    for ( unsigned int idxSigma=0; idxSigma<2*fNSigma+1; ++idxSigma ) {
+      sigmasArr[idxSigma] = double((-1*int(fNSigma))+int(idxSigma));
+    }
+
+    TGraph *graphsArr[NBranchesWeights];
+    for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+      graphsArr[idxBranchWeight] = nullptr;
+      theTree.Branch( fOrderedBranchWeightNames.at(idxBranchWeight).c_str(), &graphsArr[idxBranchWeight] );
+    }
+
+    // Loop over entries
+    for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
+      // Fill up the vals for the standard value branches
+      for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
+      }
+      // Make the graphs
+      for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
+        double weightsArr[NSigmas];
+        unsigned int idxVal = 0;
+        for ( auto const& val : fBranchWeightEntries.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at( idxEntry ) ) {
+          weightsArr[ idxVal ] = val;
+          idxVal+=1;
+        }
+        graphsArr[ idxBranchWeight ] = new TGraph(NSigmas,sigmasArr,weightsArr);
+      }
+
+      theTree.Fill();
+    }
+
+    theTree.Write();
+
+    tmp->cd();
+  }
+
+  //----------------------------------------------------------------------
   void NSigmasTree::SaveTo( TDirectory* dir ) const
   {
     std::cout << "WRITING A TTree FOR THIS Tree OBJECT WITH:" << std::endl;

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -16,14 +16,24 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<Var>& vars, const SpillCut& spillcut,
-              const Cut& cut, const SystShifts& shift )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
   {
     assert( labels.size() == vars.size() );
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );
       fBranchEntries[labels.at(i)] = {};
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut, cut, shift );
@@ -34,14 +44,24 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<MultiVar>& vars, const SpillCut& spillcut,
-              const Cut& cut, const SystShifts& shift )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
   {
     assert( labels.size() == vars.size() );
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );
       fBranchEntries[labels.at(i)] = {};
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut, cut, shift );
@@ -51,14 +71,24 @@ namespace ana
   // Constructor for a set of SpillVars
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
-              const std::vector<SpillVar>& vars, const SpillCut& spillcut)
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+              const std::vector<SpillVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
   {
     assert( labels.size() == vars.size() );
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );
       fBranchEntries[labels.at(i)] = {};
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut );
@@ -68,14 +98,24 @@ namespace ana
   // Constructor for a set of SpillMultiVars
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
-              const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut)
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0)
+              const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
   {
     assert( labels.size() == vars.size() );
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );
       fBranchEntries[labels.at(i)] = {};
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut );

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -195,28 +195,47 @@ namespace ana
     const int NBranches = fOrderedBranchNames.size();
 
     bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
     double entryValsDouble[ NBranches ];
-    long long entryValsInt[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
 
     for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
       if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
         std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
       else {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
     }
 
@@ -224,8 +243,12 @@ namespace ana
     for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
       // Fill up the vals
       for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
-        if ( !treatAsInt[idxBranch] ) entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
-        else                          entryValsInt[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
       }
       theTree.Fill();
     }
@@ -338,28 +361,47 @@ namespace ana
     const int NBranches = fOrderedBranchNames.size();
 
     bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
     double entryValsDouble[ NBranches ];
-    long long entryValsInt[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
 
     for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
       if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
         std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
       else {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
     }
 
@@ -381,8 +423,12 @@ namespace ana
     for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
       // Fill up the vals for the standard value branches
       for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
-        if ( !treatAsInt[idxBranch] ) entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
-        else                          entryValsInt[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
       }
       // Make the splines
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
@@ -437,28 +483,47 @@ namespace ana
     const int NBranches = fOrderedBranchNames.size();
 
     bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
     double entryValsDouble[ NBranches ];
-    long long entryValsInt[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
 
     for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
       if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
         std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
       else {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
     }
 
@@ -479,8 +544,12 @@ namespace ana
     for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
       // Fill up the vals for the standard value branches
       for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
-        if ( !treatAsInt[idxBranch] ) entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
-        else                          entryValsInt[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
       }
       // Save the weights
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
@@ -551,28 +620,47 @@ namespace ana
     const int NBranches = fOrderedBranchNames.size();
 
     bool treatAsInt[ NBranches ];
+    bool treatAsLong[ NBranches ];
+
     double entryValsDouble[ NBranches ];
-    long long entryValsInt[ NBranches ];
+    int entryValsInt[ NBranches ];
+    long long entryValsLong[ NBranches ];
 
     for ( unsigned int idxBranch=0; idxBranch<fOrderedBranchNames.size(); ++idxBranch ) {
       if ( fOrderedBranchNames.at(idxBranch).find("/i")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/i")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/I")!=std::string::npos ) {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/I")).c_str(),
                         &entryValsInt[idxBranch] );
         treatAsInt[idxBranch] = true;
+        treatAsLong[idxBranch] = false;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/l")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/l")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
+      }
+      else if ( fOrderedBranchNames.at(idxBranch).find("/L")!=std::string::npos ) {
+        theTree.Branch( fOrderedBranchNames.at(idxBranch).substr(0, fOrderedBranchNames.at(idxBranch).find("/L")).c_str(),
+                        &entryValsLong[idxBranch] );
+        treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = true;
       }
       else if ( fOrderedBranchNames.at(idxBranch).find("/")!=std::string::npos ) {
         std::cout << "WARNING!! A '/' was found in the variable name, possibly by mistake? Will treat this branch as a double..." << std::endl;
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
       else {
         theTree.Branch( fOrderedBranchNames.at(idxBranch).c_str(), &entryValsDouble[idxBranch] );
         treatAsInt[idxBranch] = false;
+        treatAsLong[idxBranch] = false;
       }
     }
 
@@ -591,8 +679,12 @@ namespace ana
     for ( unsigned int idxEntry=0; idxEntry < fNEntries; ++idxEntry ) {
       // Fill up the vals for the standard value branches
       for ( unsigned int idxBranch=0; idxBranch < fOrderedBranchNames.size(); ++idxBranch ) {
-        if ( !treatAsInt[idxBranch] ) entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
-        else                          entryValsInt[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        if ( !treatAsInt[idxBranch] && !treatAsLong[idxBranch] )     entryValsDouble[idxBranch] = fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry);
+        else if ( treatAsInt[idxBranch] && !treatAsLong[idxBranch] ) entryValsInt[idxBranch] = (int)lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else if ( treatAsLong[idxBranch] && !treatAsInt[idxBranch] ) entryValsLong[idxBranch] = lround(fBranchEntries.at( fOrderedBranchNames.at(idxBranch) ).at(idxEntry));
+        else {
+          if ( idxEntry==0 ) std::cout << "ERROR!! Branch " << fOrderedBranchNames.at(idxBranch) << " wants to fill as int and long..." << std::endl;
+        }
       }
       // Save the weights
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -19,7 +19,7 @@ namespace ana
               SpectrumLoaderBase& loader,
               const std::vector<Var>& vars, const SpillCut& spillcut,
               const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt, const bool saveSliceNum )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum), fSaveTruthCutType(false), SignalSelection(kNoCut)
   {
     assert( labels.size() == vars.size() );
 
@@ -51,7 +51,7 @@ namespace ana
               SpectrumLoaderBase& loader,
               const std::vector<MultiVar>& vars, const SpillCut& spillcut,
               const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt, const bool saveSliceNum )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum), fSaveTruthCutType(false), SignalSelection(kNoCut)
   {
     assert( labels.size() == vars.size() );
 
@@ -82,7 +82,7 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<SpillVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false), fSaveTruthCutType(false), SignalSelection(kNoCut)
   {
     assert( labels.size() == vars.size() );
 
@@ -109,7 +109,7 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false), fSaveTruthCutType(false), SignalSelection(kNoCut)
   {
     assert( labels.size() == vars.size() );
 
@@ -136,10 +136,15 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<TruthVar>& vars, const SpillCut& spillcut,
-              const TruthCut& truthcut, const SystShifts& shift, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false)
+              const TruthCut& truthcut,
+              const Cut& SignalSelection,
+              const SystShifts& shift,
+              const bool saveRunSubEvt)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false), fSaveTruthCutType(true), SignalSelection(SignalSelection)
   {
     assert( labels.size() == vars.size() );
+
+    fOrderedBranchNames.push_back( "CutType/i" ); fBranchEntries["CutType/i"] = {};
 
     for ( unsigned int i=0; i<labels.size(); ++i ) {
       fOrderedBranchNames.push_back( labels.at(i) );

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -16,8 +16,8 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<Var>& vars, const SpillCut& spillcut,
-              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
+              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt, const bool saveSliceNum )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum)
   {
     assert( labels.size() == vars.size() );
 
@@ -34,6 +34,10 @@ namespace ana
       fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
       fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
       fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
+    }
+    if ( saveSliceNum ) {
+      assert( fBranchEntries.find("Slice/i") == fBranchEntries.end() );
+      fOrderedBranchNames.push_back( "Slice/i" ); fBranchEntries["Slice/i"] = {};
     }
 
     loader.AddTree( *this, labels, vars, spillcut, cut, shift );
@@ -44,8 +48,8 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<MultiVar>& vars, const SpillCut& spillcut,
-              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
+              const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt, const bool saveSliceNum )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum)
   {
     assert( labels.size() == vars.size() );
 
@@ -63,6 +67,10 @@ namespace ana
       fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
       fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
     }
+    if ( saveSliceNum ) {
+      assert( fBranchEntries.find("Slice/i") == fBranchEntries.end() );
+      fOrderedBranchNames.push_back( "Slice/i" ); fBranchEntries["Slice/i"] = {};
+    }
 
     loader.AddTree( *this, labels, vars, spillcut, cut, shift );
   }
@@ -72,7 +80,7 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<SpillVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false)
   {
     assert( labels.size() == vars.size() );
 
@@ -99,7 +107,7 @@ namespace ana
   Tree::Tree( const std::string name, const std::vector<std::string>& labels,
               SpectrumLoaderBase& loader,
               const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt )
-    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt)
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(false)
   {
     assert( labels.size() == vars.size() );
 
@@ -139,7 +147,7 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
-  // Add an entry to a branch
+  // Update branch exposure
   void Tree::UpdateExposure( const double pot, const double livetime )
   {
     fPOT+=pot;

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -109,6 +109,7 @@ namespace ana
                  const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
+    void SaveToGraphs( TDirectory* dir ) const;
   };
 
   class NUniversesTree : public WeightsTree

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -120,6 +120,7 @@ namespace ana
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;
+    void SaveToTClonesArrays( TDirectory* dir ) const;
   };
 
   class NUniversesTree : public WeightsTree

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -40,6 +40,11 @@ namespace ana
           SpectrumLoaderBase& loader,
           const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt = false );
     /// constructor with a vector of \ref TruthVar
+    /// Dedicated for signal efficiency, thus has slightly different behavior
+    /// - spillcut: It does not cut event by spillcut, but creates a branch "SpillCutType"
+    /// - truthcut: Signal definition is defined here. Only the TrueInteraction (=nu) that satisfies truthcut will be filled
+    /// - SignalSelection: Reco cut that defined your signal selection. 
+    ///   For each nu, it loops over reco slices, and find if any matched slice pass this cut, and save this to "CutType" branch
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<TruthVar>& vars, const SpillCut& spillcut,
@@ -130,6 +135,11 @@ namespace ana
                  const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
                  const SpillCut& spillcut,
                  const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    /// constructor with a vector of \ref ISyst, but for TrueTree
+    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                 SpectrumLoaderBase& loader,
+                 const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
+                 const TruthCut& truthcut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false);
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -112,6 +112,8 @@ namespace ana
                  const std::vector<unsigned int>& nWeights, const bool saveRunSubEvt, const bool saveSliceNum );
     WeightsTree( const std::string name, const std::vector<std::string>& labels,
                  const std::vector<std::pair<int,int>>& nSigma, const bool saveRunSubEvt, const bool saveSliceNum );
+    WeightsTree( const std::string name, const std::vector<std::string>& labels,
+                 const std::vector<std::vector<double>>& nSigma, const bool saveRunSubEvt, const bool saveSliceNum );
     /// Function to merge the WeightsTree with a Tree, assuming both have fSaveRunSubEvt and fSaveSliceNum set to true
     void MergeTree( const Tree& inTree );
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
@@ -122,8 +124,7 @@ namespace ana
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
-    int NSigmaLo(const std::string& systToNSigma) const {return fNSigmasLo.at(systToNSigma);}
-    int NSigmaHi(const std::string& systToNSigma) const {return fNSigmasHi.at(systToNSigma);}
+    double GetSigma(const std::string& systToNSigma, unsigned int i_sigma) const {return fNSigmas.at(systToNSigma).at(i_sigma);}
     unsigned int NWeights(const std::string& systToNWts) const {return fNWeightsExpected.at(systToNWts);}
     bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
     bool SaveSliceNum() const {return fSaveSliceNum;}
@@ -133,8 +134,7 @@ namespace ana
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::map< std::string, std::vector<std::vector<double>>> fBranchWeightEntries;
-    std::map< std::string, int> fNSigmasLo;
-    std::map< std::string, int> fNSigmasHi;
+    std::map< std::string, std::vector<double>> fNSigmas;
     std::map< std::string, unsigned int> fNWeightsExpected;
     //std::map< std::string, std::vector<double>> fNWeightsThrows; // stores the expected ordering of NSigmas per knob or universe throws per knob.
     std::string fTreeName;
@@ -154,6 +154,11 @@ namespace ana
     NSigmasTree( const std::string name, const std::vector<std::string>& labels,
                  SpectrumLoaderBase& loader,
                  const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
+                 const SpillCut& spillcut,
+                 const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                 SpectrumLoaderBase& loader,
+                 const std::vector<const ISyst*>& systsToStore, const std::vector<std::vector<double>>& nSigma,
                  const SpillCut& spillcut,
                  const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     /// constructor with a vector of \ref ISyst, but for TrueTree

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -40,10 +40,10 @@ namespace ana
           SpectrumLoaderBase& loader,
           const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut );
     // Add functionality to update the protected stuff from elsewhere
-    void AddEntry( const std::string name, const double val ); // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
-    void UpdateNEntries( const long long val ) { fNEntries+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
-    void UpdatePOT( const double val ) { fPOT+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
-    void UpdateLivetime( const double val ) { fLivetime+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    /// Function to update protected members (the branches). DO NOT USE outside of the filling.
+    void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap );
+    /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
+    void UpdateExposure ( const double pot, const double livetime );
     // Utilities
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -41,7 +41,7 @@ namespace ana
           const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt = false );
     // Add functionality to update the protected stuff from elsewhere
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
-    void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap );
+    virtual void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap );
     /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
     void UpdateExposure ( const double pot, const double livetime );
     // Utilities
@@ -52,7 +52,7 @@ namespace ana
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
-    void SaveTo( TDirectory* dir ) const;
+    virtual void SaveTo( TDirectory* dir ) const;
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::string fTreeName;
@@ -83,7 +83,6 @@ namespace ana
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
-    virtual void SaveToSplines( TDirectory* dir ) const = 0;
     virtual void SaveTo( TDirectory* dir ) const = 0;
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
@@ -108,8 +107,21 @@ namespace ana
                  SpectrumLoaderBase& loader,
                  const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
                  const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
-    void SaveToSplines( TDirectory* dir ) const override;
-    void SaveTo( TDirectory* dir ) const override {SaveToSplines(dir);} // TODO: update this to save a Tree of std::vector<double> instead of splines if desired...
+    void SaveTo( TDirectory* dir ) const override;
+    void SaveToSplines( TDirectory* dir ) const;
+  };
+
+  class NUniversesTree : public WeightsTree
+  {
+  public:
+    /// constructor with a vector of vectors of \ref Var corresponding to a number of universes for which we want to extract weights
+    NUniversesTree( const std::string name, const std::vector<std::string>& labels,
+                    SpectrumLoaderBase& loader,
+                    const std::vector<std::vector<Var>>& univsKnobs, const unsigned int nUniverses,
+                    const SpillCut& spillcut,
+                    const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    void SaveTo( TDirectory* dir ) const override;
+    unsigned int NUniverses() const {return fNSigma;}
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -136,10 +136,14 @@ namespace ana
                  const SpillCut& spillcut,
                  const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     /// constructor with a vector of \ref ISyst, but for TrueTree
+    /// Dedicated for signal efficiency, thus has slightly different behavior
+    /// - Do not take spillcut
+    /// - truthcut: Signal definition is defined here. Only the TrueInteraction (=nu) that satisfies truthcut will be filled
     NSigmasTree( const std::string name, const std::vector<std::string>& labels,
                  SpectrumLoaderBase& loader,
                  const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
-                 const TruthCut& truthcut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false);
+                 const TruthCut& truthcut,
+                 const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false);
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;
@@ -154,6 +158,16 @@ namespace ana
                     const std::vector<std::vector<Var>>& univsKnobs, const std::vector<unsigned int>& nUniverses,
                     const SpillCut& spillcut,
                     const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    /// constructor with a vector of vectors of \ref Var corresponding to a number of universes for which we want to extract weights, for TrueTree
+    /// Dedicated for signal efficiency, thus has slightly different behavior
+    /// - Do not take spillcut
+    /// - truthcut: Signal definition is defined here. Only the TrueInteraction (=nu) that satisfies truthcut will be filled
+    NUniversesTree( const std::string name, const std::vector<std::string>& labels,
+                    SpectrumLoaderBase& loader,
+                    const std::vector<std::vector<TruthVar>>& univsKnobs, const std::vector<unsigned int>& nUniverses,
+                    const TruthCut& truthcut,
+                    const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false);
+
     void SaveTo( TDirectory* dir ) const override;
   };
 

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -54,6 +54,7 @@ namespace ana
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     virtual void SaveTo( TDirectory* dir ) const;
   protected:
+    friend class WeightsTree;
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::string fTreeName;
     std::vector<std::string> fOrderedBranchNames;
@@ -69,7 +70,11 @@ namespace ana
   {
   public:
     WeightsTree( const std::string name, const std::vector<std::string>& labels,
-                 const unsigned int nSigma, const bool saveRunSubEvt, const bool saveSliceNum, const unsigned int nWeightsExpected );
+                 const std::vector<unsigned int>& nWeights, const bool saveRunSubEvt, const bool saveSliceNum );
+    WeightsTree( const std::string name, const std::vector<std::string>& labels,
+                 const std::vector<std::pair<int,int>>& nSigma, const bool saveRunSubEvt, const bool saveSliceNum );
+    /// Function to merge the WeightsTree with a Tree, assuming both have fSaveRunSubEvt and fSaveSliceNum set to true
+    void MergeTree( const Tree& inTree );
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
     void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap, const std::map<std::string, std::vector<double>> weightMap );
     /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
@@ -78,7 +83,9 @@ namespace ana
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
-    int NSigma() const {return fNSigma;} // return as an int, then -NSigma to NSigma means something
+    int NSigmaLo(const std::string& systToNSigma) const {return fNSigmasLo.at(systToNSigma);}
+    int NSigmaHi(const std::string& systToNSigma) const {return fNSigmasHi.at(systToNSigma);}
+    unsigned int NWeights(const std::string& systToNWts) const {return fNWeightsExpected.at(systToNWts);}
     bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
@@ -87,6 +94,10 @@ namespace ana
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::map< std::string, std::vector<std::vector<double>>> fBranchWeightEntries;
+    std::map< std::string, unsigned int> fNSigmasLo;
+    std::map< std::string, unsigned int> fNSigmasHi;
+    std::map< std::string, unsigned int> fNWeightsExpected;
+    //std::map< std::string, std::vector<double>> fNWeightsThrows; // stores the expected ordering of NSigmas per knob or universe throws per knob.
     std::string fTreeName;
     std::vector<std::string> fOrderedBranchNames;
     std::vector<std::string> fOrderedBranchWeightNames;
@@ -95,8 +106,6 @@ namespace ana
     double fLivetime;
     bool fSaveRunSubEvt;
     bool fSaveSliceNum;
-    unsigned int fNSigma;
-    unsigned int fNWeightsExpected;
   };
 
   class NSigmasTree : public WeightsTree
@@ -105,8 +114,9 @@ namespace ana
     /// constructor with a vector of \ref ISyst
     NSigmasTree( const std::string name, const std::vector<std::string>& labels,
                  SpectrumLoaderBase& loader,
-                 const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
-                 const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+                 const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
+                 const SpillCut& spillcut,
+                 const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;
@@ -118,11 +128,10 @@ namespace ana
     /// constructor with a vector of vectors of \ref Var corresponding to a number of universes for which we want to extract weights
     NUniversesTree( const std::string name, const std::vector<std::string>& labels,
                     SpectrumLoaderBase& loader,
-                    const std::vector<std::vector<Var>>& univsKnobs, const unsigned int nUniverses,
+                    const std::vector<std::vector<Var>>& univsKnobs, const std::vector<unsigned int>& nUniverses,
                     const SpillCut& spillcut,
                     const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     void SaveTo( TDirectory* dir ) const override;
-    unsigned int NUniverses() const {return fNSigma;}
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -170,6 +170,11 @@ namespace ana
                  const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
                  const TruthCut& truthcut,
                  const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false);
+    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                 SpectrumLoaderBase& loader,
+                 const std::vector<const ISyst*>& systsToStore, const std::vector<std::vector<double>>& nSigma,
+                 const TruthCut& truthcut,
+                 const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false);
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -39,6 +39,12 @@ namespace ana
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt = false );
+    /// constructor with a vector of \ref TruthVar
+    Tree( const std::string name, const std::vector<std::string>& labels,
+          SpectrumLoaderBase& loader,
+          const std::vector<TruthVar>& vars, const SpillCut& spillcut,
+          const TruthCut& truthcut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
+
     // Add functionality to update the protected stuff from elsewhere
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
     virtual void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap );

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -25,20 +25,20 @@ namespace ana
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<Var>& vars, const SpillCut& spillcut,
-          const Cut& cut, const SystShifts& shift = kNoShift );
+          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
     /// constructor with a vector of \ref MultiVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<MultiVar>& vars, const SpillCut& spillcut,
-          const Cut& cut, const SystShifts& shift = kNoShift );
+          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
     /// constructor with a vector of \ref SpillVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
-          const std::vector<SpillVar>& vars, const SpillCut& spillcut );
+          const std::vector<SpillVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt = false );
     /// constructor with a vector of \ref SpillMultiVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
-          const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut );
+          const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut, const bool saveRunSubEvt = false );
     // Add functionality to update the protected stuff from elsewhere
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
     void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap );
@@ -48,6 +48,7 @@ namespace ana
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
+    bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void SaveTo( TDirectory* dir ) const;
@@ -58,6 +59,7 @@ namespace ana
     long long fNEntries;
     double fPOT;
     double fLivetime;
+    bool fSaveRunSubEvt;
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "sbnana/CAFAna/Core/Var.h"
+#include "sbnana/CAFAna/Core/MultiVar.h"
+#include "sbnana/CAFAna/Core/Cut.h"
+
+#include "sbnana/CAFAna/Core/SpectrumLoaderBase.h"
+#include "sbnana/CAFAna/Core/Utilities.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class TDirectory;
+class TTree;
+class TBranch;
+
+namespace ana
+{
+
+  class Tree
+  {
+  public:
+    /// constructor with a vector of \ref Var
+    Tree( const std::string name, const std::vector<std::string>& labels,
+          SpectrumLoaderBase& loader,
+          const std::vector<Var>& vars, const SpillCut& spillcut,
+          const Cut& cut, const SystShifts& shift = kNoShift );
+    /// constructor with a vector of \ref MultiVar
+    Tree( const std::string name, const std::vector<std::string>& labels,
+          SpectrumLoaderBase& loader,
+          const std::vector<MultiVar>& vars, const SpillCut& spillcut,
+          const Cut& cut, const SystShifts& shift = kNoShift );
+    /// constructor with a vector of \ref SpillVar
+    Tree( const std::string name, const std::vector<std::string>& labels,
+          SpectrumLoaderBase& loader,
+          const std::vector<SpillVar>& vars, const SpillCut& spillcut );
+    /// constructor with a vector of \ref SpillMultiVar
+    Tree( const std::string name, const std::vector<std::string>& labels,
+          SpectrumLoaderBase& loader,
+          const std::vector<SpillMultiVar>& vars, const SpillCut& spillcut );
+    // Add functionality to update the protected stuff from elsewhere
+    void AddEntry( const std::string name, const double val ); // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    void UpdateNEntries( const long long val ) { fNEntries+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    void UpdatePOT( const double val ) { fPOT+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    void UpdateLivetime( const double val ) { fLivetime+=val; } // DO NOT USE. ONLY FOR FILLING, so that it has access to protected members
+    // Utilities
+    double POT() const {return fPOT;} // as in Spectrum
+    double Livetime() const {return fLivetime;} // as in Spectrum
+    long long Entries() const {return fNEntries;}
+    void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    void SaveTo( TDirectory* dir ) const;
+  protected:
+    std::map< std::string, std::vector<double>> fBranchEntries;
+    std::string fTreeName;
+    std::vector<std::string> fOrderedBranchNames;
+    long long fNEntries;
+    double fPOT;
+    double fLivetime;
+  };
+
+}

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -25,12 +25,12 @@ namespace ana
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<Var>& vars, const SpillCut& spillcut,
-          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
+          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     /// constructor with a vector of \ref MultiVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<MultiVar>& vars, const SpillCut& spillcut,
-          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
+          const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     /// constructor with a vector of \ref SpillVar
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
@@ -49,6 +49,7 @@ namespace ana
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
     bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
+    bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void SaveTo( TDirectory* dir ) const;
@@ -60,6 +61,7 @@ namespace ana
     double fPOT;
     double fLivetime;
     bool fSaveRunSubEvt;
+    bool fSaveSliceNum;
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -43,7 +43,10 @@ namespace ana
     Tree( const std::string name, const std::vector<std::string>& labels,
           SpectrumLoaderBase& loader,
           const std::vector<TruthVar>& vars, const SpillCut& spillcut,
-          const TruthCut& truthcut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false );
+          const TruthCut& truthcut,
+          const Cut& SignalSelection,
+          const SystShifts& shift = kNoShift,
+          const bool saveRunSubEvt = false );
 
     // Add functionality to update the protected stuff from elsewhere
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
@@ -58,6 +61,8 @@ namespace ana
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    bool SaveTruthCutType() const {return fSaveTruthCutType;}
+    Cut GetSignalSelectionCut() const {return SignalSelection;}
     virtual void SaveTo( TDirectory* dir ) const;
   protected:
     friend class WeightsTree;
@@ -69,6 +74,8 @@ namespace ana
     double fLivetime;
     bool fSaveRunSubEvt;
     bool fSaveSliceNum;
+    bool fSaveTruthCutType;
+    const Cut SignalSelection;
   };
 
   // Similar to Tree but for event weights e.g. to make splines...

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -51,7 +51,8 @@ namespace ana
           const TruthCut& truthcut,
           const Cut& SignalSelection,
           const SystShifts& shift = kNoShift,
-          const bool saveRunSubEvt = false );
+          const bool saveRunSubEvt = false,
+          const bool saveTruthCutType = true);
 
     // Add functionality to update the protected stuff from elsewhere
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
@@ -81,7 +82,7 @@ namespace ana
     double fLivetime;
     bool fSaveRunSubEvt;
     bool fSaveSliceNum;
-    bool fSaveTruthCutType;
+    bool fSaveTruthCutType{false};
     const Cut SignalSelection;
   };
 

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -66,6 +66,8 @@ namespace ana
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    // Option for Truth-based Tree; Not looping and checking over reco slices to fill CutType
+    void SetSaveTruthCutType(bool _b) {fSaveTruthCutType = _b;}
     bool SaveTruthCutType() const {return fSaveTruthCutType;}
     Cut GetSignalSelectionCut() const {return SignalSelection;}
     virtual void SaveTo( TDirectory* dir ) const;

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -64,16 +64,12 @@ namespace ana
     bool fSaveSliceNum;
   };
 
-  // Similar to Tree but for a vector of ISyst to store weights and make splines...
-  class NSigmasTree
+  // Similar to Tree but for event weights e.g. to make splines...
+  class WeightsTree
   {
   public:
-    /// constructor with a vector of \ref ISyst
-    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
-                 SpectrumLoaderBase& loader,
-                 const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
-                 const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
-    // Add functionality to update the protected stuff from elsewhere
+    WeightsTree( const std::string name, const std::vector<std::string>& labels,
+                 const unsigned int nSigma, const bool saveRunSubEvt, const bool saveSliceNum, const unsigned int nWeightsExpected );
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
     void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap, const std::map<std::string, std::vector<double>> weightMap );
     /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
@@ -82,14 +78,13 @@ namespace ana
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
-    int NSigma() const {return fNSigma;}
+    int NSigma() const {return fNSigma;} // return as an int, then -NSigma to NSigma means something
     bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
     bool SaveSliceNum() const {return fSaveSliceNum;}
     void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
     void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
-    void SaveToSplines( TDirectory* dir ) const;
-    void SaveTo( TDirectory* dir ) const {SaveToSplines(dir);} // TODO: update this to save a Tree of std::vector<double> instead of splines if desired...
-
+    virtual void SaveToSplines( TDirectory* dir ) const = 0;
+    virtual void SaveTo( TDirectory* dir ) const = 0;
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::map< std::string, std::vector<std::vector<double>>> fBranchWeightEntries;
@@ -102,6 +97,19 @@ namespace ana
     bool fSaveRunSubEvt;
     bool fSaveSliceNum;
     unsigned int fNSigma;
+    unsigned int fNWeightsExpected;
+  };
+
+  class NSigmasTree : public WeightsTree
+  {
+  public:
+    /// constructor with a vector of \ref ISyst
+    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                 SpectrumLoaderBase& loader,
+                 const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
+                 const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    void SaveToSplines( TDirectory* dir ) const override;
+    void SaveTo( TDirectory* dir ) const override {SaveToSplines(dir);} // TODO: update this to save a Tree of std::vector<double> instead of splines if desired...
   };
 
 }

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -64,4 +64,44 @@ namespace ana
     bool fSaveSliceNum;
   };
 
+  // Similar to Tree but for a vector of ISyst to store weights and make splines...
+  class NSigmasTree
+  {
+  public:
+    /// constructor with a vector of \ref ISyst
+    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                 SpectrumLoaderBase& loader,
+                 const std::vector<const ISyst*>& systsToStore, const SpillCut& spillcut,
+                 const Cut& cut, const SystShifts& shift = kNoShift, const unsigned int nSigma = 3, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    // Add functionality to update the protected stuff from elsewhere
+    /// Function to update protected members (the branches). DO NOT USE outside of the filling.
+    void UpdateEntries ( const std::map<std::string, std::vector<double>> valsMap, const std::map<std::string, std::vector<double>> weightMap );
+    /// Function to update protected members (the exposures). DO NOT USE outside of the filling.
+    void UpdateExposure ( const double pot, const double livetime );
+    // Utilities
+    double POT() const {return fPOT;} // as in Spectrum
+    double Livetime() const {return fLivetime;} // as in Spectrum
+    long long Entries() const {return fNEntries;}
+    int NSigma() const {return fNSigma;}
+    bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
+    bool SaveSliceNum() const {return fSaveSliceNum;}
+    void OverridePOT(double newpot) {fPOT = newpot;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    void OverrideLivetime(double newlive) {fLivetime = newlive;} // as in Spectrum: DO NOT USE UNLESS CERTAIN THERE ISN'T A BETTER WAY!
+    void SaveToSplines( TDirectory* dir ) const;
+    void SaveTo( TDirectory* dir ) const {SaveToSplines(dir);} // TODO: update this to save a Tree of std::vector<double> instead of splines if desired...
+
+  protected:
+    std::map< std::string, std::vector<double>> fBranchEntries;
+    std::map< std::string, std::vector<std::vector<double>>> fBranchWeightEntries;
+    std::string fTreeName;
+    std::vector<std::string> fOrderedBranchNames;
+    std::vector<std::string> fOrderedBranchWeightNames;
+    long long fNEntries;
+    double fPOT;
+    double fLivetime;
+    bool fSaveRunSubEvt;
+    bool fSaveSliceNum;
+    unsigned int fNSigma;
+  };
+
 }

--- a/sbnana/CAFAna/Core/Var.cxx
+++ b/sbnana/CAFAna/Core/Var.cxx
@@ -260,6 +260,13 @@ namespace ana
     }
   }
 
+  //----------------------------------------------------------------------
+  template<class T> bool
+  operator<(const _Var<T>& a, const _Var<T>& b)
+  {
+    return a.ID() < b.ID();
+  }
+
   // explicitly instantiate the templates for the types we know we have
   template class _Var<caf::SRSpillProxy>;
   template class _Var<caf::SRSliceProxy>;

--- a/sbnana/CAFAna/Core/Var.cxx
+++ b/sbnana/CAFAna/Core/Var.cxx
@@ -124,9 +124,11 @@ namespace ana
   // explicitly instantiate the template for the types we know we have
   template Var Var2D(const Var&, const Binning&, const Var&, const Binning&);
   template SpillVar Var2D(const SpillVar&, const Binning&, const SpillVar&, const Binning&);
+  template TruthVar Var2D(const TruthVar&, const Binning&, const TruthVar&, const Binning&);
 
   template Var Var2D(const Var&, int, double, double, const Var&, int, double, double);
   template SpillVar Var2D(const SpillVar&, int, double, double, const SpillVar&, int, double, double);
+  template TruthVar Var2D(const TruthVar&, int, double, double, const TruthVar&, int, double, double);
 
   //----------------------------------------------------------------------
   template<class T> _Var<T>
@@ -151,9 +153,11 @@ namespace ana
   // explicitly instantiate the template for the types we know we have
   template Var Var3D(const Var&, const Binning&, const Var&, const Binning&, const Var&, const Binning&);
   template SpillVar Var3D(const SpillVar&, const Binning&, const SpillVar&, const Binning&, const SpillVar&, const Binning&);
+  template TruthVar Var3D(const TruthVar&, const Binning&, const TruthVar&, const Binning&, const TruthVar&, const Binning&);
 
   template Var Var3D(const Var&, int, double, double, const Var&, int, double, double, const Var&, int, double, double);
   template SpillVar Var3D(const SpillVar&, int, double, double, const SpillVar&, int, double, double, const SpillVar&, int, double, double);
+  template TruthVar Var3D(const TruthVar&, int, double, double, const TruthVar&, int, double, double, const TruthVar&, int, double, double);
 
   //----------------------------------------------------------------------
   Var Scaled(const Var& v, double s)
@@ -263,6 +267,7 @@ namespace ana
   // explicitly instantiate the templates for the types we know we have
   template class _Var<caf::SRSpillProxy>;
   template class _Var<caf::SRSliceProxy>;
+  template class _Var<caf::SRTrueInteractionProxy>;
 
   template<class T> int _Var<T>::fgNextID = 0;
 
@@ -274,4 +279,8 @@ namespace ana
   template SpillVar operator/(const SpillVar&, const SpillVar&);
   template SpillVar operator+(const SpillVar&, const SpillVar&);
   template SpillVar operator-(const SpillVar&, const SpillVar&);
+  template TruthVar operator*(const TruthVar&, const TruthVar&);
+  template TruthVar operator/(const TruthVar&, const TruthVar&);
+  template TruthVar operator+(const TruthVar&, const TruthVar&);
+  template TruthVar operator-(const TruthVar&, const TruthVar&);
 }

--- a/sbnana/CAFAna/Core/Var.h
+++ b/sbnana/CAFAna/Core/Var.h
@@ -25,6 +25,7 @@ namespace ana
   template<class T> _Var<T> operator/(const _Var<T>& a, const _Var<T>& b);
   template<class T> _Var<T> operator+(const _Var<T>& a, const _Var<T>& b);
   template<class T> _Var<T> operator-(const _Var<T>& a, const _Var<T>& b);
+  template<class T> bool operator<(const _Var<T>& a, const _Var<T>& b); // for map-making
 
   /// Template for Var and SpillVar
   template<class T> class _Var

--- a/sbnana/CAFAna/Core/Var.h
+++ b/sbnana/CAFAna/Core/Var.h
@@ -27,7 +27,7 @@ namespace ana
   template<class T> _Var<T> operator-(const _Var<T>& a, const _Var<T>& b);
   template<class T> bool operator<(const _Var<T>& a, const _Var<T>& b); // for map-making
 
-  /// Template for Var and SpillVar
+  /// Template for Var, SpillVar, and TruthVar
   template<class T> class _Var
   {
   public:

--- a/sbnana/CAFAna/Core/Var.h
+++ b/sbnana/CAFAna/Core/Var.h
@@ -11,7 +11,7 @@
 
 #include "sbnanaobj/StandardRecord/Proxy/FwdDeclare.h"
 
-namespace caf{class SRSpill; class SRSpillTruthBranch; class SRSlice;}
+namespace caf{class SRSpill; class SRTrueInteraction; class SRSlice;}
 
 namespace ana
 {
@@ -75,6 +75,9 @@ namespace ana
   /// \brief Equivalent of \ref Var acting on \ref caf::SRSpill
   typedef _Var<caf::SRSpillProxy> SpillVar;
 
+  /// \brief Equivalent of \ref Var acting on \ref caf::SRTrueInteraction
+  typedef _Var<caf::SRTrueInteractionProxy> TruthVar;
+
   /// \brief For Vars where literally all you need is a single CAF variable
   ///
   /// eg Var myVar = SIMPLEVAR(my.var.str);
@@ -83,10 +86,14 @@ namespace ana
 
 #define SIMPLESPILLVAR(CAFNAME) SpillVar([](const caf::SRSpillProxy* sr) -> double {return sr->CAFNAME;})
 
+#define SIMPLETRUTHVAR(CAFNAME) TruthVar([](const caf::SRTrueInteractionProxy* sr) -> double {return sr->CAFNAME;})
+
   /// The simplest possible Var, always 1. Used as a default weight.
   const Var kUnweighted([](const caf::SRSliceProxy*){return 1;});
 
   const SpillVar kSpillUnweighted([](const caf::SRSpillProxy*){return 1;});
+
+  const TruthVar kTruthUnweighted([](const caf::SRTrueInteractionProxy*){return 1;});
 
   /// \brief Variable formed from two input variables
   ///
@@ -115,10 +122,6 @@ namespace ana
   Var3D(const _Var<T>& a, int na, double a0, double a1,
         const _Var<T>& b, int nb, double b0, double b1,
         const _Var<T>& c, int nc, double c0, double c1);
-
-  // TODO - remove once no more legacy callers exist
-  #define SpillTruthVar2D Var2D
-  #define SpillTruthVar3D Var3D
 
   /// Use to rescale another variable.
   Var Scaled(const Var& v, double s);

--- a/sbnana/CAFAna/Systs/BoosterFluxSysts.cxx
+++ b/sbnana/CAFAna/Systs/BoosterFluxSysts.cxx
@@ -20,8 +20,14 @@ BoosterFluxHadronSyst::~BoosterFluxHadronSyst()
 //----------------------------------------------------------------------
 void BoosterFluxHadronSyst::Shift(double sigma, caf::SRSliceProxy* slc, double &weight) const
 {
+  return this->Shift(sigma, &slc->truth, weight);
+}
+
+//----------------------------------------------------------------------
+void BoosterFluxHadronSyst::Shift(double sigma, caf::SRTrueInteractionProxy* nu, double &weight) const
+{
   // Only implemented for numus so far
-  if(/*sr->mc.nnu == 0 ||*/ slc->truth.initpdg != 14) return;
+  if(nu->initpdg != 14) return;
 
   if(!fScale[0]){
     TFile f((FindCAFAnaDir() + "/Systs/booster_flux_shifts.root").c_str());
@@ -44,7 +50,7 @@ void BoosterFluxHadronSyst::Shift(double sigma, caf::SRSliceProxy* slc, double &
 
   // TODO use the regular detector flag as soon as it's filled reliably
   int det;
-  const double L = slc->truth.baseline;
+  const double L = nu->baseline;
   if(L < 150) det = 0;
   else if(L < 500) det = 1;
   else det = 2;
@@ -52,7 +58,7 @@ void BoosterFluxHadronSyst::Shift(double sigma, caf::SRSliceProxy* slc, double &
   TH1* h = fScale[det];
   assert(h);
 
-  const int bin = h->FindBin(slc->truth.E);
+  const int bin = h->FindBin(nu->E);
 
   if(bin == 0 || bin == h->GetNbinsX()+1) return;
 

--- a/sbnana/CAFAna/Systs/BoosterFluxSysts.h
+++ b/sbnana/CAFAna/Systs/BoosterFluxSysts.h
@@ -14,6 +14,7 @@ public:
   virtual ~BoosterFluxHadronSyst();
 
   void Shift(double sigma, caf::SRSliceProxy* slc, double& weight) const override;
+  void Shift(double sigma, caf::SRTrueInteractionProxy* nu, double& weight) const override;
 
 protected:
   friend const BoosterFluxHadronSyst* GetBoosterFluxHadronSyst(unsigned int);

--- a/sbnana/CAFAna/Systs/CalorimetrySysts.cxx
+++ b/sbnana/CAFAna/Systs/CalorimetrySysts.cxx
@@ -39,6 +39,10 @@ namespace ana {
 
   }
 
+  void CalorimetrySyst::Shift(double sigma, caf::SRTrueInteractionProxy *sr, double& weight) const {
+
+  }
+
   const CalorimetrySyst CalorimetrySyst_BetaUp(ana::CaloSyst::kNominal, ana::CaloSyst::kNominal, ana::CaloSyst::kUp, "CalorimetrySyst_BetaUp", "#beta +4%");
   const CalorimetrySyst CalorimetrySyst_BetaDown(ana::CaloSyst::kNominal, ana::CaloSyst::kNominal, ana::CaloSyst::kDown, "CalorimetrySyst_BetaDown", "#beta -4%");
 

--- a/sbnana/CAFAna/Systs/CalorimetrySysts.cxx
+++ b/sbnana/CAFAna/Systs/CalorimetrySysts.cxx
@@ -199,6 +199,10 @@ namespace ana {
 
   }
 
+  void CalorimetrySyst::Shift(double sigma, caf::SRTrueInteractionProxy *sr, double& weight) const {
+
+  }
+
   const CalorimetrySyst kCaloSyst("CaloSyst", "Calorimetry systematics");
 
 

--- a/sbnana/CAFAna/Systs/CalorimetrySysts.h
+++ b/sbnana/CAFAna/Systs/CalorimetrySysts.h
@@ -22,6 +22,7 @@ namespace ana
     CalorimetrySyst(CaloSyst _GainSyst, CaloSyst _AlphaSyst, CaloSyst _BetaSyst, const std::string& name, const std::string& latexName);
 
     void Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const override;
+    void Shift(double sigma, caf::SRTrueInteractionProxy *sr, double& weight) const override;
 
     // Update detector parameters
     inline void UpdateTemperature(double t){ temperature = t; }

--- a/sbnana/CAFAna/Systs/CalorimetrySysts.h
+++ b/sbnana/CAFAna/Systs/CalorimetrySysts.h
@@ -27,6 +27,7 @@ namespace ana
     Chi2Results CalculateChi2(const caf::Proxy<caf::SRTrackCalo>& calo) const;
 
     void Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const override;
+    void Shift(double sigma, caf::SRTrueInteractionProxy *sr, double& weight) const override;
 
   private:
 

--- a/sbnana/CAFAna/Systs/EnergySysts.cxx
+++ b/sbnana/CAFAna/Systs/EnergySysts.cxx
@@ -61,6 +61,10 @@ namespace ana {
    
   }
 
+  void EnergyScaleSyst::Shift(double sigma, caf::SRTrueInteractionProxy *nu, double& weight) const
+  {
+  }
+
   void RecoEnergyScaleSyst::Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const
   {
     //auto& det = sr->truth.det;
@@ -132,6 +136,9 @@ namespace ana {
           trk.mcsP.fwdP_pion *= (1+scaleMCSPi);
       }
     }
+  }
+  void RecoEnergyScaleSyst::Shift(double sigma, caf::SRTrueInteractionProxy *nu, double& weight) const
+  {
   }
 
    const EnergyScaleSyst kEnergyScaleMuon(EnergyScaleSystTerm::kConstant, EnergyScaleSystParticle::kMuon, EnergyScaleSystDetector::kAll, 0.02, "EnergyScaleMuon", "Correlated linear E_{#mu} scale");

--- a/sbnana/CAFAna/Systs/EnergySysts.h
+++ b/sbnana/CAFAna/Systs/EnergySysts.h
@@ -37,6 +37,7 @@ namespace ana
       ISyst(name, latexName), term(_term), part(_part), detector(_detector), uncertainty(_uncertainty) {}
 
     void Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const override;
+    void Shift(double sigma, caf::SRTrueInteractionProxy *sr, double& weight) const override;
 
   private:
     EnergyScaleSystTerm term;
@@ -52,6 +53,7 @@ namespace ana
       ISyst(name, latexName), term(_term), part(_part), detector(_detector), uncertainty(_uncertainty) {}
 
     void Shift(double sigma, caf::SRSliceProxy *sr, double& weight) const override;
+    void Shift(double sigma, caf::SRTrueInteractionProxy *sr, double& weight) const override;
 
   private:
     EnergyScaleSystTerm term;

--- a/sbnana/CAFAna/Systs/NuMIFluxSysts.cxx
+++ b/sbnana/CAFAna/Systs/NuMIFluxSysts.cxx
@@ -26,11 +26,17 @@ namespace ana
   //----------------------------------------------------------------------
   void NuMIFluxSyst::Shift(double sigma, caf::SRSliceProxy* slc, double& weight) const
   {
-    if(slc->truth.index < 0) return; // No neutrino
+    return this->Shift(sigma, &slc->truth, weight);
+  }
+
+  //----------------------------------------------------------------------
+  void NuMIFluxSyst::Shift(double sigma, caf::SRTrueInteractionProxy* nu, double& weight) const
+  {
+    if(nu->index < 0) return; // No neutrino
 
     // TODO switch to regular detector flag as soon as it's filled reliably
-    if(slc->truth.baseline < 500){
-      std::cout << "Using NuMIFluxSyst on what appears not to be an icarus file (baseline = " << slc->truth.baseline << ")!" << std::endl;
+    if(nu->baseline < 500){
+      std::cout << "Using NuMIFluxSyst on what appears not to be an icarus file (baseline = " << nu->baseline << ")!" << std::endl;
       abort();
     }
 
@@ -70,17 +76,17 @@ namespace ana
       }
     } // end if
 
-    const int flav = abs(slc->truth.initpdg);
+    const int flav = abs(nu->initpdg);
     if(flav != 12 && flav != 14) return;
 
     const int hcIdx = 0; // TODO TODO always FHC
     const int flavIdx = (flav == 12) ? 0 : 1;
-    const int signIdx = (slc->truth.initpdg > 0) ? 0 : 1;
+    const int signIdx = (nu->initpdg > 0) ? 0 : 1;
 
     TH1* h = fScale[hcIdx][flavIdx][signIdx];
     assert(h);
 
-    const int bin = h->FindBin(slc->truth.E);
+    const int bin = h->FindBin(nu->E);
 
     if(bin == 0 || bin == h->GetNbinsX()+1) return;
 

--- a/sbnana/CAFAna/Systs/NuMIFluxSysts.h
+++ b/sbnana/CAFAna/Systs/NuMIFluxSysts.h
@@ -15,6 +15,7 @@ namespace ana
     virtual ~NuMIFluxSyst();
 
     void Shift(double sigma, caf::SRSliceProxy* slc, double& weight) const override;
+    void Shift(double sigma, caf::SRTrueInteractionProxy* nu, double& weight) const override;
 
   protected:
     friend const NuMIFluxSyst* GetNuMIFluxSyst(const std::string&,

--- a/sbnana/CAFAna/Systs/SBNOnOffSysts.cxx
+++ b/sbnana/CAFAna/Systs/SBNOnOffSysts.cxx
@@ -21,11 +21,17 @@ namespace ana
   // --------------------------------------------------------------------------
   void SBNOnOffSyst::Shift(double x, caf::SRSliceProxy* sr, double& weight) const
   {
-    if(sr->truth.index < 0) return;
+    this->Shift(x, &sr->truth, weight);
+  }
+
+  // --------------------------------------------------------------------------
+  void SBNOnOffSyst::Shift(double x, caf::SRTrueInteractionProxy* nu, double& weight) const
+  {
+    if(nu->index < 0) return;
 
     if(fIdx == -1) fIdx = UniverseOracle::Instance().SystIndex(ShortName());
 
-    const caf::Proxy<std::vector<caf::SRMultiverse>>& wgts = sr->truth.wgt;
+    const caf::Proxy<std::vector<caf::SRMultiverse>>& wgts = nu->wgt;
     if(wgts.empty()) return;
 
     const UniverseOracle& uo = UniverseOracle::Instance();

--- a/sbnana/CAFAna/Systs/SBNOnOffSysts.h
+++ b/sbnana/CAFAna/Systs/SBNOnOffSysts.h
@@ -17,6 +17,7 @@ namespace ana
     SBNOnOffSyst(const std::string& systName);
 
     void Shift(double x, caf::SRSliceProxy* sr, double& weight) const override;
+    void Shift(double x, caf::SRTrueInteractionProxy* nu, double& weight) const override;
 
   protected:
     mutable int fIdx;

--- a/sbnana/CAFAna/Systs/SBNWeightSysts.cxx
+++ b/sbnana/CAFAna/Systs/SBNWeightSysts.cxx
@@ -22,25 +22,7 @@ namespace ana
   {
     if(sr->truth.index < 0) return 1;
 
-    if(fPSetIdx == -1){
-      const UniverseOracle& uo = UniverseOracle::Instance();
-      fPSetIdx = uo.ParameterSetIndex(fPSetName);
-    }
-
-    const caf::Proxy<std::vector<caf::SRMultiverse>>& wgts = sr->truth.wgt;
-    if(wgts.empty()) return 1;
-
-    const int Nwgts = wgts[fPSetIdx].univ.size();
-
-    static bool once = true;
-    if(!once && fUnivIdx >= Nwgts){
-      once = false;
-      std::cout << "UniverseWeight: WARNING requesting universe " << fUnivIdx << " in parameter set " << fPSetName << " which only has size " << Nwgts << ". Will wrap-around and suppress future warnings." << std::endl;
-    }
-
-    const unsigned int unividx = fUnivIdx % Nwgts;
-
-    return wgts[fPSetIdx].univ[unividx];
+    return operator()(&(sr->truth));
   }
 
   // --------------------------------------------------------------------------

--- a/sbnana/CAFAna/Systs/SBNWeightSysts.h
+++ b/sbnana/CAFAna/Systs/SBNWeightSysts.h
@@ -17,6 +17,7 @@ namespace ana
     UniverseWeight(const std::string& psetName, int univIdx);
 
     double operator()(const caf::SRSliceProxy* sr) const;
+    double operator()(const caf::SRTrueInteractionProxy* nu) const;
 
   protected:
     std::string fPSetName;
@@ -29,6 +30,11 @@ namespace ana
     return Var(UniverseWeight(psetName, univIdx));
   }
 
+  TruthVar GetTruthUniverseWeight(const std::string& psetName, int univIdx)
+  {
+    return TruthVar(UniverseWeight(psetName, univIdx));
+  }
+
 
   class SBNWeightSyst: public ISyst
   {
@@ -36,6 +42,7 @@ namespace ana
     SBNWeightSyst(const std::string& systName);
 
     void Shift(double x, caf::SRSliceProxy* sr, double& weight) const override;
+    void Shift(double x, caf::SRTrueInteractionProxy* sr, double& weight) const override;
 
   protected:
     mutable int fIdx;

--- a/sbnana/CAFAna/Systs/SBNWeightSysts.h
+++ b/sbnana/CAFAna/Systs/SBNWeightSysts.h
@@ -42,7 +42,7 @@ namespace ana
     SBNWeightSyst(const std::string& systName);
 
     void Shift(double x, caf::SRSliceProxy* sr, double& weight) const override;
-    void Shift(double x, caf::SRTrueInteractionProxy* sr, double& weight) const override;
+    void Shift(double x, caf::SRTrueInteractionProxy* nu, double& weight) const override;
 
   protected:
     mutable int fIdx;

--- a/sbnana/CAFAna/Systs/Systs.h
+++ b/sbnana/CAFAna/Systs/Systs.h
@@ -13,8 +13,12 @@ class MECSyst: public ISyst
   MECSyst() : ISyst("mec", "100% MEC Systematic") {}
   void Shift(double sigma, caf::SRSliceProxy* sr, double& weight) const override
   {
+    return this->Shift(sigma, &sr->truth, weight);
+  }
+  void Shift(double sigma, caf::SRTrueInteractionProxy* nu, double& weight) const override
+  {
     if(sigma < -1) sigma = -1;
-    if(sr->truth.genie_mode == 10) weight *= 1 + sigma;
+    if(nu->genie_mode == 10) weight *= 1 + sigma;
   }
 };
 
@@ -25,6 +29,10 @@ class POTSyst: public ISyst
   public:
   POTSyst() : ISyst("potsyst", "2% Systematic on POT") {}
   void Shift(double sigma, caf::SRSliceProxy* sr, double& weight) const override
+  {
+    return this->Shift(sigma, &sr->truth, weight);
+  }
+  void Shift(double sigma, caf::SRTrueInteractionProxy* nu, double& weight) const override
   {
     weight *= (1.0 + 0.02 * sigma);
   }

--- a/sbnana/CAFAna/Systs/Systs.h
+++ b/sbnana/CAFAna/Systs/Systs.h
@@ -46,6 +46,10 @@ class NormSyst: public ISyst
   NormSyst() : ISyst("normsyst", "10% Normalization Systematic") {}
   void Shift(double sigma, caf::SRSliceProxy* sr, double& weight) const override
   {
+    return this->Shift(sigma, &sr->truth, weight);
+  }
+  void Shift(double sigma, caf::SRTrueInteractionProxy* sr, double& weight) const override
+  {
     weight *= (1.0 + 0.1 * sigma);
   }
 };

--- a/sbnana/CAFAna/Systs/UniverseOracle.cxx
+++ b/sbnana/CAFAna/Systs/UniverseOracle.cxx
@@ -89,9 +89,9 @@ namespace ana
       if(pset.map.size() != 1) continue;
 
       // Save which position in the vector this was
-      fSystIdxs[pset.map[0].param.name] = i;
+      fSystIdxs[pset.name] = i;
       // Save all the knob values
-      fShiftVals[pset.map[0].param.name] = pset.map[0].vals;
+      fShiftVals[pset.name] = pset.map[0].vals;
     }
   }
 

--- a/sbnana/CAFAna/test/test_TruthVar.C
+++ b/sbnana/CAFAna/test/test_TruthVar.C
@@ -6,9 +6,6 @@
 #include "sbnana/CAFAna/Core/Var.h"
 #include "sbnana/SBNAna/Cuts/Cuts.h"
 
-#include "sbnana/SBNAna/Cuts/NuMIXSecCuts.h"
-#include "sbnana/SBNAna/Cuts/NuMIXSecTrueEventVars.h"
-
 #include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
 
 #include "TCanvas.h"

--- a/sbnana/CAFAna/test/test_TruthVar.C
+++ b/sbnana/CAFAna/test/test_TruthVar.C
@@ -1,0 +1,70 @@
+#include "sbnana/CAFAna/Core/Binning.h"
+#include "sbnana/CAFAna/Core/SpectrumLoader.h"
+#include "sbnana/CAFAna/Core/Spectrum.h"
+#include "sbnana/CAFAna/Core/EnsembleSpectrum.h"
+#include "sbnana/CAFAna/Systs/SBNWeightSysts.h"
+#include "sbnana/CAFAna/Core/Var.h"
+#include "sbnana/SBNAna/Cuts/Cuts.h"
+
+#include "sbnana/SBNAna/Cuts/NuMIXSecCuts.h"
+#include "sbnana/SBNAna/Cuts/NuMIXSecTrueEventVars.h"
+
+#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
+
+#include "TCanvas.h"
+#include "TFile.h"
+#include "TH1.h"
+#include "TPad.h"
+#include "TLatex.h"
+#include "TLegend.h"
+#include "TSystem.h"
+#include "TGraph.h"
+#include "TGraphAsymmErrors.h"
+
+using namespace ana;
+
+const TruthVar kTruthVar_NuE = SIMPLETRUTHVAR(E);
+
+void test_TruthVar(){
+
+  // Input
+  SpectrumLoader loader("/pnfs/icarus/scratch/users/jskim/mc/NuMI_MC_Nu_Phase2/flatcaf/v09_72_00_03p01/230804_GENIESystSGV2_FixFSI/merged/flatcaf_0.root");
+
+  // output; where plots are saved
+  TString outputPath = "./test_TruthVar/";
+  gSystem->mkdir(outputPath, kTRUE);
+
+  // Binning
+  const Binning binsEnergy = Binning::Simple(30, 0, 6);
+
+  // All nu
+  Spectrum *sTruthVar_NuE = new Spectrum("TruthVar_NuE", binsEnergy, loader, kTruthVar_NuE, kNoTruthCut, kNoSpillCut);
+
+  // EnsembleSpectrum
+  std::vector<TruthVar> vec_truthweights;
+  for(int u=0; u<100; u++){
+    std::string psetname = "GENIEReWeight_ICARUS_v2_multisim_ZExpAVariationResponse";
+    vec_truthweights.push_back( GetTruthUniverseWeight(psetname, u) );
+  }
+
+  EnsembleSpectrum *es_TruthVar_Signal_NuE = new EnsembleSpectrum("ES_TruthVar_Signal_NuE", binsEnergy, loader, kTruthVar_NuE, kNoTruthCut, kNoSpillCut, vec_truthweights);
+
+  loader.Go();
+
+  TFile *f_out = new TFile(outputPath+"/output.root", "RECREATE");
+  f_out->cd();
+
+  TH1* h_TruthVar_NuE = sTruthVar_NuE->ToTH1(3e20);
+  h_TruthVar_NuE->SetName("h_TruthVar_NuE");
+  h_TruthVar_NuE->Write();
+
+  TH1* h_TruthVar_NuE_FromES_Nominal = es_TruthVar_Signal_NuE->Nominal().ToTH1(3e20);
+  h_TruthVar_NuE_FromES_Nominal->SetName("h_TruthVar_NuE_FromES_Nominal");
+  h_TruthVar_NuE_FromES_Nominal->Write();
+  TGraphAsymmErrors* gr_Error_FromES = es_TruthVar_Signal_NuE->ErrorBand(3e20);
+  gr_Error_FromES->Write();
+  f_out->Close();
+
+
+
+}

--- a/sbnana/SBNAna/Vars/NuMIFlux.cxx
+++ b/sbnana/SBNAna/Vars/NuMIFlux.cxx
@@ -73,7 +73,13 @@ namespace ana {
   //// ----------------------------------------------
 
   const Var kGetNuMIFluxWeight([](const caf::SRSliceProxy* slc) -> double {
-    if (slc->truth.index < 0 || abs(slc->truth.initpdg) == 16) return 1.0;
+    return kGetTruthNuMIFluxWeight(&slc->truth);
+  });
+
+  //// ----------------------------------------------
+
+  const TruthVar kGetTruthNuMIFluxWeight([](const caf::SRTrueInteractionProxy* nu) -> double {
+    if (nu->index < 0 || abs(nu->initpdg) == 16) return 1.0;
 
     if (!FluxWeightNuMI.fWeight[0][0][0]) {
       std::cout << "Trying to access un-available weight array..." << std::endl;
@@ -81,19 +87,17 @@ namespace ana {
     }
 
     unsigned int hcIdx = 0; // assume always FHC for now...
-    unsigned int flavIdx = (abs(slc->truth.initpdg) == 12) ? 0 : 1;
-    unsigned int signIdx = (slc->truth.initpdg > 0) ? 0 : 1;
+    unsigned int flavIdx = (abs(nu->initpdg) == 12) ? 0 : 1;
+    unsigned int signIdx = (nu->initpdg > 0) ? 0 : 1;
 
     TH1* h = FluxWeightNuMI.fWeight[hcIdx][flavIdx][signIdx];
     assert(h);
 
-    const int bin = h->FindBin(slc->truth.E);
+    const int bin = h->FindBin(nu->E);
 
     if (bin == 0 || bin == h->GetNbinsX() + 1) return 1.0;
     if (std::isinf(h->GetBinContent(bin)) || std::isnan(h->GetBinContent(bin))) return 1.0;
     return h->GetBinContent(bin);
   });
-
-  //// ----------------------------------------------
 
 }

--- a/sbnana/SBNAna/Vars/NuMIFlux.h
+++ b/sbnana/SBNAna/Vars/NuMIFlux.h
@@ -26,5 +26,6 @@ namespace ana
   // set up to use the flux weight
   static const NuMIPpfxFluxWeight FluxWeightNuMI;
   extern const Var kGetNuMIFluxWeight;
+  extern const TruthVar kGetTruthNuMIFluxWeight;
 
 }

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -254,7 +254,7 @@ libdir	fq_dir		lib
 product		version		qual	flags		<table_format=2>
 ifdhc		v2_8_0		-
 osclib		v00.26		-
-sbnanaobj	v10_00_04	-
+sbnanaobj	v10_00_05	-
 sbndata		v01_07		-
 cetmodules	v3_24_01	-	only_for_build
 cetlib          v3_18_02


### PR DESCRIPTION
Adding `TruthVar` which corresponds to `Var` but per `SRTrueInteratcion` not `SRSlice`.  The usage was described in [doc-35174](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=35174).
* When defining an ISyst, both Shift(Slice) and Shift(TrueInteraction) must be defined. If a shift is truth-based, it is recommended to define the behavior at Shift(TrueInteraction), and call this function inside Shift(Slice). example: https://github.com/SBNSoftware/sbnana/blob/f92120a0b7d2d407f9d95255dbe206e1b05e8942/sbnana/SBNAna/Vars/NuMIFlux.cxx#L75-L101
* Also include an update in n-sigma treatment from NSigmasTrees; adding a new constructor that takes a vector of sigmas. 