### PR TITLE
CalorimetrySyst aborts in case of missing template files

### DIFF
--- a/sbnana/CAFAna/Systs/CalorimetrySysts.cxx
+++ b/sbnana/CAFAna/Systs/CalorimetrySysts.cxx
@@ -3,6 +3,7 @@
 #include "cetlib/search_path.h"
 #include <cmath>
 #include <iostream>
+#include <cstdlib> // std::abort()
 #include "TMath.h"
 
 namespace ana {
@@ -21,14 +22,22 @@ namespace ana {
 
     std::string kdEdXUncTemplateFileName = "template_dEdXUncertainty.root";
     std::string kdEdXUncTemplateFullFilePath;
-    sp.find_file(kdEdXUncTemplateFileName, kdEdXUncTemplateFullFilePath);
+    if (!sp.find_file(kdEdXUncTemplateFileName, kdEdXUncTemplateFullFilePath)) {
+      std::cerr << "\nana::CalorimetrySyst: failed to locate dE/dx template file '"
+        << kdEdXUncTemplateFileName << "'" << std::endl;
+      std::abort();
+    }
 
     TFile* file_dEdXUncTemplate = TFile::Open(kdEdXUncTemplateFullFilePath.c_str());
     dedx_unc_template = (TGraph2D*)file_dEdXUncTemplate->Get("dEdXRelUncertainty_dEdX_vs_phi");
 
     std::string kChi2TemplateFileName = "dEdxrestemplates.root";
     std::string kChi2TemplateFullFilePath;
-    sp.find_file(kChi2TemplateFileName, kChi2TemplateFullFilePath);
+    if (!sp.find_file(kChi2TemplateFileName, kChi2TemplateFullFilePath)) {
+      std::cerr << "\nana::CalorimetrySyst: failed to locate dE/dx template file '"
+        << kChi2TemplateFileName << "'" << std::endl;
+      std::abort();
+    }
 
     TFile *file_Chi2Template = TFile::Open(kChi2TemplateFullFilePath.c_str());
     dedx_range_pro = (TProfile*)file_Chi2Template->Get("dedx_range_pro");


### PR DESCRIPTION
It has been reported an issue with cryptic crashes that were tracked down to `ana::CalorimetrySyst` not finding a template data file that it needs.
The code to load the template has the template name hard-coded and no check on the success on locating the file.
This change will `abort()` (after cafe standards) when the file can't be located.

It does not solve that issue (which will be solved by appropriately modifying the dependencies), but it returns a useful message in case of error.

The misleading error message:
```
Processing [...]/sbnana/v09_93_01/slf7.x86_64.e26.prof/bin/load_cafana_libs.C...
Loading libraries..........Error in <TFile::Open>: no url specified
```
