### PR TITLE
Port BNB Quality SpillCuts/SpillVars (POT, horn current, and Figure of Merit) to sbnana v10_01_01

### DIFF
--- a/sbnana/CAFAna/Core/Defaults.h
+++ b/sbnana/CAFAna/Core/Defaults.h
@@ -1,0 +1,10 @@
+#ifndef CAFANA_DEFAULTS
+#define CAFANA_DEFAULTS
+
+namespace ana
+{
+  inline float SmallDefault = -5.f;
+  inline float LargeDefault = -999.f;
+}
+
+#endif

--- a/sbnana/CAFAna/Core/SpectrumLoader.cxx
+++ b/sbnana/CAFAna/Core/SpectrumLoader.cxx
@@ -604,7 +604,7 @@ namespace ana
   //----------------------------------------------------------------------
   void SpectrumLoader::StoreExposures()
   {
-    if(fabs(fPOT - fPOTFromHist)/std::min(fPOT, fPOTFromHist) > 0.001){
+    if(fabs(fPOT - fPOTFromHist)/std::min(fPOT, fPOTFromHist) > 0.01){
       std::cout << fPOT << " POT from hdr differs from " << fPOTFromHist << " POT from the TotalPOT histogram!" << std::endl;
       //abort();
     }

--- a/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
+++ b/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
@@ -52,7 +52,7 @@ const double LM875C_LB = +1e-2;
 const double THCURR_LB = +173, THCURR_UB = +175; //! units: kA
 
 /**
-    Figure(s) of Merit: @see getBNBFoM.cxx (and getBNBFoM2.cxx) for details
+    Figure(s) of Merit: @see getBNBFoM.cxx for details
     
     @details The Figure of Merit (FoM) is a score on the interval [0, 1] that
     acts as a measure of the geometric overlap of the BNB with the beamline's 
@@ -74,13 +74,13 @@ const SpillCut kLM875CCut = kSpillLM875C >= LM875C_LB;
 
 const SpillCut kTHCURRCut = kSpillTHCURR >= THCURR_LB && kSpillTHCURR <= THCURR_UB;
 
+const SpillCut kFoMCut_noMultiWire = kSpillFoM_noMultiWire >= FoM_LB;
 const SpillCut kFoMCut = kSpillFoM >= FoM_LB;
-const SpillCut kFoM2Cut = kSpillFoM2 >= FoM_LB;
 
 //! ^--- INDIVIDUAL CUTS ; COMBINATION CUTS ---v
 
-const SpillCut kBNBQualityCut_FoM1 = kTOR860Cut && kTOR875Cut && kLM875ACut && kLM875BCut && kLM875CCut && kTHCURRCut && kFoMCut;
+const SpillCut kBNBQualityCut_noMultiWire = kTOR860Cut && kTOR875Cut && kLM875ACut && kLM875BCut && kLM875CCut && kTHCURRCut && kFoMCut_noMultiWire;
 
-const SpillCut kBNBQualityCut_FoM2 = kTOR860Cut && kTOR875Cut && kLM875ACut && kLM875BCut && kLM875CCut && kTHCURRCut && kFoM2Cut;
+const SpillCut kBNBQualityCut = kTOR860Cut && kTOR875Cut && kLM875ACut && kLM875BCut && kLM875CCut && kTHCURRCut && kFoMCut;
 
 } //! stop using namespace ana

--- a/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
+++ b/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
@@ -58,7 +58,7 @@ const double THCURR_LB = +173, THCURR_UB = +175; //! units: kA
     acts as a measure of the geometric overlap of the BNB with the beamline's 
     nuclear target.
 */
-const double FoM_LB = 0.85;
+const double FoM_LB = 0.98;
 
 //!-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 

--- a/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
+++ b/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
@@ -1,11 +1,10 @@
-///////////////////////////////////////////////////////////////////////////////
-// File: BNBQualityCuts.cxx                                                  //
-// Author: Jacob Smith (smithja)                                             //
-// Last edited: March 6th, 2025                                              //
-//                                                                           //
-// Explicit definitions of the BNB Quality Cuts used for the ICARUS          //
-// experiment.                                                               //
-///////////////////////////////////////////////////////////////////////////////
+//! ////////////////////////////////////////////////////////////////////////////
+//! @file: BNBQualityCuts.cxx                                                  
+//! @author: Jacob Smith (smithja)   
+//! @email: jacob.a.smith@stonybrook.edu                                          
+//!                                                                          
+//! @brief Explicit definitions of BNB Quality Cuts used for SBN experiments.       
+//! ////////////////////////////////////////////////////////////////////////////
 
 #include "sbnana/CAFAna/Core/Cut.h"
 
@@ -14,8 +13,8 @@
 
 #include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
 
-namespace ana { // use namespace ana for entire file
-/*
+namespace ana { //! use namespace ana for entire file
+/**
     While there is sometimes discernable structure in a given BNB quality 
     variable (e.g. TOR860 and TOR875 stay around 4.5E12 POT when only the BNB is
     on and 3.0E12 POT when both the BNB and NuMI beams are on), exact behavior 
@@ -23,14 +22,14 @@ namespace ana { // use namespace ana for entire file
     latest (read 'final') version of a given cut will be the most stringent cut
      we can make with a limited knowledge of the detailed behavior of that cut.
 */
-const double TOR860_LB = +100e9; // units: POT
+const double TOR860_LB = +100e9; //! units: POT
 const double TOR875_LB = +100e9; 
 
-const double LM875A_LB = +1e-2; // units: rad/s
+const double LM875A_LB = +1e-2; //! units: rad/s
 const double LM875B_LB = +1e-2;
 const double LM875C_LB = +1e-2;
 
-/*
+/**
     The BTJT2 variable is somewhat unreliable to use as a spill-by-spill cut.
     BTJT2 measures the temperature of the BNB near the target. Since runs can be
     started/stopped more quickly than the thermal fluctuations of BTJT2, there
@@ -38,11 +37,10 @@ const double LM875C_LB = +1e-2;
     have diminishing returns compared to other BNB quality variables listed. 
     You may employ cuts on BTJT2 at your own peril.
 */
+//! const double BTJT2_LB = 999, BTJT2_UB = 999; //! units: deg C
 
-// const double BTJT2_LB = 999, BTJT2_UB = 999; // units: deg C
 
-
-/* 
+/** 
     SMITHJA: Further cuts on THCURR could/should be made since it was discovered 
     that the horn current is not always centered around 174 kA. 
     Further work is needed to understand horn current for different runs. The
@@ -50,10 +48,19 @@ const double LM875C_LB = +1e-2;
     found that a range of 173 to 177 included the horn currents for a majority
     of ICARUS data runs.
 */
-// const double THCURR_LB = +173, THCURR_UB = +177; // units: kA
-const double THCURR_LB = +173, THCURR_UB = +175; // units: kA
+//! const double THCURR_LB = +173, THCURR_UB = +177; //! units: kA
+const double THCURR_LB = +173, THCURR_UB = +175; //! units: kA
 
-//-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+/**
+    Figure(s) of Merit: @see getBNBFoM.cxx (and getBNBFoM2.cxx) for details
+    
+    @details The Figure of Merit (FoM) is a score on the interval [0, 1] that
+    acts as a measure of the geometric overlap of the BNB with the beamline's 
+    nuclear target.
+*/
+const double FoM_LB = 0.85;
+
+//!-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
 const SpillCut kTOR860Cut = kSpillTOR860 >= TOR860_LB;
 const SpillCut kTOR875Cut = kSpillTOR875 >= TOR875_LB;
@@ -62,13 +69,18 @@ const SpillCut kLM875ACut = kSpillLM875A >= LM875A_LB;
 const SpillCut kLM875BCut = kSpillLM875B >= LM875B_LB;
 const SpillCut kLM875CCut = kSpillLM875C >= LM875C_LB;
 
-// DEPRECIATED: see above notes about BTJT2
-//const SpillCut kBTJT2Cut = kSpillBTJT2 >= BTJT2_LB && kSpillBTJT2 <= BTJT2_UB;
+//! @depreciated: see above notes about BTJT2
+//! const SpillCut kBTJT2Cut = kSpillBTJT2 >= BTJT2_LB && kSpillBTJT2 <= BTJT2_UB;
 
 const SpillCut kTHCURRCut = kSpillTHCURR >= THCURR_LB && kSpillTHCURR <= THCURR_UB;
 
-// ^--- INDIVIDUAL CUTS ; COMBINATION CUTS ---v
+const SpillCut kFoMCut = kSpillFoM >= FoM_LB;
+const SpillCut kFoM2Cut = kSpillFoM2 >= FoM_LB;
 
-const SpillCut kBNBQualityCut = kTOR860Cut && kTOR875Cut && kLM875ACut && kLM875BCut && kLM875CCut && kTHCURRCut;
+//! ^--- INDIVIDUAL CUTS ; COMBINATION CUTS ---v
 
-} // stop using namespace ana
+const SpillCut kBNBQualityCut_FoM1 = kTOR860Cut && kTOR875Cut && kLM875ACut && kLM875BCut && kLM875CCut && kTHCURRCut && kFoMCut;
+
+const SpillCut kBNBQualityCut_FoM2 = kTOR860Cut && kTOR875Cut && kLM875ACut && kLM875BCut && kLM875CCut && kTHCURRCut && kFoM2Cut;
+
+} //! stop using namespace ana

--- a/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
+++ b/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
@@ -1,24 +1,28 @@
+///////////////////////////////////////////////////////////////////////////////
+// File: BNBQualityCuts.cxx                                                  //
+// Author: Jacob Smith (smithja)                                             //
+// Last edited: March 6th, 2025                                              //
+//                                                                           //
+// Explicit definitions of the BNB Quality Cuts used for the ICARUS          //
+// experiment.                                                               //
+///////////////////////////////////////////////////////////////////////////////
+
 #include "sbnana/CAFAna/Core/Cut.h"
+
+#include "sbnana/SBNAna/Vars/BNBVars.h"
 #include "sbnana/SBNAna/Cuts/BNBQualityCuts.h"
+
 #include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
-#include <iostream>
 
 namespace ana { // use namespace ana for entire file
-
 /*
-   Here are the hard-coded physically meaningful bounds for BNB quality
-   SpillCuts. 
+    While there is sometimes discernable structure in a given BNB quality 
+    variable (e.g. TOR860 and TOR875 stay around 4.5E12 POT when only the BNB is
+    on and 3.0E12 POT when both the BNB and NuMI beams are on), exact behavior 
+    of such variables is not known in detail as a function of time. Thus, the 
+    latest (read 'final') version of a given cut will be the most stringent cut
+     we can make with a limited knowledge of the detailed behavior of that cut.
 */
-
-/*
-   While there is sometimes discernable structure in a given BNB quality 
-   variable (e.g. TOR860 and TOR875 stay around 4.5E12 POT when only the BNB is
-   on and 3.0E12 POT when both the BNB and NuMI beams are on), exact behavior of
-   such variables is not known in detail as a function of time. Thus, the latest 
-   (read 'final') version of a given cut will be the most stringent cut we can 
-   make with a limited knowledge of the detailed behavior of that cut.
-*/
-
 const double TOR860_LB = +100e9; // units: POT
 const double TOR875_LB = +100e9; 
 
@@ -26,341 +30,45 @@ const double LM875A_LB = +1e-2; // units: rad/s
 const double LM875B_LB = +1e-2;
 const double LM875C_LB = +1e-2;
 
-// SMITHJA: I will have to get in touch with (Tom from) the External Beams group
-//          at Fermilab to get final cuts on these beam position monitor (BPM)
-//          variables since they change from run to run. If realtime values for 
-//          those optimal BPM variables are not accessible (which is the likely
-//          case), the BPM cuts will likely be hard-coded here. 
-const double HP875_LB = -0.25;  const double HP875_UB = +0.25; // units: mm
-const double VP875_LB = -0.20;  const double VP875_UB = +0.30;
-const double HPTG1_LB = -0.25;  const double HPTG1_UB = +0.25;
-const double VPTG1_LB = -0.20;  const double VPTG1_UB = +0.30;
-const double HPTG2_LB = -0.25;  const double HPTG2_UB = +0.25;
-const double VPTG2_LB = -0.20;  const double VPTG2_UB = +0.30;
-
 /*
-   The BTJT2 variable is somewhat unreliable to use as a spill-by-spill cut.
-   BTJT2 measures the temperature of the BNB near the target. Since runs can be
-   started/stopped more quickly than the thermal fluctuations of BTJT2, there
-   can be some amount of "cross contamination" between spills. For this reason
-   BTJT2 is deemed to have diminishing returns compared to other BNB quality
-   variables listed. You may employ cuts on BTJT2 at your own peril.
-
-const double BTJT2_LB = 999;  const double BTJT2_UB = 999; // units: deg C
+    The BTJT2 variable is somewhat unreliable to use as a spill-by-spill cut.
+    BTJT2 measures the temperature of the BNB near the target. Since runs can be
+    started/stopped more quickly than the thermal fluctuations of BTJT2, there
+    can be some correlation between spills. For this reason BTJT2 is deemed to 
+    have diminishing returns compared to other BNB quality variables listed. 
+    You may employ cuts on BTJT2 at your own peril.
 */
 
-const double THCURR_LB = +173;  const double THCURR_UB = +177; // units: kA
+// const double BTJT2_LB = 999, BTJT2_UB = 999; // units: deg C
 
-/* SMITHJA:
-   Further cuts on THCURR could/should be made since it was discovered that
-   the horn current (i.e. THCURR) is not always centered around 174 kA. Further
-   work needed to understand horn current for different runs. -- Jacob Smith
 
-const double THCURR_LB = +173;  const double THCURR_UB = +175; // units: kA
+/* 
+    SMITHJA: Further cuts on THCURR could/should be made since it was discovered 
+    that the horn current is not always centered around 174 kA. 
+    Further work is needed to understand horn current for different runs. The
+    cut ranging from 173 to 175 kA is for ICARUS Run 2 data. Generally it was
+    found that a range of 173 to 177 included the horn currents for a majority
+    of ICARUS data runs.
 */
+// const double THCURR_LB = +173, THCURR_UB = +177; // units: kA
+const double THCURR_LB = +173, THCURR_UB = +175; // units: kA
+
 //-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
+const SpillCut kTOR860Cut = kSpillTOR860 >= TOR860_LB;
+const SpillCut kTOR875Cut = kSpillTOR875 >= TOR875_LB;
 
+const SpillCut kLM875ACut = kSpillLM875A >= LM875A_LB;
+const SpillCut kLM875BCut = kSpillLM875B >= LM875B_LB;
+const SpillCut kLM875CCut = kSpillLM875C >= LM875C_LB;
 
-struct SpillInfo { // contains information about a spill of the BNB
-  // These are the variables that measure the quality of a spill in the BNB.
-  float TOR860, TOR875, \
-        LM875A, LM875B, LM875C, \
-        HP875, VP875, \
-        HPTG1, VPTG1, \
-        HPTG2, VPTG2, \
-//        BTJT2,
-        THCURR;
-  
-  // These are used to identify/match spills in the global vector of 
-  // SpillInfo objects (see GLOBAL_SPILL_INFO below).
-  unsigned int run, event;
-};
+// DEPRECIATED: see above notes about BTJT2
+//const SpillCut kBTJT2Cut = kSpillBTJT2 >= BTJT2_LB && kSpillBTJT2 <= BTJT2_UB;
 
-// vector containing all of the information for spills of the BNB:
-static std::vector<SpillInfo> GLOBAL_SPILL_INFO; 
+const SpillCut kTHCURRCut = kSpillTHCURR >= THCURR_LB && kSpillTHCURR <= THCURR_UB;
 
+// ^--- INDIVIDUAL CUTS ; COMBINATION CUTS ---v
 
-/*
-   This function sets all of the values for a SpillInfo object (see above).
-
-Params:
-  * run: integer identifier for the run/event
-  * info: this contains all of the BNB monitoring info for a given spill 
-          (including the event number, which is also used to identify a
-           run/event)
-*/
-void fill_spill_info( unsigned int run, const caf::Proxy<caf::SRBNBInfo> &info){
-  GLOBAL_SPILL_INFO.emplace_back();
-
-  GLOBAL_SPILL_INFO.back().run = run;
-  GLOBAL_SPILL_INFO.back().event = info.event;
-
-  GLOBAL_SPILL_INFO.back().TOR860 = info.TOR860;
-  GLOBAL_SPILL_INFO.back().TOR875 = info.TOR875;
-  GLOBAL_SPILL_INFO.back().LM875A = info.LM875A;
-  GLOBAL_SPILL_INFO.back().LM875B = info.LM875B;
-  GLOBAL_SPILL_INFO.back().LM875C = info.LM875C;
-  GLOBAL_SPILL_INFO.back().HP875  = info.HP875;
-  GLOBAL_SPILL_INFO.back().VP875  = info.VP875;
-  GLOBAL_SPILL_INFO.back().HPTG1  = info.HPTG1;
-  GLOBAL_SPILL_INFO.back().VPTG1  = info.VPTG1;
-  GLOBAL_SPILL_INFO.back().HPTG2  = info.HPTG2;
-  GLOBAL_SPILL_INFO.back().VPTG2  = info.VPTG2;
-//  GLOBAL_SPILL_INFO.back().BTJT2  = info.BTJT2;
-  GLOBAL_SPILL_INFO.back().THCURR = info.THCURR;
-}
-
-const SpillCut kTOR860([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){                           // non-zero nbnb indicates new subrun...
-        GLOBAL_SPILL_INFO.clear();                   // ...so we get rid of spills tied to last subrun...
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ // ...and fill in info for this subrun's spills
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; // ensure event matching
-        // make preliminary cut on variable of interest --v
-        if( match.TOR860 >= TOR860_LB) return true; 
-    }
-    return false; // a spill does not pass a cut if 
-                  // there is no event-matched data
-});
-
-/*
-   NOTE: For brevity of commenting, the preliminary SpillCuts below are not 
-         commented; however, they are the same as kTOR860 (see above) but with
-         different variables of interest, e.g. TOR875, LM875B, THCURR, etc.
-*/
-
-const SpillCut kTOR875([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){                               
-        GLOBAL_SPILL_INFO.clear();                   
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.TOR875 >= TOR875_LB) return true; 
-    }
-    return false; 
-});
-
-const SpillCut kLM875A([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){                               
-        GLOBAL_SPILL_INFO.clear();                   
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.LM875A >= LM875A_LB) return true; 
-    }
-    return false; 
-});
-
-const SpillCut kLM875B([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){                               
-        GLOBAL_SPILL_INFO.clear();                   
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.LM875B >= LM875B_LB) return true; 
-    }
-    return false; 
-});
-
-const SpillCut kLM875C([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){                               
-        GLOBAL_SPILL_INFO.clear();                   
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.LM875C >= LM875C_LB) return true; 
-    }
-    return false; 
-});
-
-const SpillCut kHP875([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.HP875 >= HP875_LB && match.HP875 <= HP875_UB) return true;
-    }
-    return false; 
-});
-
-const SpillCut kVP875([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.VP875 >= VP875_LB && match.VP875 <= VP875_UB) return true;
-    }
-    return false; 
-});
-
-const SpillCut kHPTG1([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.HPTG1 >= HPTG1_LB && match.HPTG1 <= HPTG1_UB) return true;
-    }
-    return false; 
-});
-
-const SpillCut kVPTG1([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.VPTG1 >= VPTG1_LB && match.VPTG1 <= VPTG1_UB) return true;
-    }
-    return false; 
-});
-
-const SpillCut kHPTG2([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.HPTG2 >= HPTG2_LB && match.HPTG2 <= HPTG2_UB) return true;
-    }
-    return false; 
-});
-
-const SpillCut kVPTG2([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.VPTG2 >= VPTG2_LB && match.VPTG2 <= VPTG2_UB) return true;
-    }
-    return false; 
-});
-/*
-const SpillCut kBTJT2([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.BTJT2 >= BTJT2_LB && match.BTJT2 < BTJT2_UB) return true;
-    }
-    return false; 
-});
-*/
-const SpillCut kTHCURR([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.THCURR >= THCURR_LB && match.THCURR <= THCURR_UB) return true;
-    }
-    return false; 
-});
-
-/* -------------------------------------- \
-//                                        |
-// ^--- INDIVIDUAL CUTS ; MASTER CUT ---v |
-//                                        |
-// ------------------------------------- */
-
-const SpillCut kBNBQuality_noBPMs_10Feb2025([](const caf::SRSpillProxy* sr) {
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){
-            fill_spill_info( sr->hdr.run, bnbinfo);
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue;
-        if( match.TOR860 >= TOR860_LB && \
-              match.TOR875 >= TOR875_LB && \
-              match.LM875A >= LM875A_LB && \
-              match.LM875B >= LM875B_LB && \
-              match.LM875C >= LM875C_LB && \
-//              match.HP875  >= HP875_LB  && match.HP875 <= HP875_UB  && 
-//              match.VP875  >= VP875_LB  && match.VP875 <= VP875_UB  && 
-//              match.HPTG1  >= HPTG1_LB  && match.HPTG1 <= HPTG1_UB  && 
-//              match.VPTG1  >= VPTG1_LB  && match.VPTG1 <= VPTG1_UB  && 
-//              match.HPTG2  >= HPTG2_LB  && match.HPTG2 <= HPTG2_UB  && 
-//              match.VPTG2  >= VPTG2_LB  && match.VPTG2 <= VPTG2_UB  && 
-//              match.BTJT2  >= BTJT2_LB  && match.BTJT2  < BTJT2_UB  &&
-              match.THCURR >= THCURR_LB && match.THCURR <= THCURR_UB) {
-            return true;
-        }
-    }
-    return false;
-});
-
-const SpillCut kBNBQuality([](const caf::SRSpillProxy* sr){
-    if( sr->hdr.nbnbinfo){
-        GLOBAL_SPILL_INFO.clear();
-        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
-            fill_spill_info( sr->hdr.run, bnbinfo);  
-        }
-    }
-    for( const auto& match: GLOBAL_SPILL_INFO) {
-        if( match.event != sr->hdr.evt) continue; 
-        if( match.TOR860 >= TOR860_LB && \
-              match.TOR875 >= TOR875_LB && \
-              match.LM875A >= LM875A_LB && \
-              match.LM875B >= LM875B_LB && \
-              match.LM875C >= LM875C_LB && \
-              match.HP875  >= HP875_LB  && match.HP875 <= HP875_UB  && \
-              match.VP875  >= VP875_LB  && match.VP875 <= VP875_UB  && \
-              match.HPTG1  >= HPTG1_LB  && match.HPTG1 <= HPTG1_UB  && \
-              match.VPTG1  >= VPTG1_LB  && match.VPTG1 <= VPTG1_UB  && \
-              match.HPTG2  >= HPTG2_LB  && match.HPTG2 <= HPTG2_UB  && \
-              match.VPTG2  >= VPTG2_LB  && match.VPTG2 <= VPTG2_UB  && \
-//              match.BTJT2  >= BTJT2_LB  && match.BTJT2  < BTJT2_UB  &&
-              match.THCURR >= THCURR_LB && match.THCURR <= THCURR_UB) {
-            return true;
-        }
-    }
-    return false; 
-});
+const SpillCut kBNBQualityCut = kTOR860Cut && kTOR875Cut && kLM875ACut && kLM875BCut && kLM875CCut && kTHCURRCut;
 
 } // stop using namespace ana

--- a/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
+++ b/sbnana/SBNAna/Cuts/BNBQualityCuts.cxx
@@ -1,0 +1,366 @@
+#include "sbnana/CAFAna/Core/Cut.h"
+#include "sbnana/SBNAna/Cuts/BNBQualityCuts.h"
+#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
+#include <iostream>
+
+namespace ana { // use namespace ana for entire file
+
+/*
+   Here are the hard-coded physically meaningful bounds for BNB quality
+   SpillCuts. 
+*/
+
+/*
+   While there is sometimes discernable structure in a given BNB quality 
+   variable (e.g. TOR860 and TOR875 stay around 4.5E12 POT when only the BNB is
+   on and 3.0E12 POT when both the BNB and NuMI beams are on), exact behavior of
+   such variables is not known in detail as a function of time. Thus, the latest 
+   (read 'final') version of a given cut will be the most stringent cut we can 
+   make with a limited knowledge of the detailed behavior of that cut.
+*/
+
+const double TOR860_LB = +100e9; // units: POT
+const double TOR875_LB = +100e9; 
+
+const double LM875A_LB = +1e-2; // units: rad/s
+const double LM875B_LB = +1e-2;
+const double LM875C_LB = +1e-2;
+
+// SMITHJA: I will have to get in touch with (Tom from) the External Beams group
+//          at Fermilab to get final cuts on these beam position monitor (BPM)
+//          variables since they change from run to run. If realtime values for 
+//          those optimal BPM variables are not accessible (which is the likely
+//          case), the BPM cuts will likely be hard-coded here. 
+const double HP875_LB = -0.25;  const double HP875_UB = +0.25; // units: mm
+const double VP875_LB = -0.20;  const double VP875_UB = +0.30;
+const double HPTG1_LB = -0.25;  const double HPTG1_UB = +0.25;
+const double VPTG1_LB = -0.20;  const double VPTG1_UB = +0.30;
+const double HPTG2_LB = -0.25;  const double HPTG2_UB = +0.25;
+const double VPTG2_LB = -0.20;  const double VPTG2_UB = +0.30;
+
+/*
+   The BTJT2 variable is somewhat unreliable to use as a spill-by-spill cut.
+   BTJT2 measures the temperature of the BNB near the target. Since runs can be
+   started/stopped more quickly than the thermal fluctuations of BTJT2, there
+   can be some amount of "cross contamination" between spills. For this reason
+   BTJT2 is deemed to have diminishing returns compared to other BNB quality
+   variables listed. You may employ cuts on BTJT2 at your own peril.
+
+const double BTJT2_LB = 999;  const double BTJT2_UB = 999; // units: deg C
+*/
+
+const double THCURR_LB = +173;  const double THCURR_UB = +177; // units: kA
+
+/* SMITHJA:
+   Further cuts on THCURR could/should be made since it was discovered that
+   the horn current (i.e. THCURR) is not always centered around 174 kA. Further
+   work needed to understand horn current for different runs. -- Jacob Smith
+
+const double THCURR_LB = +173;  const double THCURR_UB = +175; // units: kA
+*/
+//-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+
+
+struct SpillInfo { // contains information about a spill of the BNB
+  // These are the variables that measure the quality of a spill in the BNB.
+  float TOR860, TOR875, \
+        LM875A, LM875B, LM875C, \
+        HP875, VP875, \
+        HPTG1, VPTG1, \
+        HPTG2, VPTG2, \
+//        BTJT2,
+        THCURR;
+  
+  // These are used to identify/match spills in the global vector of 
+  // SpillInfo objects (see GLOBAL_SPILL_INFO below).
+  unsigned int run, event;
+};
+
+// vector containing all of the information for spills of the BNB:
+static std::vector<SpillInfo> GLOBAL_SPILL_INFO; 
+
+
+/*
+   This function sets all of the values for a SpillInfo object (see above).
+
+Params:
+  * run: integer identifier for the run/event
+  * info: this contains all of the BNB monitoring info for a given spill 
+          (including the event number, which is also used to identify a
+           run/event)
+*/
+void fill_spill_info( unsigned int run, const caf::Proxy<caf::SRBNBInfo> &info){
+  GLOBAL_SPILL_INFO.emplace_back();
+
+  GLOBAL_SPILL_INFO.back().run = run;
+  GLOBAL_SPILL_INFO.back().event = info.event;
+
+  GLOBAL_SPILL_INFO.back().TOR860 = info.TOR860;
+  GLOBAL_SPILL_INFO.back().TOR875 = info.TOR875;
+  GLOBAL_SPILL_INFO.back().LM875A = info.LM875A;
+  GLOBAL_SPILL_INFO.back().LM875B = info.LM875B;
+  GLOBAL_SPILL_INFO.back().LM875C = info.LM875C;
+  GLOBAL_SPILL_INFO.back().HP875  = info.HP875;
+  GLOBAL_SPILL_INFO.back().VP875  = info.VP875;
+  GLOBAL_SPILL_INFO.back().HPTG1  = info.HPTG1;
+  GLOBAL_SPILL_INFO.back().VPTG1  = info.VPTG1;
+  GLOBAL_SPILL_INFO.back().HPTG2  = info.HPTG2;
+  GLOBAL_SPILL_INFO.back().VPTG2  = info.VPTG2;
+//  GLOBAL_SPILL_INFO.back().BTJT2  = info.BTJT2;
+  GLOBAL_SPILL_INFO.back().THCURR = info.THCURR;
+}
+
+const SpillCut kTOR860([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){                           // non-zero nbnb indicates new subrun...
+        GLOBAL_SPILL_INFO.clear();                   // ...so we get rid of spills tied to last subrun...
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ // ...and fill in info for this subrun's spills
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; // ensure event matching
+        // make preliminary cut on variable of interest --v
+        if( match.TOR860 >= TOR860_LB) return true; 
+    }
+    return false; // a spill does not pass a cut if 
+                  // there is no event-matched data
+});
+
+/*
+   NOTE: For brevity of commenting, the preliminary SpillCuts below are not 
+         commented; however, they are the same as kTOR860 (see above) but with
+         different variables of interest, e.g. TOR875, LM875B, THCURR, etc.
+*/
+
+const SpillCut kTOR875([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){                               
+        GLOBAL_SPILL_INFO.clear();                   
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.TOR875 >= TOR875_LB) return true; 
+    }
+    return false; 
+});
+
+const SpillCut kLM875A([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){                               
+        GLOBAL_SPILL_INFO.clear();                   
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.LM875A >= LM875A_LB) return true; 
+    }
+    return false; 
+});
+
+const SpillCut kLM875B([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){                               
+        GLOBAL_SPILL_INFO.clear();                   
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.LM875B >= LM875B_LB) return true; 
+    }
+    return false; 
+});
+
+const SpillCut kLM875C([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){                               
+        GLOBAL_SPILL_INFO.clear();                   
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.LM875C >= LM875C_LB) return true; 
+    }
+    return false; 
+});
+
+const SpillCut kHP875([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.HP875 >= HP875_LB && match.HP875 <= HP875_UB) return true;
+    }
+    return false; 
+});
+
+const SpillCut kVP875([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.VP875 >= VP875_LB && match.VP875 <= VP875_UB) return true;
+    }
+    return false; 
+});
+
+const SpillCut kHPTG1([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.HPTG1 >= HPTG1_LB && match.HPTG1 <= HPTG1_UB) return true;
+    }
+    return false; 
+});
+
+const SpillCut kVPTG1([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.VPTG1 >= VPTG1_LB && match.VPTG1 <= VPTG1_UB) return true;
+    }
+    return false; 
+});
+
+const SpillCut kHPTG2([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.HPTG2 >= HPTG2_LB && match.HPTG2 <= HPTG2_UB) return true;
+    }
+    return false; 
+});
+
+const SpillCut kVPTG2([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.VPTG2 >= VPTG2_LB && match.VPTG2 <= VPTG2_UB) return true;
+    }
+    return false; 
+});
+/*
+const SpillCut kBTJT2([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.BTJT2 >= BTJT2_LB && match.BTJT2 < BTJT2_UB) return true;
+    }
+    return false; 
+});
+*/
+const SpillCut kTHCURR([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.THCURR >= THCURR_LB && match.THCURR <= THCURR_UB) return true;
+    }
+    return false; 
+});
+
+/* -------------------------------------- \
+//                                        |
+// ^--- INDIVIDUAL CUTS ; MASTER CUT ---v |
+//                                        |
+// ------------------------------------- */
+
+const SpillCut kBNBQuality_noBPMs_10Feb2025([](const caf::SRSpillProxy* sr) {
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){
+            fill_spill_info( sr->hdr.run, bnbinfo);
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue;
+        if( match.TOR860 >= TOR860_LB && \
+              match.TOR875 >= TOR875_LB && \
+              match.LM875A >= LM875A_LB && \
+              match.LM875B >= LM875B_LB && \
+              match.LM875C >= LM875C_LB && \
+//              match.HP875  >= HP875_LB  && match.HP875 <= HP875_UB  && 
+//              match.VP875  >= VP875_LB  && match.VP875 <= VP875_UB  && 
+//              match.HPTG1  >= HPTG1_LB  && match.HPTG1 <= HPTG1_UB  && 
+//              match.VPTG1  >= VPTG1_LB  && match.VPTG1 <= VPTG1_UB  && 
+//              match.HPTG2  >= HPTG2_LB  && match.HPTG2 <= HPTG2_UB  && 
+//              match.VPTG2  >= VPTG2_LB  && match.VPTG2 <= VPTG2_UB  && 
+//              match.BTJT2  >= BTJT2_LB  && match.BTJT2  < BTJT2_UB  &&
+              match.THCURR >= THCURR_LB && match.THCURR <= THCURR_UB) {
+            return true;
+        }
+    }
+    return false;
+});
+
+const SpillCut kBNBQuality([](const caf::SRSpillProxy* sr){
+    if( sr->hdr.nbnbinfo){
+        GLOBAL_SPILL_INFO.clear();
+        for( const auto &bnbinfo : sr->hdr.bnbinfo){ 
+            fill_spill_info( sr->hdr.run, bnbinfo);  
+        }
+    }
+    for( const auto& match: GLOBAL_SPILL_INFO) {
+        if( match.event != sr->hdr.evt) continue; 
+        if( match.TOR860 >= TOR860_LB && \
+              match.TOR875 >= TOR875_LB && \
+              match.LM875A >= LM875A_LB && \
+              match.LM875B >= LM875B_LB && \
+              match.LM875C >= LM875C_LB && \
+              match.HP875  >= HP875_LB  && match.HP875 <= HP875_UB  && \
+              match.VP875  >= VP875_LB  && match.VP875 <= VP875_UB  && \
+              match.HPTG1  >= HPTG1_LB  && match.HPTG1 <= HPTG1_UB  && \
+              match.VPTG1  >= VPTG1_LB  && match.VPTG1 <= VPTG1_UB  && \
+              match.HPTG2  >= HPTG2_LB  && match.HPTG2 <= HPTG2_UB  && \
+              match.VPTG2  >= VPTG2_LB  && match.VPTG2 <= VPTG2_UB  && \
+//              match.BTJT2  >= BTJT2_LB  && match.BTJT2  < BTJT2_UB  &&
+              match.THCURR >= THCURR_LB && match.THCURR <= THCURR_UB) {
+            return true;
+        }
+    }
+    return false; 
+});
+
+} // stop using namespace ana

--- a/sbnana/SBNAna/Cuts/BNBQualityCuts.h
+++ b/sbnana/SBNAna/Cuts/BNBQualityCuts.h
@@ -24,12 +24,12 @@ namespace ana {
 
     extern const SpillCut kTHCURRCut;
 
-    //! Figure(s) of Merit: @see getBNBFoM.cxx (and getBNBFoM2.cxx) for details
-    extern const SpillCut kFoMCut; 
-    extern const SpillCut kFoM2Cut;
+    //! Figure(s) of Merit: @see getBNBFoM.cxx for details
+    extern const SpillCut kFoMCut_noMultiWire; 
+    extern const SpillCut kFoMCut;
 
     //! ^--- INDIVIDUAL CUTS ; COMBINATION CUTS ---v
 
-    extern const SpillCut kBNBQualityCut_FoM1;
-    extern const SpillCut kBNBQualityCut_FoM2;
+    extern const SpillCut kBNBQualityCut_noMultiWire;
+    extern const SpillCut kBNBQualityCut;
 }

--- a/sbnana/SBNAna/Cuts/BNBQualityCuts.h
+++ b/sbnana/SBNAna/Cuts/BNBQualityCuts.h
@@ -1,38 +1,31 @@
-#pragma once
+///////////////////////////////////////////////////////////////////////////////
+// File: BNBQualityCuts.h                                                    //
+// Author: Jacob Smith (smithja)                                             //
+// Last edited: March 6th, 2025                                              //
+//                                                                           //
+// Header file to define all of the BNB Quality Cuts for the ICARUS          //
+// experiment.                                                               //
+///////////////////////////////////////////////////////////////////////////////
 
 #include "sbnana/CAFAna/Core/Cut.h"
 
 namespace ana {
+    extern const SpillCut kTOR860Cut;
+    extern const SpillCut kTOR875Cut;
 
-extern const SpillCut kTOR860;
-extern const SpillCut kTOR875;
-
-extern const SpillCut kLM875A;
-extern const SpillCut kLM875B;
-extern const SpillCut kLM875C;
-
-extern const SpillCut kHP875;
-extern const SpillCut kVP875;
-
-extern const SpillCut kHPTG1; 
-extern const SpillCut kVPTG1;
-
-extern const SpillCut kHPTG2;
-extern const SpillCut kVPTG2;
+    extern const SpillCut kLM875ACut;
+    extern const SpillCut kLM875BCut;
+    extern const SpillCut kLM875CCut;
 
 /*
-   This cut is left commented out since it is hard to implement but may be of
-   future use. See the BNBQualityCuts_<Nov2024, Jan2025>.cxx files for more
-   information. -- Jacob Smith
-
-extern const SpillCut kBTJT2; 
+    This cut is left commented out since it is hard to implement but may be of
+    future use. See the BNBQualityCuts.cxx for more information.
 */
+//     extern const SpillCut kBTJT2;
 
-extern const SpillCut kTHCURR;
+    extern const SpillCut kTHCURRCut;
 
-// ^--- INDIVIDUAL CUTS ; MASTER CUT ---v
+    // ^--- INDIVIDUAL CUTS ; COMBINATION CUTS ---v
 
-extern const SpillCut kBNBQuality_noBPMs_10Feb2025;
-extern const SpillCut kBNBQuality; // combination of individual cuts given above
-                                   // NB: NOT IN USE AS OF Feb. 10th, 2025
+    extern const SpillCut kBNBQualityCut;
 }

--- a/sbnana/SBNAna/Cuts/BNBQualityCuts.h
+++ b/sbnana/SBNAna/Cuts/BNBQualityCuts.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "sbnana/CAFAna/Core/Cut.h"
+
+namespace ana {
+
+extern const SpillCut kTOR860;
+extern const SpillCut kTOR875;
+
+extern const SpillCut kLM875A;
+extern const SpillCut kLM875B;
+extern const SpillCut kLM875C;
+
+extern const SpillCut kHP875;
+extern const SpillCut kVP875;
+
+extern const SpillCut kHPTG1; 
+extern const SpillCut kVPTG1;
+
+extern const SpillCut kHPTG2;
+extern const SpillCut kVPTG2;
+
+/*
+   This cut is left commented out since it is hard to implement but may be of
+   future use. See the BNBQualityCuts_<Nov2024, Jan2025>.cxx files for more
+   information. -- Jacob Smith
+
+extern const SpillCut kBTJT2; 
+*/
+
+extern const SpillCut kTHCURR;
+
+// ^--- INDIVIDUAL CUTS ; MASTER CUT ---v
+
+extern const SpillCut kBNBQuality_noBPMs_10Feb2025;
+extern const SpillCut kBNBQuality; // combination of individual cuts given above
+                                   // NB: NOT IN USE AS OF Feb. 10th, 2025
+}

--- a/sbnana/SBNAna/Cuts/BNBQualityCuts.h
+++ b/sbnana/SBNAna/Cuts/BNBQualityCuts.h
@@ -1,11 +1,10 @@
-///////////////////////////////////////////////////////////////////////////////
-// File: BNBQualityCuts.h                                                    //
-// Author: Jacob Smith (smithja)                                             //
-// Last edited: March 6th, 2025                                              //
-//                                                                           //
-// Header file to define all of the BNB Quality Cuts for the ICARUS          //
-// experiment.                                                               //
-///////////////////////////////////////////////////////////////////////////////
+//! ////////////////////////////////////////////////////////////////////////////
+//! @file: BNBQualityCuts.h                                                    
+//! @author: Jacob Smith (smithja)  
+//! @email: jacob.a.smith@stonybrook.edu                                           
+//!                                                                           
+//! @brief Header file to define BNB Quality Cuts for SBN experiments.
+//! ////////////////////////////////////////////////////////////////////////////
 
 #include "sbnana/CAFAna/Core/Cut.h"
 
@@ -17,15 +16,20 @@ namespace ana {
     extern const SpillCut kLM875BCut;
     extern const SpillCut kLM875CCut;
 
-/*
+/**
     This cut is left commented out since it is hard to implement but may be of
     future use. See the BNBQualityCuts.cxx for more information.
 */
-//     extern const SpillCut kBTJT2;
+//!    extern const SpillCut kBTJT2;
 
     extern const SpillCut kTHCURRCut;
 
-    // ^--- INDIVIDUAL CUTS ; COMBINATION CUTS ---v
+    //! Figure(s) of Merit: @see getBNBFoM.cxx (and getBNBFoM2.cxx) for details
+    extern const SpillCut kFoMCut; 
+    extern const SpillCut kFoM2Cut;
 
-    extern const SpillCut kBNBQualityCut;
+    //! ^--- INDIVIDUAL CUTS ; COMBINATION CUTS ---v
+
+    extern const SpillCut kBNBQualityCut_FoM1;
+    extern const SpillCut kBNBQualityCut_FoM2;
 }

--- a/sbnana/SBNAna/Vars/BNBVars.cxx
+++ b/sbnana/SBNAna/Vars/BNBVars.cxx
@@ -19,34 +19,8 @@
 #include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
 
 #include <iostream>
-#include <vector>
-#include <algorithm> //! for using reverse iterators
 
 namespace ana {
-    /** @struct FlatCAF variables in hdr.spillbnbinfo are logged for an event's
-     * triggering spill. As of July 16th, 2025, we were only able to populate
-     * the multi-wire fit parameters (from IFBeam) in hdr.bnbinfo, which logs
-     * information for all spills, including those that don't have a trigger.
-     * Use of this structure and a globally accessible vector is required to
-     * select triggering spills from hdr.bnbinfo.
-    */
-    struct SpillInfo {
-        float MW876HS, MW876VS, MW875HS, MW875VS;
-        unsigned int run, event;
-    };
-
-    static std::vector<SpillInfo> globalSpillInfo;
-
-    void FillSpillInfo(unsigned int run, const caf::Proxy<caf::SRBNBInfo> &info) {
-        globalSpillInfo.emplace_back();
-        globalSpillInfo.back().run = run;
-        globalSpillInfo.back().event = info.event;
-        globalSpillInfo.back().MW876HS = info.M876HS;
-        globalSpillInfo.back().MW876VS = info.M876VS;
-        globalSpillInfo.back().MW875HS = info.M875HS;
-        globalSpillInfo.back().MW875VS = info.M875VS;
-    }
-
     /** Multi-wire Readout Fit Parameters:
      * @note We determine beam width primarily by fitting gaussian curves to
      * multi-wire device data; we can also extract beam position from fits.
@@ -60,68 +34,16 @@ namespace ana {
     */
 
     /** @var kSpillMW875HorWidth */
-    const SpillVar kSpillMW875HorWidth([](const caf::SRSpillProxy *sr) {
-        if (sr->hdr.nbnbinfo) { //! non-zero nbnbinfo -> new subrun
-            globalSpillInfo.clear(); //! discard spills from previous subrun
-            for (const auto &bnbinfo: sr->hdr.bnbinfo) { //! fill in this event's
-                FillSpillInfo( sr->hdr.run, bnbinfo);    //!   spill information
-            }
-        }
-
-        //! Select last spill with matching event. This is the triggering spill.
-        for (auto it = globalSpillInfo.rbegin(); it != globalSpillInfo.rend(); ++it) {
-            if ( it->event != sr->hdr.evt) continue;
-            return SIMPLESPILLVAR( hdr.bnbinfo.M875HS);
-        }
-    });
+    const SpillVar kSpillMW875HorWidth = SIMPLESPILLVAR( hdr.spillbnbinfo.M875HS);
 
     /** @var kSpillMW875VerWidth */
-    const SpillVar kSpillMW875VerWidth([](const caf::SRSpillProxy *sr) {
-        if (sr->hdr.nbnbinfo) { //! non-zero nbnbinfo -> new subrun
-            globalSpillInfo.clear(); //! discard spills from previous subrun
-            for (const auto &bnbinfo: sr->hdr.bnbinfo) { //! fill in this event's
-                FillSpillInfo( sr->hdr.run, bnbinfo);    //!   spill information
-            }
-        }
-
-        //! Select last spill with matching event. This is the triggering spill.
-        for (auto it = globalSpillInfo.rbegin(); it != globalSpillInfo.rend(); ++it) {
-            if ( it->event != sr->hdr.evt) continue;
-            return SIMPLESPILLVAR( hdr.bnbinfo.M875VS);
-        }
-    });
+    const SpillVar kSpillMW875VerWidth = SIMPLESPILLVAR( hdr.spillbnbinfo.M875VS);
 
     /** @var kSpillMW876HorWidth */
-    const SpillVar kSpillMW876HorWidth([](const caf::SRSpillProxy *sr) {
-        if (sr->hdr.nbnbinfo) { //! non-zero nbnbinfo -> new subrun
-            globalSpillInfo.clear(); //! discard spills from previous subrun
-            for (const auto &bnbinfo: sr->hdr.bnbinfo) { //! fill in this event's
-                FillSpillInfo( sr->hdr.run, bnbinfo);    //!   spill information
-            }
-        }
-
-        //! Select last spill with matching event. This is the triggering spill.
-        for (auto it = globalSpillInfo.rbegin(); it != globalSpillInfo.rend(); ++it) {
-            if ( it->event != sr->hdr.evt) continue;
-            return SIMPLESPILLVAR( hdr.bnbinfo.M876HS);
-        }
-    });
+    const SpillVar kSpillMW876HorWidth = SIMPLESPILLVAR( hdr.spillbnbinfo.M876HS);
 
     /** @var kSpillMW876VerWidth */
-    const SpillVar kSpillMW876VerWidth([](const caf::SRSpillProxy *sr) {
-        if (sr->hdr.nbnbinfo) { //! non-zero nbnbinfo -> new subrun
-            globalSpillInfo.clear(); //! discard spills from previous subrun
-            for (const auto &bnbinfo: sr->hdr.bnbinfo) { //! fill in this event's
-                FillSpillInfo( sr->hdr.run, bnbinfo);    //!   spill information
-            }
-        }
-
-        //! Select last spill with matching event. This is the triggering spill.
-        for (auto it = globalSpillInfo.rbegin(); it != globalSpillInfo.rend(); ++it) {
-            if ( it->event != sr->hdr.evt) continue;
-            return SIMPLESPILLVAR( hdr.bnbinfo.M876VS);
-        }
-    });
+    const SpillVar kSpillMW876VerWidth = SIMPLESPILLVAR( hdr.spillbnbinfo.M876VS);
 
     //! ////////////////////////////////////////////////////////////////////////
     //!   ^--- Multi-wire Fit Parameters ; Other BNB Variables ---v

--- a/sbnana/SBNAna/Vars/BNBVars.cxx
+++ b/sbnana/SBNAna/Vars/BNBVars.cxx
@@ -1,0 +1,63 @@
+///////////////////////////////////////////////////////////////////////////////
+// File: BNBVars.cxx                                                         //
+// Author: Jacob Smith (smithja)                                             //
+// Last edited: February 12th, 2025                                          //
+//                                                                           //
+// Explicit definitions of the variables used in BNB Quality Cuts for the    //
+// ICARUS experiment. These SpillVars are declared with Bruce Howard's       //
+// SIMPLESPILLVAR() function allowing SpillCuts to be easily integrated with //
+// creating Spectra (like what is done with regular Cuts).                   //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "sbnana/SBNAna/Vars/BNBVars.h"
+
+#include "sbnana/CAFAna/Core/Utilities.h"
+#include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
+
+#include <iostream>
+
+namespace ana
+{
+    // readout time for a given spill
+    // units: s (i.e. seconds)
+    const SpillVar kSpillTimeSec = SIMPLESPILLVAR( hdr.spillbnbinfo.spill_time_sec);
+
+    // toroid devices: monitor protons on target (POT)
+    // units: POT
+    const SpillVar kSpillTOR860 = SIMPLESPILLVAR( hdr.spillbnbinfo.TOR860);
+    const SpillVar kSpillTOR875 = SIMPLESPILLVAR( hdr.spillbnbinfo.TOR875);
+    
+    // loss monitors: measure backscattering of beam just upstream of target
+    // NB: larger reading is better, implies beam is hitting more of target
+    // units: rad / s (i.e. rads per second)
+    const SpillVar kSpillLM875A = SIMPLESPILLVAR( hdr.spillbnbinfo.LM875A);
+    const SpillVar kSpillLM875B = SIMPLESPILLVAR( hdr.spillbnbinfo.LM875B);
+    const SpillVar kSpillLM875C = SIMPLESPILLVAR( hdr.spillbnbinfo.LM875C);
+    
+    // beam position monitors: measure beam position at different points upstream
+    // of target
+    // NB: not always centered at (0, 0); check SBNAna/Cuts/BNBQualityCuts.cxx
+    //     for information on nominal beam position for different runs
+    // units: mm
+    const SpillVar kSpillHP875 = SIMPLESPILLVAR( hdr.spillbnbinfo.HP875);
+    const SpillVar kSpillVP875 = SIMPLESPILLVAR( hdr.spillbnbinfo.VP875);
+   
+    const SpillVar kSpillHPTG1 = SIMPLESPILLVAR( hdr.spillbnbinfo.HPTG1);
+    const SpillVar kSpillVPTG1 = SIMPLESPILLVAR( hdr.spillbnbinfo.VPTG1);
+
+    const SpillVar kSpillHPTG2 = SIMPLESPILLVAR( hdr.spillbnbinfo.HPTG2);
+    const SpillVar kSpillVPTG2 = SIMPLESPILLVAR( hdr.spillbnbinfo.VPTG2);
+ 
+    // DEPRECIATED, SEE NB
+    // temperature reading near target
+    // NB: this beam monitoring device provided diminishing returns when combined
+    //     with all of the other devices listed here. additionally, temperature
+    //     readings can be correlated between spills if they are close enough in
+    //     time
+    // units: degrees celsius
+//    const SpillVar kSpillBTJT2 = SIMPLESPILLVAR( hdr.spillbnbinfo.BTJT2);
+    
+    // focusing horn current
+    // units: kA
+    const SpillVar kSpillTHCURR = SIMPLESPILLVAR( hdr.spillbnbinfo.THCURR);
+}

--- a/sbnana/SBNAna/Vars/BNBVars.cxx
+++ b/sbnana/SBNAna/Vars/BNBVars.cxx
@@ -22,28 +22,28 @@
 
 namespace ana {
     /** Multi-wire Readout Fit Parameters:
-     * @note We determine beam width primarily by fitting gaussian curves to
+     * @note We determine beam sigma primarily by fitting gaussian curves to
      * multi-wire device data; we can also extract beam position from fits.
      * Beam position should be taken from beam position monitor variables
      * above, but can be taken from below if needed.
      *
-     * @note Widths and positions provided for both horizontal and vertical
+     * @note Sigmas and positions provided for both horizontal and vertical
      * directions perpendicular to the beam direction.
      * 
      * units: mm
     */
 
-    /** @var kSpillMW875HorWidth */
-    const SpillVar kSpillMW875HorWidth = SIMPLESPILLVAR( hdr.spillbnbinfo.M875HS);
+    /** @var kSpillMW875HorSigma */
+    const SpillVar kSpillMW875HorSigma = SIMPLESPILLVAR( hdr.spillbnbinfo.M875HS);
 
-    /** @var kSpillMW875VerWidth */
-    const SpillVar kSpillMW875VerWidth = SIMPLESPILLVAR( hdr.spillbnbinfo.M875VS);
+    /** @var kSpillMW875VerSigma */
+    const SpillVar kSpillMW875VerSigma = SIMPLESPILLVAR( hdr.spillbnbinfo.M875VS);
 
-    /** @var kSpillMW876HorWidth */
-    const SpillVar kSpillMW876HorWidth = SIMPLESPILLVAR( hdr.spillbnbinfo.M876HS);
+    /** @var kSpillMW876HorSigma */
+    const SpillVar kSpillMW876HorSigma = SIMPLESPILLVAR( hdr.spillbnbinfo.M876HS);
 
-    /** @var kSpillMW876VerWidth */
-    const SpillVar kSpillMW876VerWidth = SIMPLESPILLVAR( hdr.spillbnbinfo.M876VS);
+    /** @var kSpillMW876VerSigma */
+    const SpillVar kSpillMW876VerSigma = SIMPLESPILLVAR( hdr.spillbnbinfo.M876VS);
 
     //! ////////////////////////////////////////////////////////////////////////
     //!   ^--- Multi-wire Fit Parameters ; Other BNB Variables ---v
@@ -201,17 +201,17 @@ namespace ana {
         double kSpillHPTG2Val         = kSpillHPTG2(sr);
         double kSpillVP873Val         = kSpillVP873(sr);
         double kSpillVP875Val         = kSpillVP875(sr);
-        double kSpillMW875HorWidthVal = kSpillMW875HorWidth(sr);
-        double kSpillMW875VerWidthVal = kSpillMW875VerWidth(sr);
-        double kSpillMW876HorWidthVal = kSpillMW876HorWidth(sr);
-        double kSpillMW876VerWidthVal = kSpillMW876VerWidth(sr);
+        double kSpillMW875HorSigmaVal = kSpillMW875HorSigma(sr);
+        double kSpillMW875VerSigmaVal = kSpillMW875VerSigma(sr);
+        double kSpillMW876HorSigmaVal = kSpillMW876HorSigma(sr);
+        double kSpillMW876VerSigmaVal = kSpillMW876VerSigma(sr);
 
         double fom2 = getBNBFoM2( kSpillTimeSecVal, 
             kSpillTOR860Val, kSpillTOR875Val,
             kSpillHP875Val, kSpillHPTG1Val, kSpillHPTG2Val,
             kSpillVP873Val, kSpillVP875Val,
-            kSpillMW875HorWidthVal, kSpillMW875VerWidthVal,
-            kSpillMW876HorWidthVal, kSpillMW876VerWidthVal
+            kSpillMW875HorSigmaVal, kSpillMW875VerSigmaVal,
+            kSpillMW876HorSigmaVal, kSpillMW876VerSigmaVal
         );
         return fom2;
     });

--- a/sbnana/SBNAna/Vars/BNBVars.cxx
+++ b/sbnana/SBNAna/Vars/BNBVars.cxx
@@ -173,14 +173,16 @@ namespace ana {
         //! Extract variables used in FoM calculations and cast as double
         //! for compatibility with getBNBFoM().
         double kSpillTimeSecVal = kSpillTimeSec(sr);
-        double kSpillTORVal     = kSpillTOR(sr);
+        double kSpillTOR860Val  = kSpillTOR860(sr);
+        double kSpillTOR875Val  = kSpillTOR875(sr);
         double kSpillHP875Val   = kSpillHP875(sr);
         double kSpillHPTG1Val   = kSpillHPTG1(sr);
         double kSpillHPTG2Val   = kSpillHPTG2(sr);
         double kSpillVP873Val   = kSpillVP873(sr);
         double kSpillVP875Val   = kSpillVP875(sr);
 
-        double fom = getBNBFoM( kSpillTimeSecVal, kSpillTORVal,
+        double fom = getBNBFoM( kSpillTimeSecVal, 
+            kSpillTOR860Val, kSpillTOR875Val,
             kSpillHP875Val, kSpillHPTG1Val, kSpillHPTG2Val,
             kSpillVP873Val, kSpillVP875Val);
         return fom;
@@ -192,7 +194,8 @@ namespace ana {
         //! Extract variables used in FoM calculations and cast as double
         //! for compatibility with getBNBFoM2().
         double kSpillTimeSecVal       = kSpillTimeSec(sr);
-        double kSpillTORVal           = kSpillTOR(sr);
+        double kSpillTOR860Val        = kSpillTOR860(sr);
+        double kSpillTOR875Val        = kSpillTOR875(sr);
         double kSpillHP875Val         = kSpillHP875(sr);
         double kSpillHPTG1Val         = kSpillHPTG1(sr);
         double kSpillHPTG2Val         = kSpillHPTG2(sr);
@@ -203,7 +206,8 @@ namespace ana {
         double kSpillMW876HorWidthVal = kSpillMW876HorWidth(sr);
         double kSpillMW876VerWidthVal = kSpillMW876VerWidth(sr);
 
-        double fom2 = getBNBFoM2( kSpillTimeSecVal, kSpillTORVal,
+        double fom2 = getBNBFoM2( kSpillTimeSecVal, 
+            kSpillTOR860Val, kSpillTOR875Val,
             kSpillHP875Val, kSpillHPTG1Val, kSpillHPTG2Val,
             kSpillVP873Val, kSpillVP875Val,
             kSpillMW875HorWidthVal, kSpillMW875VerWidthVal,

--- a/sbnana/SBNAna/Vars/BNBVars.cxx
+++ b/sbnana/SBNAna/Vars/BNBVars.cxx
@@ -1,63 +1,292 @@
-///////////////////////////////////////////////////////////////////////////////
-// File: BNBVars.cxx                                                         //
-// Author: Jacob Smith (smithja)                                             //
-// Last edited: February 12th, 2025                                          //
-//                                                                           //
-// Explicit definitions of the variables used in BNB Quality Cuts for the    //
-// ICARUS experiment. These SpillVars are declared with Bruce Howard's       //
-// SIMPLESPILLVAR() function allowing SpillCuts to be easily integrated with //
-// creating Spectra (like what is done with regular Cuts).                   //
-///////////////////////////////////////////////////////////////////////////////
+//! ////////////////////////////////////////////////////////////////////////////
+//!  @file: BNBVars.cxx
+//!  @author: Jacob Smith (smithja)
+//!  @email: jacob.a.smith@stonybrook.edu
+//!
+//!  @brief Explicit definitions of variables used in BNB Quality Cuts for the
+//!  ICARUS experiment. 
+//!  
+//!  @details Most SpillVars here are declared with Bruce Howard's
+//!  SIMPLESPILLVAR() function allowing SpillVars to be easily integrated with
+//!  creating Spectra (like what is done with regular Vars). Other composite
+//!  SpillVars are created and some SpillVars have aliases.
+//! ////////////////////////////////////////////////////////////////////////////
 
 #include "sbnana/SBNAna/Vars/BNBVars.h"
+#include "sbnana/SBNAna/Vars/getBNBFoM.h"
 
 #include "sbnana/CAFAna/Core/Utilities.h"
 #include "sbnanaobj/StandardRecord/Proxy/SRProxy.h"
 
 #include <iostream>
+#include <vector>
+#include <algorithm> //! for using reverse iterators
 
-namespace ana
-{
-    // readout time for a given spill
-    // units: s (i.e. seconds)
+namespace ana {
+    /** @struct FlatCAF variables in hdr.spillbnbinfo are logged for an event's
+     * triggering spill. As of July 16th, 2025, we were only able to populate
+     * the multi-wire fit parameters (from IFBeam) in hdr.bnbinfo, which logs
+     * information for all spills, including those that don't have a trigger.
+     * Use of this structure and a globally accessible vector is required to
+     * select triggering spills from hdr.bnbinfo.
+    */
+    struct SpillInfo {
+        float MW876HS, MW876VS, MW875HS, MW875VS;
+        unsigned int run, event;
+    };
+
+    static std::vector<SpillInfo> globalSpillInfo;
+
+    void FillSpillInfo(unsigned int run, const caf::Proxy<caf::SRBNBInfo> &info) {
+        globalSpillInfo.emplace_back();
+        globalSpillInfo.back().run = run;
+        globalSpillInfo.back().event = info.event;
+        globalSpillInfo.back().MW876HS = info.M876HS;
+        globalSpillInfo.back().MW876VS = info.M876VS;
+        globalSpillInfo.back().MW875HS = info.M875HS;
+        globalSpillInfo.back().MW875VS = info.M875VS;
+    }
+
+    /** Multi-wire Readout Fit Parameters:
+     * @note We determine beam width primarily by fitting gaussian curves to
+     * multi-wire device data; we can also extract beam position from fits.
+     * Beam position should be taken from beam position monitor variables
+     * above, but can be taken from below if needed.
+     *
+     * @note Widths and positions provided for both horizontal and vertical
+     * directions perpendicular to the beam direction.
+     * 
+     * units: mm
+    */
+
+    /** @var kSpillMW875HorWidth */
+    const SpillVar kSpillMW875HorWidth([](const caf::SRSpillProxy *sr) {
+        if (sr->hdr.nbnbinfo) { //! non-zero nbnbinfo -> new subrun
+            globalSpillInfo.clear(); //! discard spills from previous subrun
+            for (const auto &bnbinfo: sr->hdr.bnbinfo) { //! fill in this event's
+                FillSpillInfo( sr->hdr.run, bnbinfo);    //!   spill information
+            }
+        }
+
+        //! Select last spill with matching event. This is the triggering spill.
+        for (auto it = globalSpillInfo.rbegin(); it != globalSpillInfo.rend(); ++it) {
+            if ( it->event != sr->hdr.evt) continue;
+            return SIMPLESPILLVAR( hdr.bnbinfo.M875HS);
+        }
+    });
+
+    /** @var kSpillMW875VerWidth */
+    const SpillVar kSpillMW875VerWidth([](const caf::SRSpillProxy *sr) {
+        if (sr->hdr.nbnbinfo) { //! non-zero nbnbinfo -> new subrun
+            globalSpillInfo.clear(); //! discard spills from previous subrun
+            for (const auto &bnbinfo: sr->hdr.bnbinfo) { //! fill in this event's
+                FillSpillInfo( sr->hdr.run, bnbinfo);    //!   spill information
+            }
+        }
+
+        //! Select last spill with matching event. This is the triggering spill.
+        for (auto it = globalSpillInfo.rbegin(); it != globalSpillInfo.rend(); ++it) {
+            if ( it->event != sr->hdr.evt) continue;
+            return SIMPLESPILLVAR( hdr.bnbinfo.M875VS);
+        }
+    });
+
+    /** @var kSpillMW876HorWidth */
+    const SpillVar kSpillMW876HorWidth([](const caf::SRSpillProxy *sr) {
+        if (sr->hdr.nbnbinfo) { //! non-zero nbnbinfo -> new subrun
+            globalSpillInfo.clear(); //! discard spills from previous subrun
+            for (const auto &bnbinfo: sr->hdr.bnbinfo) { //! fill in this event's
+                FillSpillInfo( sr->hdr.run, bnbinfo);    //!   spill information
+            }
+        }
+
+        //! Select last spill with matching event. This is the triggering spill.
+        for (auto it = globalSpillInfo.rbegin(); it != globalSpillInfo.rend(); ++it) {
+            if ( it->event != sr->hdr.evt) continue;
+            return SIMPLESPILLVAR( hdr.bnbinfo.M876HS);
+        }
+    });
+
+    /** @var kSpillMW876VerWidth */
+    const SpillVar kSpillMW876VerWidth([](const caf::SRSpillProxy *sr) {
+        if (sr->hdr.nbnbinfo) { //! non-zero nbnbinfo -> new subrun
+            globalSpillInfo.clear(); //! discard spills from previous subrun
+            for (const auto &bnbinfo: sr->hdr.bnbinfo) { //! fill in this event's
+                FillSpillInfo( sr->hdr.run, bnbinfo);    //!   spill information
+            }
+        }
+
+        //! Select last spill with matching event. This is the triggering spill.
+        for (auto it = globalSpillInfo.rbegin(); it != globalSpillInfo.rend(); ++it) {
+            if ( it->event != sr->hdr.evt) continue;
+            return SIMPLESPILLVAR( hdr.bnbinfo.M876VS);
+        }
+    });
+
+    //! ////////////////////////////////////////////////////////////////////////
+    //!   ^--- Multi-wire Fit Parameters ; Other BNB Variables ---v
+    //! ////////////////////////////////////////////////////////////////////////
+
+    //! Readout time for a given spill.
+    //! units: s (i.e. seconds)
+
+    /** @var kSpillTimeSec */
     const SpillVar kSpillTimeSec = SIMPLESPILLVAR( hdr.spillbnbinfo.spill_time_sec);
 
-    // toroid devices: monitor protons on target (POT)
-    // units: POT
-    const SpillVar kSpillTOR860 = SIMPLESPILLVAR( hdr.spillbnbinfo.TOR860);
-    const SpillVar kSpillTOR875 = SIMPLESPILLVAR( hdr.spillbnbinfo.TOR875);
-    
-    // loss monitors: measure backscattering of beam just upstream of target
-    // NB: larger reading is better, implies beam is hitting more of target
-    // units: rad / s (i.e. rads per second)
-    const SpillVar kSpillLM875A = SIMPLESPILLVAR( hdr.spillbnbinfo.LM875A);
-    const SpillVar kSpillLM875B = SIMPLESPILLVAR( hdr.spillbnbinfo.LM875B);
-    const SpillVar kSpillLM875C = SIMPLESPILLVAR( hdr.spillbnbinfo.LM875C);
-    
-    // beam position monitors: measure beam position at different points upstream
-    // of target
-    // NB: not always centered at (0, 0); check SBNAna/Cuts/BNBQualityCuts.cxx
-    //     for information on nominal beam position for different runs
-    // units: mm
-    const SpillVar kSpillHP875 = SIMPLESPILLVAR( hdr.spillbnbinfo.HP875);
-    const SpillVar kSpillVP875 = SIMPLESPILLVAR( hdr.spillbnbinfo.VP875);
-   
-    const SpillVar kSpillHPTG1 = SIMPLESPILLVAR( hdr.spillbnbinfo.HPTG1);
-    const SpillVar kSpillVPTG1 = SIMPLESPILLVAR( hdr.spillbnbinfo.VPTG1);
 
+    //! Toroid Devices: monitor protons on target (POT)
+    //! units: POT
+
+    /** @var kSpillTOR860 */
+    const SpillVar kSpillTOR860 = SIMPLESPILLVAR( hdr.spillbnbinfo.TOR860);
+    /** @var kSpillTOR875 */
+    const SpillVar kSpillTOR875 = SIMPLESPILLVAR( hdr.spillbnbinfo.TOR875);
+
+
+    //! Use closest toroid device to target to get POT reading.
+
+    /** @var kSpillTOR */
+    const SpillVar kSpillTOR([](const caf::SRSpillProxy *sr) {
+        if (kSpillTOR875(sr) > 0) { //! use TOR875 if it has data
+            return kSpillTOR875(sr);
+        }
+        else { //! otherwise, use TOR860
+            return kSpillTOR860(sr);
+        }
+    });
+
+
+    //! Loss Monitors: measure backscattering of beam just upstream of target
+    //! 
+    //! @note higher reading is better, implies beam is hitting more of target
+    //!
+    //! units: rad / s (i.e. rads per second)
+
+    /** @var kSpillLM875A */
+    const SpillVar kSpillLM875A = SIMPLESPILLVAR( hdr.spillbnbinfo.LM875A);
+    /** @var kSpillLM875B */
+    const SpillVar kSpillLM875B = SIMPLESPILLVAR( hdr.spillbnbinfo.LM875B);
+    /** @var kSpillLM875C */
+    const SpillVar kSpillLM875C = SIMPLESPILLVAR( hdr.spillbnbinfo.LM875C);
+
+
+    //! Use closest loss monitor to the target to get back-scattering radiation
+    //! reading.
+
+    /** @var kSpillLM875 */
+    const SpillVar kSpillLM875([](const caf::SRSpillProxy *sr) {
+        if (kSpillLM875C(sr) > 0) {       //! use LM875C if it has data
+            return kSpillLM875C(sr);
+        }
+        else if (kSpillLM875B(sr) > 0) {  //! otherwise, use LM875B if it has data
+            return kSpillLM875B(sr);
+        }
+        else {
+            return kSpillLM875A(sr);      //! other-otherwise, default to LM875A
+        }
+    });
+
+
+    //! Beam Position Monitors: measure beam position at different points 
+    //! upstream of target
+    //!
+    //! @note not always centered at (0, 0); @see SBNAna/Cuts/BNBQualityCuts.cxx
+    //! for information on nominal beam position for different runs
+    //! 
+    //! @note VPTG1 and VPTG2 unreliable for ICARUS (and presumably SBND) runs;
+    //! VP873 identified as a suitable replacement
+    //! 
+    //! units: mm
+
+    /** @var kSpillVP873 */
+    const SpillVar kSpillVP873 = SIMPLESPILLVAR( hdr.spillbnbinfo.VP873);
+
+    /** @var kSpillHP875 */
+    const SpillVar kSpillHP875 = SIMPLESPILLVAR( hdr.spillbnbinfo.HP875);
+    /** @var kSpillVP875 */
+    const SpillVar kSpillVP875 = SIMPLESPILLVAR( hdr.spillbnbinfo.VP875);
+
+    /** @var kSpillHPTG1 */
+    const SpillVar kSpillHPTG1 = SIMPLESPILLVAR( hdr.spillbnbinfo.HPTG1);
+    /** @var kSpillVPTG1 */
+//!    const SpillVar kSpillVPTG1 = SIMPLESPILLVAR( hdr.spillbnbinfo.VPTG1);
+
+    /** @var kSpillHPTG2 */
     const SpillVar kSpillHPTG2 = SIMPLESPILLVAR( hdr.spillbnbinfo.HPTG2);
-    const SpillVar kSpillVPTG2 = SIMPLESPILLVAR( hdr.spillbnbinfo.VPTG2);
- 
-    // DEPRECIATED, SEE NB
-    // temperature reading near target
-    // NB: this beam monitoring device provided diminishing returns when combined
-    //     with all of the other devices listed here. additionally, temperature
-    //     readings can be correlated between spills if they are close enough in
-    //     time
-    // units: degrees celsius
-//    const SpillVar kSpillBTJT2 = SIMPLESPILLVAR( hdr.spillbnbinfo.BTJT2);
-    
-    // focusing horn current
-    // units: kA
+    /** @var kSpillVPTG2 */
+//!    const SpillVar kSpillVPTG2 = SIMPLESPILLVAR( hdr.spillbnbinfo.VPTG2);
+
+
+    //! @deprecated
+    //! Temperature reading near target.
+    //!
+    //! @note this beam monitoring device provided diminishing returns when 
+    //! combined with all of the other devices listed here. additionally, 
+    //! temperature readings can be correlated between spills if they are close 
+    //! enough in time
+    //!
+    //! units: degrees celsius
+
+    /** @var kSpillBTJT2 */
+//!    const SpillVar kSpillBTJT2 = SIMPLESPILLVAR( hdr.spillbnbinfo.BTJT2);
+
+
+    //! Focusing Horn Current
+    //! units: kA
+
+    /** @var kSpillTHCURR */
     const SpillVar kSpillTHCURR = SIMPLESPILLVAR( hdr.spillbnbinfo.THCURR);
+
+
+
+
+
+    //!/////////////////////////////////////////////////////////////////////////
+    //! Figure(s) of Merit: @see getBNBFoM.cxx (and getBNBFoM2.cxx) for details
+    //!/////////////////////////////////////////////////////////////////////////
+
+    //! @note This Figure of Merit DOES NOT take BNB width into account.
+    /** @var kSpillFoM */
+    const SpillVar kSpillFoM([](const caf::SRSpillProxy *sr) {
+        //! Extract variables used in FoM calculations and cast as double
+        //! for compatibility with getBNBFoM().
+        double kSpillTimeSecVal = kSpillTimeSec(sr);
+        double kSpillTORVal     = kSpillTOR(sr);
+        double kSpillHP875Val   = kSpillHP875(sr);
+        double kSpillHPTG1Val   = kSpillHPTG1(sr);
+        double kSpillHPTG2Val   = kSpillHPTG2(sr);
+        double kSpillVP873Val   = kSpillVP873(sr);
+        double kSpillVP875Val   = kSpillVP875(sr);
+
+        double fom = getBNBFoM( kSpillTimeSecVal, kSpillTORVal,
+            kSpillHP875Val, kSpillHPTG1Val, kSpillHPTG2Val,
+            kSpillVP873Val, kSpillVP875Val);
+        return fom;
+    });
+
+    //! @note This Figure of Merit DOES take BNB width into account.
+    /** @var kSpillFoM2 */
+    const SpillVar kSpillFoM2([](const caf::SRSpillProxy *sr) {
+        //! Extract variables used in FoM calculations and cast as double
+        //! for compatibility with getBNBFoM2().
+        double kSpillTimeSecVal       = kSpillTimeSec(sr);
+        double kSpillTORVal           = kSpillTOR(sr);
+        double kSpillHP875Val         = kSpillHP875(sr);
+        double kSpillHPTG1Val         = kSpillHPTG1(sr);
+        double kSpillHPTG2Val         = kSpillHPTG2(sr);
+        double kSpillVP873Val         = kSpillVP873(sr);
+        double kSpillVP875Val         = kSpillVP875(sr);
+        double kSpillMW875HorWidthVal = kSpillMW875HorWidth(sr);
+        double kSpillMW875VerWidthVal = kSpillMW875VerWidth(sr);
+        double kSpillMW876HorWidthVal = kSpillMW876HorWidth(sr);
+        double kSpillMW876VerWidthVal = kSpillMW876VerWidth(sr);
+
+        double fom2 = getBNBFoM2( kSpillTimeSecVal, kSpillTORVal,
+            kSpillHP875Val, kSpillHPTG1Val, kSpillHPTG2Val,
+            kSpillVP873Val, kSpillVP875Val,
+            kSpillMW875HorWidthVal, kSpillMW875VerWidthVal,
+            kSpillMW876HorWidthVal, kSpillMW876VerWidthVal
+        );
+        return fom2;
+    });
 }

--- a/sbnana/SBNAna/Vars/BNBVars.cxx
+++ b/sbnana/SBNAna/Vars/BNBVars.cxx
@@ -164,14 +164,14 @@ namespace ana {
 
 
     //!/////////////////////////////////////////////////////////////////////////
-    //! Figure(s) of Merit: @see getBNBFoM.cxx (and getBNBFoM2.cxx) for details
+    //! Figure(s) of Merit: @see getBNBFoM.cxx for details
     //!/////////////////////////////////////////////////////////////////////////
 
     //! @note This Figure of Merit DOES NOT take BNB width into account.
-    /** @var kSpillFoM */
-    const SpillVar kSpillFoM([](const caf::SRSpillProxy *sr) {
+    /** @var kSpillFoM_noMultiWire */
+    const SpillVar kSpillFoM_noMultiWire([](const caf::SRSpillProxy *sr) {
         //! Extract variables used in FoM calculations and cast as double
-        //! for compatibility with getBNBFoM().
+        //! for compatibility with getBNBFoM_noMultiWire().
         double kSpillTimeSecVal = kSpillTimeSec(sr);
         double kSpillTOR860Val  = kSpillTOR860(sr);
         double kSpillTOR875Val  = kSpillTOR875(sr);
@@ -181,7 +181,7 @@ namespace ana {
         double kSpillVP873Val   = kSpillVP873(sr);
         double kSpillVP875Val   = kSpillVP875(sr);
 
-        double fom = getBNBFoM( kSpillTimeSecVal, 
+        double fom = getBNBFoM_noMultiWire( kSpillTimeSecVal, 
             kSpillTOR860Val, kSpillTOR875Val,
             kSpillHP875Val, kSpillHPTG1Val, kSpillHPTG2Val,
             kSpillVP873Val, kSpillVP875Val);
@@ -189,10 +189,10 @@ namespace ana {
     });
 
     //! @note This Figure of Merit DOES take BNB width into account.
-    /** @var kSpillFoM2 */
-    const SpillVar kSpillFoM2([](const caf::SRSpillProxy *sr) {
+    /** @var kSpillFoM */
+    const SpillVar kSpillFoM([](const caf::SRSpillProxy *sr) {
         //! Extract variables used in FoM calculations and cast as double
-        //! for compatibility with getBNBFoM2().
+        //! for compatibility with getBNBFoM().
         double kSpillTimeSecVal       = kSpillTimeSec(sr);
         double kSpillTOR860Val        = kSpillTOR860(sr);
         double kSpillTOR875Val        = kSpillTOR875(sr);
@@ -206,13 +206,13 @@ namespace ana {
         double kSpillMW876HorSigmaVal = kSpillMW876HorSigma(sr);
         double kSpillMW876VerSigmaVal = kSpillMW876VerSigma(sr);
 
-        double fom2 = getBNBFoM2( kSpillTimeSecVal, 
+        double fom = getBNBFoM( kSpillTimeSecVal, 
             kSpillTOR860Val, kSpillTOR875Val,
             kSpillHP875Val, kSpillHPTG1Val, kSpillHPTG2Val,
             kSpillVP873Val, kSpillVP875Val,
             kSpillMW875HorSigmaVal, kSpillMW875VerSigmaVal,
             kSpillMW876HorSigmaVal, kSpillMW876VerSigmaVal
         );
-        return fom2;
+        return fom;
     });
 }

--- a/sbnana/SBNAna/Vars/BNBVars.h
+++ b/sbnana/SBNAna/Vars/BNBVars.h
@@ -1,0 +1,60 @@
+///////////////////////////////////////////////////////////////////////////////
+// File: BNBVars.h                                                           //
+// Author: Jacob Smith (smithja)                                             //
+// Last edited: February 12th, 2025                                          //
+//                                                                           //
+// Header file to define all of the variables used in BNB Quality Cuts for   //
+// the ICARUS experiment.                                                    //
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "sbnana/CAFAna/Core/MultiVar.h"
+#include "sbnana/CAFAna/Core/Var.h"
+#include "sbnana/CAFAna/Core/Cut.h"
+
+namespace ana
+{
+    // readout time for a given spill
+    // units: s (i.e. seconds)
+    extern const SpillVar kSpillTimeSec;
+
+    // toroid devices: monitor protons on target (POT)
+    // units: POT
+    extern const SpillVar kSpillTOR860;
+    extern const SpillVar kSpillTOR875;
+    
+    // loss monitors: measure backscattering of beam just upstream of target
+    // NB: larger reading is better, implies beam is hitting more of target
+    // units: rad / s (i.e. rads per second)
+    extern const SpillVar kSpillLM875A;
+    extern const SpillVar kSpillLM875B;
+    extern const SpillVar kSpillLM875C;
+    
+    // beam position monitors: measure beam position at different points upstream
+    // of target
+    // NB: not always centered at (0, 0); check SBNAna/Cuts/BNBQualityCuts.cxx
+    //     for information on nominal beam position for different runs
+    // units: mm
+    extern const SpillVar kSpillHP875;
+    extern const SpillVar kSpillVP875;
+    
+    extern const SpillVar kSpillHPTG1;
+    extern const SpillVar kSpillVPTG1;
+    
+    extern const SpillVar kSpillHPTG2;
+    extern const SpillVar kSpillVPTG2;
+    
+    // DEPRECIATED, SEE NB
+    // temperature reading near target
+    // NB: this beam monitoring device provided diminishing returns when combined
+    //     with all of the other devices listed here. additionally, temperature
+    //     readings can be correlated between spills if they are close enough in
+    //     time
+    // units: degrees celsius
+//    extern const SpillVar kSpillBTJT2;
+    
+    // focusing horn current
+    // units: kA
+    extern const SpillVar kSpillTHCURR;
+}

--- a/sbnana/SBNAna/Vars/BNBVars.h
+++ b/sbnana/SBNAna/Vars/BNBVars.h
@@ -65,17 +65,17 @@ namespace ana
     extern const SpillVar kSpillTHCURR;
 
     //! Multi-wire Readout Fit Parameters:
-    //! @note We determine beam width primarily by fitting gaussian curves to
+    //! @note We determine beam sigma primarily by fitting gaussian curves to
     //! multi-wire device data; we can also extract beam position from fits.
     //! Beam position should be taken from beam position monitor variables
     //! above, but can be taken from below if needed.
-    //! @note Widths and positions provided for both horizontal and vertical
+    //! @note Sigmas and positions provided for both horizontal and vertical
     //! directions perpendicular to the beam direction.
     //! units: mm
-    extern const SpillVar kSpillMW875HorWidth;
-    extern const SpillVar kSpillMW875VerWidth;
-    extern const SpillVar kSpillMW876HorWidth;
-    extern const SpillVar kSpillMW876VerWidth;
+    extern const SpillVar kSpillMW875HorSigma;
+    extern const SpillVar kSpillMW875VerSigma;
+    extern const SpillVar kSpillMW876HorSigma;
+    extern const SpillVar kSpillMW876VerSigma;
 
     //! Figure(s) of Merit: @see getBNBFoM.cxx (and getBNBFoM2.cxx) for details
     extern const SpillVar kSpillFoM;

--- a/sbnana/SBNAna/Vars/BNBVars.h
+++ b/sbnana/SBNAna/Vars/BNBVars.h
@@ -1,11 +1,11 @@
-///////////////////////////////////////////////////////////////////////////////
-// File: BNBVars.h                                                           //
-// Author: Jacob Smith (smithja)                                             //
-// Last edited: February 12th, 2025                                          //
-//                                                                           //
-// Header file to define all of the variables used in BNB Quality Cuts for   //
-// the ICARUS experiment.                                                    //
-///////////////////////////////////////////////////////////////////////////////
+//! ////////////////////////////////////////////////////////////////////////////
+//! @file: BNBVars.h                                                           
+//! @author: Jacob Smith (smithja)
+//! @email: jacob.a.smith@stonybrook.edu                                       
+//!                                                                           
+//! @brief Header file to define variables used in BNB Quality Cuts for the 
+//! SBN experiments.                                                    
+//! ////////////////////////////////////////////////////////////////////////////
 
 #pragma once
 
@@ -15,46 +15,69 @@
 
 namespace ana
 {
-    // readout time for a given spill
-    // units: s (i.e. seconds)
+    //! Readout time for a given spill.
+    //! units: s (i.e. seconds)
     extern const SpillVar kSpillTimeSec;
 
-    // toroid devices: monitor protons on target (POT)
-    // units: POT
+    //! Toroid Devices: monitor protons on target (POT)
+    //! units: POT
     extern const SpillVar kSpillTOR860;
     extern const SpillVar kSpillTOR875;
+    extern const SpillVar kSpillTOR;
     
-    // loss monitors: measure backscattering of beam just upstream of target
-    // NB: larger reading is better, implies beam is hitting more of target
-    // units: rad / s (i.e. rads per second)
+    //! Loss Monitors: measure backscattering of beam just upstream of target
+    //! @note larger reading is better, implies beam is hitting more of target
+    //! units: rad / s (i.e. rads per second)
     extern const SpillVar kSpillLM875A;
     extern const SpillVar kSpillLM875B;
     extern const SpillVar kSpillLM875C;
-    
-    // beam position monitors: measure beam position at different points upstream
-    // of target
-    // NB: not always centered at (0, 0); check SBNAna/Cuts/BNBQualityCuts.cxx
-    //     for information on nominal beam position for different runs
-    // units: mm
+    extern const SpillVar kSpillLM875;
+
+    //! Beam Position Monitors: measure beam position at different points
+    //! upstream of target
+    //! @note not always centered at (0, 0); @see SBNAna/Cuts/BNBQualityCuts.cxx
+    //! for information on nominal beam position for different runs
+    //! @note VPTG1 and VPTG2 unreliable for ICARUS (and presumably SBND) runs;
+    //! VP873 identified as a suitable replacement
+    //! units: mm
     extern const SpillVar kSpillHP875;
     extern const SpillVar kSpillVP875;
     
     extern const SpillVar kSpillHPTG1;
-    extern const SpillVar kSpillVPTG1;
+ //!   extern const SpillVar kSpillVPTG1;
     
     extern const SpillVar kSpillHPTG2;
-    extern const SpillVar kSpillVPTG2;
+ //!   extern const SpillVar kSpillVPTG2;
+
+    extern const SpillVar kSpillVP873;
+
+    //! @deprecated
+    //! Temperature reading near target.
+    //! @note this beam monitoring device provided diminishing returns when 
+    //! combined with all of the other devices listed here. additionally, 
+    //! temperature readings can be correlated between spills if they are close 
+    //! enough in time
+    //! units: degrees celsius
+//!    extern const SpillVar kSpillBTJT2;
     
-    // DEPRECIATED, SEE NB
-    // temperature reading near target
-    // NB: this beam monitoring device provided diminishing returns when combined
-    //     with all of the other devices listed here. additionally, temperature
-    //     readings can be correlated between spills if they are close enough in
-    //     time
-    // units: degrees celsius
-//    extern const SpillVar kSpillBTJT2;
-    
-    // focusing horn current
-    // units: kA
+    //! Focusing Horn Current
+    //! units: kA
     extern const SpillVar kSpillTHCURR;
+
+    //! Multi-wire Readout Fit Parameters:
+    //! @note We determine beam width primarily by fitting gaussian curves to
+    //! multi-wire device data; we can also extract beam position from fits.
+    //! Beam position should be taken from beam position monitor variables
+    //! above, but can be taken from below if needed.
+    //! @note Widths and positions provided for both horizontal and vertical
+    //! directions perpendicular to the beam direction.
+    //! units: mm
+    extern const SpillVar kSpillMW875HorWidth;
+    extern const SpillVar kSpillMW875VerWidth;
+    extern const SpillVar kSpillMW876HorWidth;
+    extern const SpillVar kSpillMW876VerWidth;
+
+    //! Figure(s) of Merit: @see getBNBFoM.cxx (and getBNBFoM2.cxx) for details
+    extern const SpillVar kSpillFoM;
+    extern const SpillVar kSpillFoM2;
 }

--- a/sbnana/SBNAna/Vars/BNBVars.h
+++ b/sbnana/SBNAna/Vars/BNBVars.h
@@ -77,7 +77,7 @@ namespace ana
     extern const SpillVar kSpillMW876HorSigma;
     extern const SpillVar kSpillMW876VerSigma;
 
-    //! Figure(s) of Merit: @see getBNBFoM.cxx (and getBNBFoM2.cxx) for details
+    //! Figure(s) of Merit: @see getBNBFoM.cxx for details
+    extern const SpillVar kSpillFoM_noMultiWire;
     extern const SpillVar kSpillFoM;
-    extern const SpillVar kSpillFoM2;
 }

--- a/sbnana/SBNAna/Vars/getBNBFoM.cxx
+++ b/sbnana/SBNAna/Vars/getBNBFoM.cxx
@@ -851,7 +851,7 @@ Double_t getBNBFoM2( const Double_t spillTimeSec,
     }
     else { 
         //! @warning defaulting to Figure of Merit without multi-wire data
-        std::cerr << "[WARNING] No reliable multi-wire data, defaulting to calcFoM()." << std::endl;
+        std::cerr << "[WARNING] No reliable multi-wire data, defaulting to calcFoM(), which does not make use of BNB width data via multi-wire devices." << std::endl;
         return calcFoM( tgtHorPos, horAng, tgtVerPos, verAng, TOR);
     }
 

--- a/sbnana/SBNAna/Vars/getBNBFoM.cxx
+++ b/sbnana/SBNAna/Vars/getBNBFoM.cxx
@@ -19,8 +19,9 @@
 //! suite referenced in the above files that makes its way into FoM calculations.
 //! ////////////////////////////////////////////////////////////////////////////
 
-bool debug = false; //! displays helpful output for debugging; must recompile
-                    //! SBNAna for change to take affect.
+//! @note You must recompile SBNAna after makeing any changes to this file.
+bool verbose = false; //! displays details about function execution
+bool debug = false; //! displays helpful output for debugging
 
 #include "getBNBFoM.h"
 
@@ -977,7 +978,11 @@ Double_t getBNBFoM2( const Double_t spillTimeSec,
     }
     else { 
         //! @warning defaulting to Figure of Merit without multi-wire data
-        std::cerr << "[WARNING] No reliable multi-wire data, defaulting to calcFoM(), which does not make use of BNB width data via multi-wire devices." << std::endl;
+        if (verbose) {
+            std::cerr << "[WARNING] No reliable multi-wire data, defaulting ";
+            std::cerr << "[WARNING] to calcFoM(), which does not make use of BNB width ";
+            std::cerr << "[WARNING] data via multi-wire devices." << std::endl;
+        }
         Double_t fom = 1 - pow(10, calcFoM( tgtHorPos, horAng, tgtVerPos, verAng, TOR));
         return fom;
     }

--- a/sbnana/SBNAna/Vars/getBNBFoM.cxx
+++ b/sbnana/SBNAna/Vars/getBNBFoM.cxx
@@ -1,0 +1,889 @@
+//! ////////////////////////////////////////////////////////////////////////////
+//! @file: getBNBFoM.cxx
+//! @author: Jacob Smith (smithja)
+//! @email: jacob.a.smith@stonybrook.edu
+//!
+//! Special thanks to Zarko Pavlovic (zarko) and Joseph Zennamo (jaz8600) for
+//! helping me understand the MicroBooNE code which this script is based off of.
+//!
+//! @note This code is almost entirely based off MicroBooNE's getFOM2 code in 
+//! the ubraw GitHub repo. How we calculate our Figure of Merit (FoM) is almost
+//! identical to what's done in getFOM2.cxx. See below for further details.
+//!
+//! @details Calculates the Booster Neutrino Beam (BNB) Figure of Merit (FoM),
+//! which is a score on the interval [0, 1] that acts as a measure of the 
+//! geometric overlap of the BNB with the beamline's nuclear target. There are 
+//! separate cuts placed on the protons per pulse (PPP) and horn current in the 
+//! BNBVars<.h, .cxx> and BNBQualityCuts<.h, .cxx> files. The PPP––via 
+//! kSpillTOR875 (and secondarily kSpillTOR876)-––is the only quantity from the
+//! suite referenced in the above files that makes its way into FoM calculations.
+//! ////////////////////////////////////////////////////////////////////////////
+#include "getBNBFoM.h"
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include <iostream>
+#include <math.h>
+#include <stdexcept>
+
+#include "TROOT.h"
+#include "TH1D.h"
+#include "TF1.h"
+
+
+/** @struct OffsetData Holds the timestamped calibration positions of Beam
+ * Position Monitors.
+ */
+struct OffsetData {
+    std::vector<int> Times; //! non-leap seconds since UNIX epoch
+    std::vector<Double_t> Vals; //! transverse distance from BNB beamline [mm]
+};
+
+std::unordered_map<std::string, OffsetData> offsets = {
+    {"HP875", {
+        { 1420092000, 1574190445, 1576014670, 1588603117, 1605634657, 
+            1606510357, 1608593857, 1668802510, 1711030691 },
+        { -3.40, -1.20, -1.20, -3.33, -1.20, 0.75, -2.40, -5.53, -3.42 }
+    }},
+    {"VP875", {
+        { 1420092000, 1574190445, 1576014670, 1588603117, 1605634657, 
+            1606510357, 1608070057, 1608593857, 1612921957 },
+        { 1.48, 1.30, 1.30, 1.43, 1.30, -0.34, -3.60, 2.40, -0.70 }
+    }},
+    {"HPTG1", {
+        { 1420092000, 1576014670, 1606510357, 1677887110, 1711030691 },
+        { 0.46, 0.0, -2.15, -1.16, -0.03 }
+    }},
+    {"VPTG1", {
+        { 1420092000, 1576014670, 1588603117, 1605706657, 1606510357,
+            1608070057, 1608593857 },
+        { 0.39, -0.10, 0.0, -0.10, -4.53, -7.50, -4.70 }
+    }},
+    {"HPTG2", {
+        { 1420092000, 1574190444, 1576014670, 1588603117, 1605706657, 
+            1606510357, 1608593857, 1668802510 },
+        { 1.07, -0.40, -0.40, 0.0, -0.40, -2.31, 0.0, -0.84 }
+    }},
+    {"VPTG2", {
+        { 1420092000, 1572899153, 1574190445, 1576014670, 1588603117,
+            1605706657, 1606510357, 1612798657, 1612921957 },
+        { 1.84, -3.15, 0.10, 0.10, 0.0, 0.10, 0.82, 0.0, 0.80 }
+    }},
+    {"VP873", {
+        { 1615250280, 1734021000, 1734034620 },
+        { 3.4, 12, 2.8 }
+    }}
+};
+
+//! Position of beam-monitoring device along the direction of the 
+//! beamline, i.e. z-position [mm].
+Double_t VP873ZPos         = 1911.53656;
+Double_t mw875ZPos         = 2018.20648;
+Double_t HP875ZPos         = 2021.16104;
+Double_t VP875ZPos         = 2023.193205;
+Double_t mw876ZPos         = 2029.66766;
+Double_t HPTG1ZPos         = 2048.33267;
+Double_t HPTG2ZPos         = 2052.40662;
+Double_t targetCenterZPos  = 2068.70895;
+
+//! Numbers for beam width measurements from M875BB and M876BB.
+//! These are used in 0th, 1st, and 2nd order expansions when
+//! determining beam width quantities.
+//! Study done by Zarko Pavlovic (zarko) to obtain these numbers.
+//! How he or others arived at these numbers and what they represent is unknown.
+//! But given the low 2nd-order expansion coefficents, it's unlikely this study
+//! will ever need to be repeated.
+std::vector<Double_t> p875x = { 0.431857, 0.158077, 0.00303551};
+std::vector<Double_t> p875y = { 0.279128, 0.337048, 0};
+std::vector<Double_t> p876x = { 0.166172, 0.30999,  -0.00630299};
+std::vector<Double_t> p876y = { 0.13425,  0.580862, 0};
+
+/** @fn expandWidth()
+ * @brief Utilizing BNB studies (see notes around p876x, etc.), calculate
+ * the BNB width at the nuclear target up to an N-th order expansion
+ * @return BNB width at the nuclear target
+ */
+static std::optional<Double_t> expandWidth(const Double_t width, const std::vector<Double_t>& coeff, const size_t N) {
+    if (N > coeff.size()) {
+        std::cerr << "[WARN] Requested expansion order " << N 
+                  << " exceeds number of coefficients (" << coeff.size() 
+                  << ")." << std::endl;
+        return std::nullopt;
+    }
+    Double_t result = coeff[0];
+    for (size_t i = 1; i < N; ++i) {
+        result += coeff[i] * std::pow(width, i);
+    }
+    return result;
+}
+
+/** @fn isReasonable()
+ * @brief tests if a BNB width is within the given bounds
+ * @return boolean indicating if given width is within given bounds
+ */
+static bool isReasonable( const Double_t width, const Double_t lower, const Double_t upper) {
+    if ( width >= lower && width <= upper) return true;
+    return false;
+}
+
+/** @fn getValidBPMCalibVal()
+ * @brief Return the latest calibration value before or at a given timestamp for
+ * a specific device.
+ * 
+ * @param timestamp UNIX-formatted timestamp [s].
+ * @param device The name of the beam monitoring device.
+ * 
+ * @return Optional value: for given timestamp, most recent valid calibration 
+ * value [mm] (or std::nullopt).
+ */
+std::optional<Double_t> getValidBPMCalibVal(const int& timestamp,
+                                        const std::string& device) {
+    const auto& times = offsets.at(device).Times;
+    const auto& vals  = offsets.at(device).Vals;
+
+    //! Find the first index where times[i] > timestamp
+    //! The last time <= timestamp is then at index (i - 1), if i != 0
+    auto it = std::upper_bound(times.begin(), times.end(), timestamp);
+
+    if (it == times.begin()) {
+        return std::nullopt; //! No value at or before timestamp
+    } 
+
+    int idx = std::distance(times.begin(), it) - 1;
+    return vals[idx]; //! Latest valid value
+}
+
+/** @fn getValidBPMCalibTime()
+ * @brief Return the latest timestamp of a calibration value before or at a 
+ * given timestamp for a specific device.
+ * 
+ * @param timestamp UNIX-formatted timestamp [s].
+ * @param device The name of the beam monitoring device.
+ * 
+ * @return Optional value: for given timestamp, most recent timestamp of a 
+ * valid calibration value [mm] (or std::nullopt).
+ */
+std::optional<Double_t> getValidBPMCalibTime(const int& timestamp,
+                                        const std::string& device) {
+    const auto& times = offsets.at(device).Times;
+
+    //! Find the first index where times[i] > timestamp
+    //! The last time <= timestamp is then at index (i - 1), if i != 0
+    auto it = std::upper_bound(times.begin(), times.end(), timestamp);
+
+    if (it == times.begin()) {
+        return std::nullopt; //! No valid value at or before timestamp
+    } 
+
+    int idx = std::distance(times.begin(), it) - 1;
+    return times[idx]; //! Latest timestamp for a valid value
+}
+
+/** @fn swimBNB()
+ * @brief Propagate beam centroid and sigma matrix through transfer matrices.
+ *
+ * @param centroid1 Input centroid (6-vector)
+ * @param sigma1 Input sigma matrix (6x6)
+ * @param xferc Transfer matrix for centroid
+ * @param xfers Transfer matrix for sigma
+ * @param cx Output centroid x [mm]
+ * @param cy Output centroid y [mm]
+ * @param sx Output beam sigma-x [mm]
+ * @param sy Output beam sigma-y [mm]
+ * @param rho Output beam correlation coefficient
+ * 
+ * @post Beam centriod and sigma parameters as well as beam correlation 
+ * coefficent are modifed in the body of calcFoM() or @calcFoM2()
+ */
+void swimBNB(const Double_t centroid1[6], 
+                const Double_t sigma1[6][6],
+                const Double_t xferc[6][6], 
+                const Double_t xfers[6][6],
+                Double_t& cx, 
+                Double_t& cy, 
+                Double_t& sx, 
+                Double_t& sy, 
+                Double_t& rho) {
+    Double_t centroid2[6] = {0};
+    for (unsigned int i = 0; i < 6; ++i)
+        for (unsigned int j = 0; j < 6; ++j)
+            centroid2[i] += xferc[i][j] * centroid1[j];
+
+    cx = centroid2[0];
+    cy = centroid2[2];
+
+    Double_t sigma2[6][6] = {{0}};
+    for (unsigned int i = 0; i < 6; ++i)
+        for (unsigned int j = 0; j < 6; ++j)
+            for (unsigned int k = 0; k < 6; ++k)
+                for (unsigned int m = 0; m < 6; ++m)
+                    sigma2[i][m] += xfers[i][j] * sigma1[j][k] * xfers[m][k];
+
+    sx = std::sqrt(sigma2[0][0]) * 1000.0;
+    sy = std::sqrt(sigma2[2][2]) * 1000.0;
+    rho = sigma2[0][2] / std::sqrt(sigma2[0][0] * sigma2[2][2]);
+}
+
+/** @fn funcIntBivar()
+ * @brief Compute overlap integral of a 2D bivariate Gaussian with a cylinder.
+ * 
+ * @param cx Beam centroid x-position [mm]
+ * @param cy Beam centroid y-position [mm]
+ * @param sx Beam sigma-x [mm]
+ * @param sy Beam sigma-y [mm]
+ * @param rho Beam correlation coefficient
+ * 
+ * @return log10(1 - overlap fraction), or -10000 if integral is unphysical
+ */
+Double_t funcIntBivar(const Double_t cx, 
+                        const Double_t cy,
+                        const Double_t sx, 
+                        const Double_t sy,
+                        const Double_t rho) {
+    const Double_t dbin = 0.1, r = 4.75, rr = r * r;
+    const Double_t rho2 = rho * rho;
+    const int imax = static_cast<int>(round((2.0 * r) / dbin));
+    const int jmax = static_cast<int>(round((2.0 * r) / dbin));
+    Double_t sum = 0.0;
+
+    for (unsigned int i = 0; i <= imax; ++i) {
+        Double_t x = -r + i * dbin;
+        for (unsigned int j = 0; j <= jmax; ++j) {
+            Double_t y = -r + j * dbin;
+            if (x * x + y * y < rr) {
+                Double_t tx = (x + cx) / sx;
+                Double_t ty = (y + cy) / sy;
+                Double_t z = tx * tx - 2.0 * rho * tx * ty + ty * ty;
+                sum += std::exp(-z / (2.0 * (1.0 - rho2)));
+            }
+        }
+    }
+
+    sum *= dbin * dbin / (2.0 * 3.14159 * sx * sy * std::sqrt(1.0 - rho2));
+    return (sum >= 1.0) ? -10000. : std::log10(1.0 - sum);
+}
+
+/** @fn calcFoM()
+ * @brief Calculate the Figure of Merit for BNB alignment WITHOUT use of 
+ * multi-wire data.
+ * 
+ * @details This function uses the beam's centroid and sigma matrix to propagate
+ * ("swim") the beam envelope to different locations (upstream, center, 
+ * downstream) of the target, computes overlap integrals with a cylindrical 
+ * target, and forms a weighted sum.
+ * 
+ * @note calcFoM() is the same as calcFoM2() but with scalex = scaley = 1 
+ * 
+ * @param horPos BNB's horizontal position at nuclear target [mm]
+ * @param horAng BNB's horizontal angle at nuclear target [rad]
+ * @param verPos BNB's vertical position at nuclear target [mm]
+ * @param verAng BNB's vertical angle at nuclear target [rad]
+ * @param PPP Protons per pulse (used for emittance and momentum spread)
+ * 
+ * @return Double representing log10(1 - overlap-fraction), or -10000 if invalid.
+ */
+Double_t calcFoM(const Double_t horPos, 
+                    const Double_t horAng, 
+                    const Double_t verPos, 
+                    const Double_t verAng,
+                    const Double_t PPP) {
+    //! Beam Twiss parameters and dispersions from MiniBooNE AnalysisFramework
+    //! Code from DQ_BeamLine_twiss_init.F
+    const Double_t bx = 4.68, ax = 0.0389, gx = (1 + ax * ax) / bx;
+    const Double_t nx = 0.0958, npx = -0.0286;
+    const Double_t by = 59.12, ay = 2.4159, gy = (1 + ay * ay) / by;
+    const Double_t ny = 0.4577, npy = -0.0271;
+
+    //! LIKELY emittance and momentum spread as functions of protons-per-pulse
+    //! Code from DQ_BeamLine_make_tgt_fom2.F
+    const Double_t ex = 0.1775E-06 + 0.1827E-07 * PPP;
+    const Double_t ey = 0.1382E-06 + 0.2608E-08 * PPP;
+    const Double_t dp = 0.4485E-03 + 0.6100E-04 * PPP;
+
+    Double_t tex = ex, tey = ey, tdp = dp;
+
+    //! Code from DQ_BeamLine_beam_init.F
+    Double_t sigma1[6][6] = {{0}};
+    Double_t centroid1[6] = {horPos, horAng, verPos, verAng, 0.0, 0.0};
+
+    sigma1[5][5] = tdp * tdp;
+    sigma1[0][0] = tex * bx + nx * nx * tdp * tdp;
+    sigma1[0][1] = -tex * ax + nx * npx * tdp * tdp;
+    sigma1[1][1] = tex * gx + npx * npx * tdp * tdp;
+    sigma1[0][5] = nx * tdp * tdp;
+    sigma1[1][5] = npx * tdp * tdp;
+    sigma1[1][0] = sigma1[0][1];
+    sigma1[5][0] = sigma1[0][5];
+    sigma1[5][1] = sigma1[1][5];
+
+    sigma1[2][2] = tey * by + ny * ny * tdp * tdp;
+    sigma1[2][3] = -tey * ay + ny * npy * tdp * tdp;
+    sigma1[3][3] = tey * gy + npy * npy * tdp * tdp;
+    sigma1[2][5] = ny * tdp * tdp;
+    sigma1[3][5] = npy * tdp * tdp;
+    sigma1[3][2] = sigma1[2][3];
+    sigma1[5][2] = sigma1[2][5];
+    sigma1[5][3] = sigma1[3][5];
+
+    const Double_t begtocnt[6][6] = {
+        {0.65954, 0.43311, 0.00321, 0.10786, 0.00000, 1.97230},
+        {0.13047, 1.60192, 0.00034, 0.00512, 0.00000, 1.96723},
+        {-0.00287, -0.03677, -0.35277, -4.68056, 0.00000, 0.68525},
+        {-0.00089, -0.00430, -0.17722, -5.18616, 0.00000, 0.32300},
+        {-0.00104, 0.00232, -0.00001, -0.00224, 1.00000, -0.00450},
+        {0.00000, 0.00000, 0.00000, 0.00000, 0.00000, 1.00000}
+    };
+
+    Double_t cnttoups[6][6] = {{0}};
+    Double_t cnttodns[6][6] = {{0}};
+    Double_t identity[6][6] = {{0}};
+    Double_t begtoups[6][6] = {{0}};
+    Double_t begtodns[6][6] = {{0}};
+
+    for (unsigned int i = 0; i < 6; ++i) {
+        for (unsigned int j = 0; j < 6; ++j) {
+            identity[i][j] = (i == j);
+            cnttoups[i][j] = (i == j);
+            cnttodns[i][j] = (i == j);
+        }
+    }
+    cnttoups[0][1] = cnttoups[2][3] = -0.35710;
+    cnttodns[0][1] = cnttodns[2][3] = +0.35710;
+
+    for (unsigned int i = 0; i < 6; ++i) {
+        for (unsigned int j = 0; j < 6; ++j) {
+            for (unsigned int k = 0; k < 6; ++k) {
+                begtoups[i][k] += cnttoups[i][j] * begtocnt[j][k];
+                begtodns[i][k] += cnttodns[i][j] * begtocnt[j][k];
+            }
+        }
+    }
+
+    Double_t cx, cy, sx, sy, rho;
+
+    //! swim to upstream of target
+    swimBNB(centroid1, sigma1, cnttoups, begtoups, cx, cy, sx, sy, rho);
+    Double_t fom_a = funcIntBivar(cx, cy, sx, sy, rho);
+
+    //! swim to center of target
+    swimBNB(centroid1, sigma1, identity, begtocnt, cx, cy, sx, sy, rho);
+    Double_t fom_b = funcIntBivar(cx, cy, sx, sy, rho);
+
+    //! swim to downstream of target
+    swimBNB(centroid1, sigma1, cnttodns, begtodns, cx, cy, sx, sy, rho);
+    Double_t fom_c = funcIntBivar(cx, cy, sx, sy, rho);
+
+    if (fom_a <= -10000. 
+        || fom_b <= -10000. 
+        || fom_c <= -10000.) {
+            return -10000.;
+    }
+
+    return fom_a * 0.6347 + fom_b * 0.2812 + fom_c * 0.0841;
+}
+
+/** @fn calcFoM2()
+ * @brief Calculate the Figure of Merit for BNB alignment WITH the use of 
+ * multi-wire data.
+ * 
+ * @details This function uses the beam's centroid and sigma matrix to propagate
+ * ("swim") the beam envelope to different locations (upstream, center, 
+ * downstream) of the target, computes overlap integrals with a cylindrical 
+ * target, and forms a weighted sum.
+ * 
+ * @param horPos BNB's horizontal position at nuclear target [mm]
+ * @param horAng BNB's horizontal angle at nuclear target [rad]
+ * @param verPos BNB's vertical position at nuclear target [mm]
+ * @param verAng BNB's vertical angle at nuclear target [rad]
+ * @param PPP Protons per pulse (used for emittance and momentum spread)
+ * @param tgtHorWidth Horizontal width of the BNB at the nuclear target [mm]
+ * @param tgtVerWidth Vertical width of the BNB at the nuclear target [mm]
+ * 
+ * @return Double representing log10(1 - overlap-fraction), or -10000 if invalid.
+ */
+Double_t calcFoM2(const Double_t horPos, 
+                    const Double_t horAng, 
+                    const Double_t verPos, 
+                    const Double_t verAng,
+                    const Double_t PPP, 
+                    const Double_t tgtHorWidth, 
+                    const Double_t tgtVerWidth) {
+    //! Beam Twiss parameters and dispersions from MiniBooNE AnalysisFramework
+    //! Code from DQ_BeamLine_twiss_init.F
+    const Double_t bx = 4.68, ax = 0.0389, gx = (1 + ax * ax) / bx;
+    const Double_t nx = 0.0958, npx = -0.0286;
+    const Double_t by = 59.12, ay = 2.4159, gy = (1 + ay * ay) / by;
+    const Double_t ny = 0.4577, npy = -0.0271;
+
+    //! LIKELY emittance and momentum spread as functions of protons-per-pulse
+    //! Code from DQ_BeamLine_make_tgt_fom2.F
+    const Double_t ex = 0.1775E-06 + 0.1827E-07 * PPP;
+    const Double_t ey = 0.1382E-06 + 0.2608E-08 * PPP;
+    const Double_t dp = 0.4485E-03 + 0.6100E-04 * PPP;
+
+    Double_t tex = ex, tey = ey, tdp = dp;
+
+    //! Code from DQ_BeamLine_beam_init.F
+    Double_t sigma1[6][6] = {{0}};
+    Double_t centroid1[6] = {horPos, horAng, verPos, verAng, 0.0, 0.0};
+
+    sigma1[5][5] = tdp * tdp;
+    sigma1[0][0] = tex * bx + nx * nx * tdp * tdp;
+    sigma1[0][1] = -tex * ax + nx * npx * tdp * tdp;
+    sigma1[1][1] = tex * gx + npx * npx * tdp * tdp;
+    sigma1[0][5] = nx * tdp * tdp;
+    sigma1[1][5] = npx * tdp * tdp;
+    sigma1[1][0] = sigma1[0][1];
+    sigma1[5][0] = sigma1[0][5];
+    sigma1[5][1] = sigma1[1][5];
+
+    sigma1[2][2] = tey * by + ny * ny * tdp * tdp;
+    sigma1[2][3] = -tey * ay + ny * npy * tdp * tdp;
+    sigma1[3][3] = tey * gy + npy * npy * tdp * tdp;
+    sigma1[2][5] = ny * tdp * tdp;
+    sigma1[3][5] = npy * tdp * tdp;
+    sigma1[3][2] = sigma1[2][3];
+    sigma1[5][2] = sigma1[2][5];
+    sigma1[5][3] = sigma1[3][5];
+
+    const Double_t begtocnt[6][6] = {
+        {0.65954, 0.43311, 0.00321, 0.10786, 0.00000, 1.97230},
+        {0.13047, 1.60192, 0.00034, 0.00512, 0.00000, 1.96723},
+        {-0.00287, -0.03677, -0.35277, -4.68056, 0.00000, 0.68525},
+        {-0.00089, -0.00430, -0.17722, -5.18616, 0.00000, 0.32300},
+        {-0.00104, 0.00232, -0.00001, -0.00224, 1.00000, -0.00450},
+        {0.00000, 0.00000, 0.00000, 0.00000, 0.00000, 1.00000}
+    };
+
+    Double_t cnttoups[6][6] = {{0}};
+    Double_t cnttodns[6][6] = {{0}};
+    Double_t identity[6][6] = {{0}};
+    Double_t begtoups[6][6] = {{0}};
+    Double_t begtodns[6][6] = {{0}};
+
+    for (unsigned int i = 0; i < 6; ++i) {
+        for (unsigned int j = 0; j < 6; ++j) {
+            identity[i][j] = (i == j);
+            cnttoups[i][j] = (i == j);
+            cnttodns[i][j] = (i == j);
+        }
+    }
+    cnttoups[0][1] = cnttoups[2][3] = -0.35710;
+    cnttodns[0][1] = cnttodns[2][3] = +0.35710;
+
+    for (unsigned int i = 0; i < 6; ++i) {
+        for (unsigned int j = 0; j < 6; ++j) {
+            for (unsigned int k = 0; k < 6; ++k) {
+                begtoups[i][k] += cnttoups[i][j] * begtocnt[j][k];
+                begtodns[i][k] += cnttodns[i][j] * begtocnt[j][k];
+            }
+        }
+    }
+
+    Double_t cx, cy, sx, scalex, sy, scaley, rho;
+
+    //! swim to upstream of target
+    swimBNB(centroid1, sigma1, cnttoups, begtoups, cx, cy, sx, sy, rho);
+    scalex = tgtHorWidth / sx;
+    scaley = tgtVerWidth / sy;
+    Double_t fom_a = funcIntBivar(cx, cy, sx*scalex, sy*scaley, rho);
+
+    //! swim to center of target
+    swimBNB(centroid1, sigma1, identity, begtocnt, cx, cy, sx, sy, rho);
+    scalex = tgtHorWidth / sx;
+    scaley = tgtVerWidth / sy;
+    Double_t fom_b = funcIntBivar(cx, cy, sx*scalex, sy*scaley, rho);
+
+    //! swim to downstream of target
+    swimBNB(centroid1, sigma1, cnttodns, begtodns, cx, cy, sx, sy, rho);
+    scalex = tgtHorWidth / sx;
+    scaley = tgtVerWidth / sy;
+    Double_t fom_c = funcIntBivar(cx, cy, sx*scalex, sy*scaley, rho);
+
+    if (fom_a <= -10000. 
+        || fom_b <= -10000. 
+        || fom_c <= -10000.) {
+            return -10000.;
+    }
+
+    return fom_a * 0.6347 + fom_b * 0.2812 + fom_c * 0.0841;
+}
+
+/** @fn getBNBFoM()
+ * @brief Identifies and calculates necessary quantities to calculate a Figure
+ * of Merit then returns the Figure of Merit.
+ * 
+ * @param spillTimeSec readout timestamp for given spill [non-leap seconds
+ * since UNIX epoch (Jan 1, 1970 at midnight UTC/GMT)]
+ * @param TOR Protons per pulse (used for emittance and momentum spread)
+ * @param HP875 Horizontal position of BNB upstream of nuclear target [mm]
+ * @param HPTG1 Horizontal position of BNB upstream of nuclear target [mm]
+ * @param HPTG2 Horizontal position of BNB upstream of nuclear target [mm]
+ * @param VP873 Vertical position of BNB upstream of nuclear target [mm]
+ * @param VP875 Vertical position of BNB upstream of nuclear target [mm]
+ * 
+ * Order of horizontal BPMs: HP875, HPTG1, HPTG2
+ * Order of vertical BPMs: VP873, VP875
+ * 
+ * @return BNB Figure of Merit not utilizing beam width data from multi-wire
+ * devices
+ */
+Double_t getBNBFoM( const Double_t spillTimeSec,
+                      const Double_t TOR,
+                      const Double_t HP875, 
+                      const Double_t HPTG1,
+                      const Double_t HPTG2,
+                      const Double_t VP873,
+                      const Double_t VP875) {
+    /** 
+     * HPTG1 and HPTG2 calibration positions are expected to be complementary, 
+     * i.e. when one has a valid calibration position the other does not. To
+     * determine which of these BPMs to use, we pick the one that has the
+     * most recently updated (and valid) calibration position. Furthermore, we
+     * prioritize the use of HPTG2 if there is ever a spillTimeSec where
+     * HPTG1TimeDiff == HPTG2TimeDiff since HPTG2 is marginally closer to the
+     * nuclear target. This helps to give the most accurate horAng and 
+     * tgtHorPos when projecting from HP875.
+     */
+    Double_t HP875TimeDiff = -1.;
+    Double_t HPTG1TimeDiff = -1.;
+    Double_t HPTG2TimeDiff = -1.;
+    Double_t VP873TimeDiff = -1.;
+    Double_t VP875TimeDiff = -1.;
+
+    std::optional<Double_t> HP875CalibTime = getValidBPMCalibTime( spillTimeSec, "HP875");
+    std::optional<Double_t> HPTG1CalibTime = getValidBPMCalibTime( spillTimeSec, "HPTG1");
+    std::optional<Double_t> HPTG2CalibTime = getValidBPMCalibTime( spillTimeSec, "HPTG2");
+
+    std::optional<Double_t> VP873CalibTime = getValidBPMCalibTime( spillTimeSec, "VP873");
+    std::optional<Double_t> VP875CalibTime = getValidBPMCalibTime( spillTimeSec, "VP875");
+
+    if (HP875CalibTime.has_value()) {
+        HP875TimeDiff = spillTimeSec - HP875CalibTime.value();
+    }
+
+    if (HPTG1CalibTime.has_value()) {
+        HPTG1TimeDiff = spillTimeSec - HPTG1CalibTime.value();
+    }
+
+    if (HPTG2CalibTime.has_value()) {
+        HPTG2TimeDiff = spillTimeSec - HPTG2CalibTime.value();
+    }
+
+    if (VP873CalibTime.has_value()) {
+        VP873TimeDiff = spillTimeSec - VP873CalibTime.value();
+    }
+
+    if (VP875CalibTime.has_value()) {
+        VP875TimeDiff = spillTimeSec - VP875CalibTime.value();
+    }
+
+
+    /** @warning
+     * If both HPTG1TimeDiff and HPTG2TimeDiff are negative (very unlikely),
+     * the earliest known HPTG1 and HPTG2 calibration positions were logged
+     * after the current spillTimeSec. This prevents us from calculating a
+     * Figure of Merit since we only have one horizontal BPM and cannot
+     * calculate horAng and tgtHorPos. Similarly, if we have at least one of
+     * VP873TimeDiff and VP875TimeDiff less than zero, we'll only have one
+     * vertical BPM and will not be able to calculate a Figure of Merit. Since
+     * HP875 is theoretically valid for all ICARUS timestamps, we also assert
+     * we could not calculate a (meaningful) Figure of Merit if HP875 *ever*
+     * has a negative time difference for a given spillTimeSec timestamp.
+     */
+    if ( (HPTG1TimeDiff < 0 && HPTG2TimeDiff < 0)
+            || (HP875TimeDiff < 0 || VP873TimeDiff < 0 || VP875TimeDiff < 0)) { 
+        return -2.;
+    }
+    
+    //! Get most recent calibration position of Beam Position Monitor (BPM) 
+    //! devices and calculate offset from calibration position.
+    std::optional<Double_t> HP875CalibVal = getValidBPMCalibVal( spillTimeSec, "HP875");
+    Double_t HP875Offset = HP875 - HP875CalibVal.value();
+
+    Double_t HPTGXOffset = -999; //! 'X' is stand-in 
+    Double_t HPTGXZPos = -999;   //! char for '1' or '2'
+    if (HPTG2TimeDiff <= HPTG1TimeDiff) { //! prefer HPTG2 if time diffs match
+        std::optional<Double_t> HPTG2CalibVal = getValidBPMCalibVal( spillTimeSec, "HPTG2");
+        HPTGXOffset = HPTG2 - HPTG2CalibVal.value();        
+        HPTGXZPos = HPTG2ZPos;
+    }
+    else {
+        std::optional<Double_t> HPTG1CalibVal = getValidBPMCalibVal( spillTimeSec, "HPTG1");
+        HPTGXOffset = HPTG1 - HPTG1CalibVal.value();        
+        HPTGXZPos = HPTG1ZPos;
+    }
+
+    std::optional<Double_t> VP873CalibVal = getValidBPMCalibVal( spillTimeSec, "VP873");
+    Double_t VP873Offset = VP873 - VP873CalibVal.value();    
+    
+    std::optional<Double_t> VP875CalibVal = getValidBPMCalibVal( spillTimeSec, "VP875");
+    Double_t VP875Offset = VP875 - VP875CalibVal.value();
+    /**
+     * Calculate angles between horizontal/vertical BPMs and project the BNB 
+     * to the transverse plane intersecting the center of the nuclear target 
+     * (along the beamline direction, i.e. z). We project the horizontal
+     * position from HP875 to the nuclear target since HPTG1 and HPTG2 are close 
+     * to the front of the target. We project the vertical position from VP875
+     * since both VP873 and VP875 are sufficiently far from the nuclear target
+     * and VP875 is closer to the nuclear target.
+     * 
+     * @note angle calculations use the small angle approximation
+     * 
+     * Order of horizontal BPMs: HP875, HPTG1, HPTG2
+     * Order of vertical BPMs: VP873, VP875
+     */
+    Double_t horAng = (HPTGXOffset - HP875Offset) / (HPTGXZPos - HP875ZPos);
+    horAng = atan(horAng);
+    Double_t tgtHorPos = HP875Offset + horAng * (targetCenterZPos - HP875ZPos);
+
+    Double_t verAng = (VP875Offset - VP873Offset) / (VP875ZPos - VP873ZPos);
+    verAng = atan(verAng);
+    Double_t tgtVerPos = VP873Offset + horAng * (targetCenterZPos - HP875ZPos);
+
+    /**
+     * Calculating a Figure of Merit without the use of multi-wire data amounts
+     * to setting scalex and scaley both equal to 1 (see documentation on
+     * getBNBFoM() and getBNBFoM2() for more details).
+     * scalex = tgtHorWidth / sx, i.e. the x-scale is the width of the BNB at 
+     * the center of the nuclear target divided by the width of the BNB at at 
+     * one of the positions you can "swim" to (see swimBNB for details on this).
+     * In general, we have that tgtHorWidth = sx for a given timestamp. At this
+     * timestamp, we can "swim" to different locations to get different sx, but
+     * tgtHorWidth is constant at a given timestamp. We set tgtHorWidth = sx = 1 
+     * for this Figure of Merit calculation that does not make use of the 
+     * multi-wire data. tgtHorWidth = sx = 1 is done inside calcFoM(), and thus 
+     * we do not pass BNB width data to the calcFoM() below. For a Figure of 
+     * Merit that makes use of BNB width data, please see getBNBFoM2() and
+     * calcFoM2().
+     *
+     * @note One could do studies to come up with a better value for 
+     * tgtHorWidth = sx by, e.g., visually inspecting the (hopefully) gaussian 
+     * profiles of the multi-wire devices. However, since the goal in SBN is to 
+     * use a Figure of Merit that *does* use multi-wire data, we have not 
+     * concerned ourselves too much with what constant value we set 
+     * tgtHorWidth = sx.
+     */
+    return calcFoM( tgtHorPos, horAng, tgtVerPos, verAng, TOR);
+}
+
+/** @fn getBNBFoM2()
+ * @brief Identifies and calculates necessary quantities to calculate a Figure
+ * of Merit then returns the Figure of Merit.
+ * 
+ * @note If there is not good multi-wire fit parameters, this function defaults
+ * to returning a Figure of Merit that does not use multi-wire data, i.e.
+ * calcFoM().
+ * 
+ * @param spillTimeSec readout timestamp for given spill [non-leap seconds
+ * since UNIX epoch (Jan 1, 1970 at midnight UTC/GMT)]
+ * @param TOR Protons per pulse (used for emittance and momentum spread)
+ * @param HP875 Horizontal position of BNB upstream of nuclear target [mm]
+ * @param HPTG1 Horizontal position of BNB upstream of nuclear target [mm]
+ * @param HPTG2 Horizontal position of BNB upstream of nuclear target [mm]
+ * @param VP873 Vertical position of BNB upstream of nuclear target [mm]
+ * @param VP875 Vertical position of BNB upstream of nuclear target [mm]
+ * @param MW875HorWidth Horizontal width of the BNB upstream of target [mm]
+ * @param MW875VerWidth Vertical width of the BNB upstream of target [mm]
+ * @param MW876HorWidth Horizontal width of the BNB upstream of target [mm]
+ * @param MW876VerWidth Vertical width of the BNB upstream of target [mm]
+ * 
+ * Order of horizontal BPMs: HP875, HPTG1, HPTG2
+ * Order of vertical BPMs: VP873, VP875
+ * Order of multi-wire readout (MWR) devices: MW875, MW876
+ * 
+ * @return BNB Figure of Merit utilizing beam width data from multi-wire
+ * devices.
+ */
+Double_t getBNBFoM2( const Double_t spillTimeSec,
+                      const Double_t TOR,
+                      const Double_t HP875, 
+                      const Double_t HPTG1,
+                      const Double_t HPTG2,
+                      const Double_t VP873,
+                      const Double_t VP875,
+                      const Double_t MW875HorWidth,
+                      const Double_t MW875VerWidth,
+                      const Double_t MW876HorWidth,
+                      const Double_t MW876VerWidth) {
+    /** 
+     * HPTG1 and HPTG2 calibration positions are expected to be complementary, 
+     * i.e. when one has a valid calibration position the other does not. To
+     * determine which of these BPMs to use, we pick the one that has the
+     * most recently updated (and valid) calibration position. Furthermore, we
+     * prioritize the use of HPTG2 if there is ever a spillTimeSec where
+     * HPTG1TimeDiff == HPTG2TimeDiff since HPTG2 is marginally closer to the
+     * nuclear target. This helps to give the most accurate horAng and 
+     * tgtHorPos when projecting from HP875.
+     */
+    Double_t HP875TimeDiff = -1.;
+    Double_t HPTG1TimeDiff = -1.;
+    Double_t HPTG2TimeDiff = -1.;
+    Double_t VP873TimeDiff = -1.;
+    Double_t VP875TimeDiff = -1.;
+
+    std::optional<Double_t> HP875CalibTime = getValidBPMCalibTime( spillTimeSec, "HP875");
+    std::optional<Double_t> HPTG1CalibTime = getValidBPMCalibTime( spillTimeSec, "HPTG1");
+    std::optional<Double_t> HPTG2CalibTime = getValidBPMCalibTime( spillTimeSec, "HPTG2");
+
+    std::optional<Double_t> VP873CalibTime = getValidBPMCalibTime( spillTimeSec, "VP873");
+    std::optional<Double_t> VP875CalibTime = getValidBPMCalibTime( spillTimeSec, "VP875");
+
+    if (HP875CalibTime.has_value()) {
+        HP875TimeDiff = spillTimeSec - HP875CalibTime.value();
+    }
+
+    if (HPTG1CalibTime.has_value()) {
+        HPTG1TimeDiff = spillTimeSec - HPTG1CalibTime.value();
+    }
+
+    if (HPTG2CalibTime.has_value()) {
+        HPTG2TimeDiff = spillTimeSec - HPTG2CalibTime.value();
+    }
+
+    if (VP873CalibTime.has_value()) {
+        VP873TimeDiff = spillTimeSec - VP873CalibTime.value();
+    }
+
+    if (VP875CalibTime.has_value()) {
+        VP875TimeDiff = spillTimeSec - VP875CalibTime.value();
+    }
+
+    /** @warning
+     * If both HPTG1TimeDiff and HPTG2TimeDiff are negative (very unlikely),
+     * the earliest known HPTG1 and HPTG2 calibration positions were logged
+     * after the current spillTimeSec. This prevents us from calculating a
+     * Figure of Merit since we only have one horizontal BPM and cannot
+     * calculate horAng and tgtHorPos. Similarly, if we have at least one of
+     * VP873TimeDiff and VP875TimeDiff less than zero, we'll only have one
+     * vertical BPM and will not be able to calculate a Figure of Merit. Since
+     * HP875 is theoretically valid for all ICARUS timestamps, we also assert
+     * we could not calculate a (meaningful) Figure of Merit if HP875 *ever*
+     * has a negative time difference for a given spillTimeSec timestamp.
+     */
+    if ( (HPTG1TimeDiff < 0 && HPTG2TimeDiff < 0)
+            || (HP875TimeDiff < 0 || VP873TimeDiff < 0 || VP875TimeDiff < 0)) { 
+        return -2.;
+    }
+    
+    //! Get most recent calibration position of Beam Position Monitor (BPM) 
+    //! devices and calculate offset from calibration position.
+    std::optional<Double_t> HP875CalibVal = getValidBPMCalibVal( spillTimeSec, "HP875");
+    Double_t HP875Offset = HP875 - HP875CalibVal.value();
+
+    Double_t HPTGXOffset = -999; //! 'X' is stand-in 
+    Double_t HPTGXZPos = -999;   //! char for '1' or '2'
+    if (HPTG2TimeDiff <= HPTG1TimeDiff) { //! prefer HPTG2 if time diffs match
+        std::optional<Double_t> HPTG2CalibVal = getValidBPMCalibVal( spillTimeSec, "HPTG2");
+        HPTGXOffset = HPTG2 - HPTG2CalibVal.value();  
+        HPTGXZPos = HPTG2ZPos;
+    }
+    else {
+        std::optional<Double_t> HPTG1CalibVal = getValidBPMCalibVal( spillTimeSec, "HPTG1");
+        HPTGXOffset = HPTG1 - HPTG1CalibVal.value();
+        HPTGXZPos = HPTG1ZPos;
+    }
+
+    std::optional<Double_t> VP873CalibVal = getValidBPMCalibVal( spillTimeSec, "VP873");
+    Double_t VP873Offset = VP873 - VP873CalibVal.value();
+    
+    std::optional<Double_t> VP875CalibVal = getValidBPMCalibVal( spillTimeSec, "VP875");
+    Double_t VP875Offset = VP875 - VP875CalibVal.value();
+    /**
+     * Calculate angles between horizontal/vertical BPMs and project the BNB 
+     * to the transverse plane intersecting the center of the nuclear target 
+     * (along the beamline direction, i.e. z). We project the horizontal
+     * position from HP875 to the nuclear target since HPTG1 and HPTG2 are close
+     * to the front of the target. We project the vertical position from VP875
+     * since both VP873 and VP875 are sufficiently far from the nuclear target
+     * and VP875 is closer to the nuclear target.
+     * 
+     * Order of horizontal BPMs: HP875, HPTG1, HPTG2
+     * Order of vertical BPMs: VP873, VP875
+     */
+    Double_t horAng = (HPTGXOffset - HP875Offset) / (HPTGXZPos - HP875ZPos);
+    horAng = atan(horAng);
+    Double_t tgtHorPos = HP875Offset + horAng * (targetCenterZPos - HP875ZPos);
+
+    Double_t verAng = (VP875Offset - VP873Offset) / (VP875ZPos - VP873ZPos);
+    verAng = atan(verAng);
+    Double_t tgtVerPos = VP873Offset + horAng * (targetCenterZPos - HP875ZPos);
+
+    /**
+     * Prioritize using MW876 data if it has reasonable fit parameters.
+     * Otherwise, prioritize using MW875 data. If none of the multi-wire 
+     * devices have reasonable fit parameters, default to using calcFoM()
+     * instead of calcFoM2(). Note calcFoM() does not make use of any 
+     * multi-wire data.
+     * 
+     * @note What counts as "reasonable" is up to interpretation. For the time
+     * being, we use the hard-coded values that MicroBooNE used ( @see
+     * getFOM2.cxx in MicroBooNE's ubraw GitHub repository for details).
+     */
+
+    std::optional<Double_t> tgtHorWidth = std::nullopt, tgtVerWidth = std::nullopt;
+    if ( isReasonable( MW876HorWidth, 0.5, 10) 
+        && isReasonable( MW876VerWidth, 0.3, 10) ) {
+            tgtHorWidth = expandWidth( MW876HorWidth, p876x, 2);
+            tgtVerWidth = expandWidth( MW876VerWidth, p876y, 2);
+
+            /** @warning 
+             * If specified N for expansion is greater than the number of
+             * available coefficents, cannot calculate Figure of Merit
+             */
+            if ( !tgtHorWidth.has_value() || !tgtVerWidth.has_value()) {
+                return -1.;
+            }
+    }
+    else if ( isReasonable( MW875HorWidth, 0.5, 10) 
+        && isReasonable(MW875VerWidth, 0.3, 10) ) {
+            tgtHorWidth = expandWidth( MW875HorWidth, p875x, 2);
+            tgtVerWidth = expandWidth( MW875VerWidth, p875y, 2);
+
+            /** @warning 
+             * If specified N for expansion is greater than the number of
+             * available coefficents, cannot calculate Figure of Merit
+             */
+            if ( !tgtHorWidth.has_value() || !tgtVerWidth.has_value()) {
+                return -1.;
+            }
+    }
+    else { 
+        //! @warning defaulting to Figure of Merit without multi-wire data
+        std::cerr << "[WARNING] No reliable multi-wire data, defaulting to calcFoM()." << std::endl;
+        return calcFoM( tgtHorPos, horAng, tgtVerPos, verAng, TOR);
+    }
+
+    //! Extract values from std::optional objects
+    Double_t tgtHorWidthVal = tgtHorWidth.value();
+    Double_t tgtVerWidthVal = tgtVerWidth.value();
+
+    return calcFoM2( tgtHorPos, horAng, tgtVerPos, verAng, 
+        TOR, tgtHorWidthVal, tgtVerWidthVal);
+}
+
+
+
+
+
+
+
+
+
+//!-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+//! @todo
+
+/**
+ * @brief Fit (hopefully) gaussian profile of a given multi-wire device and
+ * extract the gaussian fit parameters.
+ * 
+ * @note This function should only be implemented if it is found that the
+ * multi-wire fit parameters on IFBeam are not reliable. There's no sense in
+ * re-fitting if we trust the IFBeam fit parameters. The IFBeam fit parameters
+ * are what is referenced as kSpillMW875HorWidth, kSpillMW876VerPos, etc., in
+ * the BNBVars.cxx and BNBVars.h files.
+ */
+void processMWRProfile() {
+    std::cout << "Placeholder: extract gaussian fit params from MWR device \n";
+}

--- a/sbnana/SBNAna/Vars/getBNBFoM.cxx
+++ b/sbnana/SBNAna/Vars/getBNBFoM.cxx
@@ -39,7 +39,10 @@ bool debug = false; //! displays helpful output for debugging
 
 
 /** @struct OffsetData Holds the timestamped calibration positions of Beam
- * Position Monitors.
+ * Position Monitors. This data was obtained by Zarko Pavlovic via IFBeam.
+ * These Beam Position Monitor offsets come from the autotune program,
+ * which is the program responsible for keeping the BNB focused on the
+ * nuclear target.
  */
 struct OffsetData {
     std::vector<int> Times; //! non-leap seconds since UNIX epoch
@@ -409,6 +412,14 @@ Double_t calcFoM_noMultiWire(const Double_t horPos,
             return -4.0;
     }
 
+    //! @note: These Figure of Merit weights are from a MiniBooNE-era
+    //! study. While the details of this study are lost to time, the
+    //! general idea behind these weights is as follows: the BNB will
+    //! have exponentially fewer interactions with the nuclear target
+    //! as you move down the beamline. Thus, we want to have our
+    //! Figure of Merit weighted towards where the majority of 
+    //! BNB-target interactions are located, i.e. the front of the 
+    //! target.
     Double_t fom =  fom_a * 0.6347 + fom_b * 0.2812 + fom_c * 0.0841;
 
 

--- a/sbnana/SBNAna/Vars/getBNBFoM.h
+++ b/sbnana/SBNAna/Vars/getBNBFoM.h
@@ -43,7 +43,7 @@ Double_t funcIntbivar(
     const Double_t rho
 );
 
-Double_t calcFoM(
+Double_t calcFoM_noMultiWire(
     const Double_t horPos, 
     const Double_t horAng, 
     const Double_t verPos, 
@@ -51,7 +51,7 @@ Double_t calcFoM(
     const Double_t PPP
 );
 
-Double_t calcFoM2(
+Double_t calcFoM(
     const Double_t horPos, 
     const Double_t horAng, 
     const Double_t verPos, 
@@ -61,7 +61,7 @@ Double_t calcFoM2(
     const Double_t tgtVerSigma
 );
 
-Double_t getBNBFoM( 
+Double_t getBNBFoM_noMultiWire( 
     const Double_t spillTimeSec,
     const Double_t TOR860,
     const Double_t TOR875,
@@ -72,7 +72,7 @@ Double_t getBNBFoM(
     const Double_t VP875
 );
 
-Double_t getBNBFoM2( 
+Double_t getBNBFoM( 
     const Double_t spillTimeSec,
     const Double_t TOR860,
     const Double_t TOR875,

--- a/sbnana/SBNAna/Vars/getBNBFoM.h
+++ b/sbnana/SBNAna/Vars/getBNBFoM.h
@@ -63,7 +63,8 @@ Double_t calcFoM2(
 
 Double_t getBNBFoM( 
     const Double_t spillTimeSec,
-    const Double_t TOR,
+    const Double_t TOR860,
+    const Double_t TOR875,
     const Double_t HP875, 
     const Double_t HPTG1,
     const Double_t HPTG2,
@@ -73,7 +74,8 @@ Double_t getBNBFoM(
 
 Double_t getBNBFoM2( 
     const Double_t spillTimeSec,
-    const Double_t TOR,
+    const Double_t TOR860,
+    const Double_t TOR875,
     const Double_t HP875,
     const Double_t HPTG1, 
     const Double_t HPTG2,

--- a/sbnana/SBNAna/Vars/getBNBFoM.h
+++ b/sbnana/SBNAna/Vars/getBNBFoM.h
@@ -57,8 +57,8 @@ Double_t calcFoM2(
     const Double_t verPos, 
     const Double_t verAng, 
     const Double_t PPP, 
-    const Double_t tgtHorWidth, 
-    const Double_t tgtVerWidth
+    const Double_t tgtHorSigma, 
+    const Double_t tgtVerSigma
 );
 
 Double_t getBNBFoM( 
@@ -81,10 +81,10 @@ Double_t getBNBFoM2(
     const Double_t HPTG2,
     const Double_t VP873,
     const Double_t VP875,
-    const Double_t MW875HorWidth,
-    const Double_t MW875VerWidth,
-    const Double_t MW876HorWidth,
-    const Double_t MW876VerWidth
+    const Double_t MW875HorSigma,
+    const Double_t MW875VerSigma,
+    const Double_t MW876HorSigma,
+    const Double_t MW876VerSigma
 );
 
 #endif

--- a/sbnana/SBNAna/Vars/getBNBFoM.h
+++ b/sbnana/SBNAna/Vars/getBNBFoM.h
@@ -1,0 +1,86 @@
+//! ////////////////////////////////////////////////////////////////////////////
+//! @file: getBNBFoM.h                                                           
+//! @author: Jacob Smith (smithja)
+//! @email: jacob.a.smith@stonybrook.edu                                       
+//!                                                                           
+//! @brief Header file to define all of functions used in calculating a Booster
+//! Neutrino Beam (BNB) Figure of Merit (FoM) for use on the SBN experiments.                  
+//! ////////////////////////////////////////////////////////////////////////////
+#ifndef _GETBNBFOM_H
+#define _GETBNBFOM_H
+
+#include "TROOT.h"
+
+std::optional<Double_t> getValidBPMCalibVal( 
+    const int& timestamp, 
+    const std::string& device
+);
+
+std::optional<Double_t> getValidBPMCalibTime( 
+    const int& timestamp, 
+    const std::string& device
+);
+    
+void swimBNB(
+    const Double_t centroid1[6], 
+    const Double_t sigma1[6][6],
+    const Double_t xferc[6][6], 
+    const Double_t xfers[6][6],
+    Double_t& cx,
+    Double_t& cy, 
+    Double_t& sx, 
+    Double_t& sy, 
+    Double_t& rho
+);
+
+Double_t funcIntbivar(
+    const Double_t cx, 
+    const Double_t cy,
+    const Double_t sx, 
+    const Double_t sy,
+    const Double_t rho
+);
+
+Double_t calcFoM(
+    const Double_t horPos, 
+    const Double_t horAng, 
+    const Double_t verPos, 
+    const Double_t verAng, 
+    const Double_t PPP
+);
+
+Double_t calcFoM2(
+    const Double_t horPos, 
+    const Double_t horAng, 
+    const Double_t verPos, 
+    const Double_t verAng, 
+    const Double_t PPP, 
+    const Double_t tgtHorWidth, 
+    const Double_t tgtVerWidth
+);
+
+Double_t getBNBFoM( 
+    const Double_t spillTimeSec,
+    const Double_t TOR,
+    const Double_t HP875, 
+    const Double_t HPTG1,
+    const Double_t HPTG2,
+    const Double_t VP873,
+    const Double_t VP875
+);
+
+Double_t getBNBFoM2( 
+    const Double_t spillTimeSec,
+    const Double_t TOR,
+    const Double_t HP875,
+    const Double_t HPTG1, 
+    const Double_t HPTG2,
+    const Double_t VP873,
+    const Double_t VP875,
+    const Double_t MW875HorWidth,
+    const Double_t MW875VerWidth,
+    const Double_t MW876HorWidth,
+    const Double_t MW876VerWidth
+);
+
+#endif

--- a/sbnana/SBNAna/Vars/getBNBFoM.h
+++ b/sbnana/SBNAna/Vars/getBNBFoM.h
@@ -9,6 +9,8 @@
 #ifndef _GETBNBFOM_H
 #define _GETBNBFOM_H
 
+#include <optional>
+
 #include "TROOT.h"
 
 std::optional<Double_t> getValidBPMCalibVal( 


### PR DESCRIPTION
This pull request ports the BNB Quality work from [feature/smithja_BNBQuality](https://github.com/SBNSoftware/sbnana/tree/feature/smithja_BNBQuality). When the sbnana repo was first cloned and the development environment was first set up, code was placed under directories labeled with `sbnana v10_00_00` by accident. However, **this code was developed against `sbnana v10_01_01`**. 

The full commit history and development context for the original branch are preserved at the link above. This PR consolidates that work for compatibility with re-spun flat CAF files that include data for the BNB multi-wire readout devices. These devices are currently the only available source of BNB width information. Additionally, this code requires at least `sbnanaobj v10_00_05`. This version of sbnanaobj allows the multi-wire data to be accessed in the flat CAFs. See [sbnanaobj PR #143](https://github.com/SBNSoftware/sbnanaobj/pull/143) for more details.

No further development is expected on the original branch. However, the current SpillCuts are intentionally conservative and may be refined in the future based on detector performance or analysis feedback. Future updates to BNB quality should be made against this branch post-merge, or directly to develop.