### PR TITLE
Add On/Off Systematics and save sigma values for NSigmaTree

### DIFF
--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -488,7 +488,8 @@ namespace ana
               std::map<std::string, std::vector<double>> headerVals;
               std::map<std::string, std::vector<double>> recordVals;
               for ( auto& [syst, systname] : treemapIt->second ) {
-                for ( int sigma=treemapIt->first->NSigmaLo(systname); sigma<=treemapIt->first->NSigmaHi(systname); ++sigma ) {
+                for ( unsigned int i_sigma=0; i_sigma<treemapIt->first->NWeights(systname); ++i_sigma){
+                  double sigma = treemapIt->first->GetSigma(systname, i_sigma);
 
                   // Need to provide a clean slate for each new set of systematic
                   // shifts to work from. Copying the whole StandardRecord is pretty

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -1338,11 +1338,9 @@ namespace ana
       // Save the weights
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
-        const double lo = fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
-        const double hi = fNSigmasHi.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
+        knob_vals[ fOrderedBranchWeightNames.at(idxBranchWeight) ] = fNSigmas.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         for ( unsigned int idxWt = 0; idxWt < (unsigned int)NSigmas; ++idxWt ) {
           weights[ fOrderedBranchWeightNames.at(idxBranchWeight) ].push_back(fBranchWeightEntries.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at(idxEntry).at(idxWt));
-          knob_vals[ fOrderedBranchWeightNames.at(idxBranchWeight) ].push_back(lo + (hi-lo)*(double)idxWt/(NSigmas-1));
         }
       }
 

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -701,7 +701,7 @@ namespace ana
       fNWeightsExpected[labels.at(i)] = (unsigned int)((nSigma.at(i).second-nSigma.at(i).first) + 1);
       fNSigmas[labels.at(i)] = {};
       for( unsigned int i_sigma=0; i_sigma<fNWeightsExpected[labels.at(i)]; ++i_sigma){
-        fNSigmas[labels.at(i)].push_back( nSigma.at(i).first + i_sigma );
+        fNSigmas[labels.at(i)].push_back( (float)nSigma.at(i).first + (float)i_sigma );
       }
 
     }

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -1256,14 +1256,17 @@ namespace ana
     }
 
     std::map< std::string, std::vector<double> > weights;
+    std::map< std::string, std::vector<double> > knob_vals;
 
     // set up map
     for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
       weights[ fOrderedBranchWeightNames.at(idxBranchWeight) ] = {};
+      knob_vals[ fOrderedBranchWeightNames.at(idxBranchWeight) ] = {};
     }
     // set up branches
     for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
       theTree.Branch( fOrderedBranchWeightNames.at(idxBranchWeight).c_str(), &weights[fOrderedBranchWeightNames.at(idxBranchWeight)] );
+      theTree.Branch( (fOrderedBranchWeightNames.at(idxBranchWeight)+"_sigma").c_str(), &knob_vals[fOrderedBranchWeightNames.at(idxBranchWeight)] );
     }
 
     // Loop over entries
@@ -1280,8 +1283,11 @@ namespace ana
       // Save the weights
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
+        const double lo = fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
+        const double hi = fNSigmasHi.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         for ( unsigned int idxWt = 0; idxWt < (unsigned int)NSigmas; ++idxWt ) {
           weights[ fOrderedBranchWeightNames.at(idxBranchWeight) ].push_back(fBranchWeightEntries.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at(idxEntry).at(idxWt));
+          knob_vals[ fOrderedBranchWeightNames.at(idxBranchWeight) ].push_back(lo + (hi-lo)*(double)idxWt/(NSigmas-1));
         }
       }
 
@@ -1290,6 +1296,7 @@ namespace ana
       // clear eights vec:
       for ( unsigned int idxBranchWeight=0; idxBranchWeight<fOrderedBranchWeightNames.size(); ++idxBranchWeight ) {
         weights[ fOrderedBranchWeightNames.at(idxBranchWeight) ].clear();
+        knob_vals[ fOrderedBranchWeightNames.at(idxBranchWeight) ].clear();
       }
     }
 

--- a/sbnana/CAFAna/Core/Tree.cxx
+++ b/sbnana/CAFAna/Core/Tree.cxx
@@ -663,8 +663,10 @@ namespace ana
       fOrderedBranchWeightNames.push_back( labels.at(i) );
       fBranchWeightEntries[labels.at(i)] = {};
 
-      fNSigmasLo[labels.at(i)] = 0;
-      fNSigmasHi[labels.at(i)] = nWeights.at(i);
+      fNSigmas[labels.at(i)] = {};
+      for( unsigned int i_sigma=0; i_sigma<nWeights.at(i); ++i_sigma){
+        fNSigmas[labels.at(i)].push_back( i_sigma );
+      }
       fNWeightsExpected[labels.at(i)] = nWeights.at(i);
     }
 
@@ -696,9 +698,48 @@ namespace ana
 
       assert( nSigma.at(i).second > nSigma.at(i).first );
 
-      fNSigmasLo[labels.at(i)] = nSigma.at(i).first;
-      fNSigmasHi[labels.at(i)] = nSigma.at(i).second;
       fNWeightsExpected[labels.at(i)] = (unsigned int)((nSigma.at(i).second-nSigma.at(i).first) + 1);
+      fNSigmas[labels.at(i)] = {};
+      for( unsigned int i_sigma=0; i_sigma<fNWeightsExpected[labels.at(i)]; ++i_sigma){
+        fNSigmas[labels.at(i)].push_back( nSigma.at(i).first + i_sigma );
+      }
+
+    }
+
+    if ( saveRunSubEvt ) {
+      assert( fBranchEntries.find("Run/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Subrun/i") == fBranchEntries.end() &&
+              fBranchEntries.find("Evt/i") == fBranchEntries.end() );
+
+      fOrderedBranchNames.push_back( "Run/i" ); fBranchEntries["Run/i"] = {};
+      fOrderedBranchNames.push_back( "Subrun/i" ); fBranchEntries["Subrun/i"] = {};
+      fOrderedBranchNames.push_back( "Evt/i" ); fBranchEntries["Evt/i"] = {};
+    }
+    if ( saveSliceNum ) {
+      assert( fBranchEntries.find("Slice/i") == fBranchEntries.end() );
+      fOrderedBranchNames.push_back( "Slice/i" ); fBranchEntries["Slice/i"] = {};
+    }
+  }
+
+  //----------------------------------------------------------------------
+  WeightsTree::WeightsTree( const std::string name, const std::vector<std::string>& labels,
+                            const std::vector<std::vector<double>>& nSigma, const bool saveRunSubEvt, const bool saveSliceNum )
+    : fTreeName(name), fNEntries(0), fPOT(0), fLivetime(0), fSaveRunSubEvt(saveRunSubEvt), fSaveSliceNum(saveSliceNum)
+  {
+    assert( nSigma.size()==labels.size() );
+
+    for ( unsigned int i=0; i<labels.size(); ++i ) {
+      fOrderedBranchWeightNames.push_back( labels.at(i) );
+      fBranchWeightEntries[labels.at(i)] = {};
+
+      assert( nSigma.at(i).size()>0 );
+
+      fNSigmas[labels.at(i)] = {};
+      for( unsigned int i_sigma=0; i_sigma<nSigma.at(i).size(); ++i_sigma){
+        fNSigmas[labels.at(i)].push_back( nSigma.at(i).at(i_sigma) );
+      }
+      fNWeightsExpected[labels.at(i)] = nSigma.at(i).size();
+
     }
 
     if ( saveRunSubEvt ) {
@@ -807,6 +848,20 @@ namespace ana
 
     loader.AddNSigmasTree( *this, labels, systsToStore, spillcut, cut, shift );
   }
+  //----------------------------------------------------------------------
+  NSigmasTree::NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                            SpectrumLoaderBase& loader,
+                            const std::vector<const ISyst*>& systsToStore, const std::vector<std::vector<double>>& nSigma,
+                            const SpillCut& spillcut,
+                            const Cut& cut, const SystShifts& shift, const bool saveRunSubEvt, const bool saveSliceNum )
+  : WeightsTree(name,labels,nSigma,saveRunSubEvt,saveSliceNum)
+  {
+    assert( labels.size() == systsToStore.size() );
+    assert( nSigma.size() == labels.size() );
+
+    loader.AddNSigmasTree( *this, labels, systsToStore, spillcut, cut, shift );
+  }
+
 
   //----------------------------------------------------------------------
   void NSigmasTree::SaveToSplines( TDirectory* dir ) const
@@ -908,7 +963,7 @@ namespace ana
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         double sigmasArr[NSigmas];
         for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
-          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + int(idxSigma));
+          sigmasArr[idxSigma] = fNSigmas.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at(idxSigma);
         }
 
         double weightsArr[NSigmas];
@@ -1030,7 +1085,7 @@ namespace ana
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         double sigmasArr[NSigmas];
         for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
-          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + int(idxSigma));
+          sigmasArr[idxSigma] = fNSigmas.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at(idxSigma);
         }
 
         double weightsArr[NSigmas];
@@ -1151,7 +1206,7 @@ namespace ana
         const int NSigmas = fNWeightsExpected.at( fOrderedBranchWeightNames.at(idxBranchWeight) );
         double sigmasArr[NSigmas];
         for ( unsigned int idxSigma=0; idxSigma<(unsigned int)NSigmas; ++idxSigma ) {
-          sigmasArr[idxSigma] = double(fNSigmasLo.at( fOrderedBranchWeightNames.at(idxBranchWeight) ) + int(idxSigma));
+          sigmasArr[idxSigma] = fNSigmas.at( fOrderedBranchWeightNames.at(idxBranchWeight) ).at(idxSigma);
         }
 
         double weightsArr[NSigmas];

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -94,6 +94,8 @@ namespace ana
                  const std::vector<unsigned int>& nWeights, const bool saveRunSubEvt, const bool saveSliceNum );
     WeightsTree( const std::string name, const std::vector<std::string>& labels,
                  const std::vector<std::pair<int,int>>& nSigma, const bool saveRunSubEvt, const bool saveSliceNum );
+    WeightsTree( const std::string name, const std::vector<std::string>& labels,
+                 const std::vector<std::vector<double>>& nSigma, const bool saveRunSubEvt, const bool saveSliceNum );
     /// Function to merge the WeightsTree with a Tree, assuming both have fSaveRunSubEvt and fSaveSliceNum set to true
     void MergeTree( const Tree& inTree );
     /// Function to update protected members (the branches). DO NOT USE outside of the filling.
@@ -104,8 +106,7 @@ namespace ana
     double POT() const {return fPOT;} // as in Spectrum
     double Livetime() const {return fLivetime;} // as in Spectrum
     long long Entries() const {return fNEntries;}
-    int NSigmaLo(const std::string& systToNSigma) const {return fNSigmasLo.at(systToNSigma);}
-    int NSigmaHi(const std::string& systToNSigma) const {return fNSigmasHi.at(systToNSigma);}
+    double GetSigma(const std::string& systToNSigma, unsigned int i_sigma) const {return fNSigmas.at(systToNSigma).at(i_sigma);}
     unsigned int NWeights(const std::string& systToNWts) const {return fNWeightsExpected.at(systToNWts);}
     bool SaveRunSubEvent() const {return fSaveRunSubEvt;}
     bool SaveSliceNum() const {return fSaveSliceNum;}
@@ -115,8 +116,7 @@ namespace ana
   protected:
     std::map< std::string, std::vector<double>> fBranchEntries;
     std::map< std::string, std::vector<std::vector<double>>> fBranchWeightEntries;
-    std::map< std::string, int> fNSigmasLo;
-    std::map< std::string, int> fNSigmasHi;
+    std::map< std::string, std::vector<double>> fNSigmas;
     std::map< std::string, unsigned int> fNWeightsExpected;
     //std::map< std::string, std::vector<double>> fNWeightsThrows; // stores the expected ordering of NSigmas per knob or universe throws per knob.
     std::string fTreeName;
@@ -138,6 +138,22 @@ namespace ana
                  const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
                  const SpillCut& spillcut,
                  const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+
+    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                 SpectrumLoaderBase& loader,
+                 const std::vector<const ISyst*>& systsToStore, const std::vector<std::vector<double>>& nSigma,
+                 const SpillCut& spillcut,
+                 const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
+    /// constructor with a vector of \ref ISyst, but for TrueTree
+    /// Dedicated for signal efficiency, thus has slightly different behavior
+    /// - Do not take spillcut
+    /// - truthcut: Signal definition is defined here. Only the TrueInteraction (=nu) that satisfies truthcut will be filled
+    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
+                 SpectrumLoaderBase& loader,
+                 const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
+                 const TruthCut& truthcut,
+                 const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false);
+
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;
     void SaveToGraphs( TDirectory* dir ) const;

--- a/sbnana/CAFAna/Core/Tree.h
+++ b/sbnana/CAFAna/Core/Tree.h
@@ -146,13 +146,6 @@ namespace ana
                  const Cut& cut, const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false, const bool saveSliceNum = false );
     /// constructor with a vector of \ref ISyst, but for TrueTree
     /// Dedicated for signal efficiency, thus has slightly different behavior
-    /// - Do not take spillcut
-    /// - truthcut: Signal definition is defined here. Only the TrueInteraction (=nu) that satisfies truthcut will be filled
-    NSigmasTree( const std::string name, const std::vector<std::string>& labels,
-                 SpectrumLoaderBase& loader,
-                 const std::vector<const ISyst*>& systsToStore, const std::vector<std::pair<int,int>>& nSigma,
-                 const TruthCut& truthcut,
-                 const SystShifts& shift = kNoShift, const bool saveRunSubEvt = false);
 
     void SaveTo( TDirectory* dir ) const override;
     void SaveToSplines( TDirectory* dir ) const;

--- a/sbnana/CAFAna/Systs/SBNOnOffSysts.cxx
+++ b/sbnana/CAFAna/Systs/SBNOnOffSysts.cxx
@@ -1,0 +1,62 @@
+#include "sbnana/CAFAna/Systs/SBNOnOffSysts.h"
+
+#include "sbnana/CAFAna/Cuts/TruthCuts.h"
+
+#include "sbnana/CAFAna/Systs/UniverseOracle.h"
+
+#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
+
+#include <cassert>
+#include <iostream>
+
+namespace ana
+{
+  // --------------------------------------------------------------------------
+  SBNOnOffSyst::SBNOnOffSyst(const std::string& systName)
+    : ISyst(systName, systName),
+      fIdx(-1)
+  {
+  }
+
+  // --------------------------------------------------------------------------
+  void SBNOnOffSyst::Shift(double x, caf::SRSliceProxy* sr, double& weight) const
+  {
+    if(sr->truth.index < 0) return;
+
+    if(fIdx == -1) fIdx = UniverseOracle::Instance().SystIndex(ShortName());
+
+    const caf::Proxy<std::vector<caf::SRMultiverse>>& wgts = sr->truth.wgt;
+    if(wgts.empty()) return;
+
+    const UniverseOracle& uo = UniverseOracle::Instance();
+    double x1;
+    int i = uo.ClosestShiftIndex(ShortName(), 1, ESide::kBelow, &x1);
+    double wgt = wgts[fIdx].univ[i];
+
+    if(x > 0) weight *= x < 1.0 ? x * wgt : wgt;
+  }
+
+  // --------------------------------------------------------------------------
+  std::vector<std::string> GetSBNOnOffNames()
+  {
+    // We can't ask the UniverseOracle about this, because it doesn't get
+    // properly configured until it's seen its first CAF file.
+    return { "GENIEReWeight_SBN_v1_multisigma_VecFFCCQEshape",
+             "GENIEReWeight_SBN_v1_multisigma_DecayAngMEC",
+             "GENIEReWeight_SBN_v1_multisigma_Theta_Delta2Npi",
+             "GENIEReWeight_SBN_v1_multisigma_ThetaDelta2NRad"
+    };
+  }
+
+  // --------------------------------------------------------------------------
+  const std::vector<const ISyst*>& GetSBNOnOffSysts()
+  {
+    static std::vector<const ISyst*> ret;
+    if(!ret.empty()) return ret;
+
+    for(const std::string& name: GetSBNOnOffNames())
+      ret.push_back(new SBNOnOffSyst(name));
+
+    return ret;
+  }
+}

--- a/sbnana/CAFAna/Systs/SBNOnOffSysts.cxx
+++ b/sbnana/CAFAna/Systs/SBNOnOffSysts.cxx
@@ -33,7 +33,8 @@ namespace ana
     int i = uo.ClosestShiftIndex(ShortName(), 1, ESide::kBelow, &x1);
     double wgt = wgts[fIdx].univ[i];
 
-    if(x > 0) weight *= x < 1.0 ? x * wgt : wgt;
+    if(x < 0) x *= -1;
+    if(x != 0) weight *= x < 1.0 ? x * wgt : wgt;
   }
 
   // --------------------------------------------------------------------------

--- a/sbnana/CAFAna/Systs/SBNOnOffSysts.h
+++ b/sbnana/CAFAna/Systs/SBNOnOffSysts.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "sbnana/CAFAna/Core/ISyst.h"
+#include "sbnana/CAFAna/Core/Cut.h"
+#include "sbnana/CAFAna/Core/Var.h"
+
+#include "sbnanaobj/StandardRecord/Proxy/FwdDeclare.h"
+
+#include <unordered_map>
+#include <vector>
+
+namespace ana
+{
+  class SBNOnOffSyst: public ISyst
+  {
+  public:
+    SBNOnOffSyst(const std::string& systName);
+
+    void Shift(double x, caf::SRSliceProxy* sr, double& weight) const override;
+
+  protected:
+    mutable int fIdx;
+  };
+
+  std::vector<std::string> GetSBNOnOffNames();
+  const std::vector<const ISyst*>& GetSBNOnOffSysts();
+}


### PR DESCRIPTION
Add new SBNOnOffSyst class for those systematics which only have 1 sigma weights in the CAFs.

Add new "_sigma" branches to NSigmaTree which stores the knob value for each weight.