### PR TITLE
Added filename on assertion to help dCache tickets

### DIFF
--- a/sbnana/CAFAna/Core/FileListSource.cxx
+++ b/sbnana/CAFAna/Core/FileListSource.cxx
@@ -99,7 +99,7 @@ namespace ana
 
     fFile = TFile::Open(loc.c_str()); // This pattern allows xrootd
     if (!fFile) {
-      std::cerr << "Possible assertion fail in file << " << loc << std::endl;
+      std::cerr << "Error opening ROOT input file '" << loc << "'" << std::endl;
     }
     assert(fFile);
 

--- a/sbnana/CAFAna/Core/FileListSource.cxx
+++ b/sbnana/CAFAna/Core/FileListSource.cxx
@@ -98,6 +98,9 @@ namespace ana
     loc = pnfs2xrootd(loc); // no-op for non /pnfs locations
 
     fFile = TFile::Open(loc.c_str()); // This pattern allows xrootd
+    if (!fFile) {
+      std::cerr << "Possible assertion fail in file << " << loc << std::endl;
+    }
     assert(fFile);
 
     for(int i = 0; i < fStride; ++i){


### PR DESCRIPTION
# Problem

When dCache pools are down, running an analysis through a `cafe` script can return an error message saying that the pools are unavailable. However, if loading files throught `samweb` definitions in a `SpectrumLoader`, the file at which the analysis crashes is not known, and no information is shared in the assertion. This information is useful to grid/computing experts to allow the problem (which dCache pool is down) to be exacly pinpointed. 

# Fix

If the `fFile` is `nullptr` (so `assertion(fFile)` will break the analysis) throw out the filename